### PR TITLE
Add expand/collapse to starter task cards 

### DIFF
--- a/static/admin/starter-tasks.html
+++ b/static/admin/starter-tasks.html
@@ -203,36 +203,59 @@
             };
 
             container.innerHTML = tasks.map(t => `
-                <div class="card">
-                    <div class="card-header">
+                <div class="card" id="task-${t.id}">
+                    <div class="card-header" style="cursor: pointer;" onclick="toggleTask(${t.id})">
                         <div>
-                            <h3 class="card-title">${escapeHtml(t.title)}</h3>
+                            <h3 class="card-title" style="display: flex; align-items: center; gap: 8px;">
+                                <span class="task-toggle" id="toggle-${t.id}" style="transition: transform 0.2s; display: inline-block;">&#9654;</span>
+                                ${escapeHtml(t.title)}
+                            </h3>
                             <p class="card-meta">
                                 ${t.skill_name ? `Skill: ${escapeHtml(t.skill_name)}` : ''}
                                 ${t.estimated_hours ? ` · ~${t.estimated_hours}h` : ''}
-                                ${t.assigned_to_name ? ` · Assigned to: <a href="/static/admin/volunteer-detail.html?id=${t.assigned_to_id}">${escapeHtml(t.assigned_to_name)}</a>` : ''}
+                                ${t.assigned_to_name ? ` · Assigned to: <a href="/static/admin/volunteer-detail.html?id=${t.assigned_to_id}" onclick="event.stopPropagation()">${escapeHtml(t.assigned_to_name)}</a>` : ''}
+                                ${t.review_rating ? ` · <span style="color: ${ratingColors[t.review_rating]};">${t.review_rating}</span>` : ''}
                             </p>
                         </div>
                         <span class="status-badge status-${t.status === 'completed' ? 'completed' : t.status === 'submitted' ? 'seeking_help' : t.status === 'assigned' ? 'in_progress' : 'on_hold'}">
                             ${t.status}
                         </span>
                     </div>
-                    <p style="white-space: pre-wrap;">${escapeHtml(t.description)}</p>
-                    ${t.review_rating ? `
-                        <p style="margin-top: 12px; font-weight: 500; color: ${ratingColors[t.review_rating]};">
-                            Rating: ${t.review_rating}
-                        </p>
-                        ${t.review_notes ? `<p style="font-size: 0.875rem; color: var(--text-light);">${escapeHtml(t.review_notes)}</p>` : ''}
-                    ` : ''}
-                    <div class="card-footer">
-                        <span style="font-size: 0.875rem; color: var(--text-light);">${formatDate(t.created_at)}</span>
-                        <div style="display: flex; gap: 8px;">
-                            ${t.status === 'open' ? `<button class="btn btn-small btn-secondary" onclick="openAssign(${t.id})">Assign</button>` : ''}
-                            ${t.status === 'submitted' ? `<button class="btn btn-small btn-primary" onclick="openReview(${t.id})">Review</button>` : ''}
+                    <div id="details-${t.id}" style="display: none;">
+                        <p style="white-space: pre-wrap; margin: 12px 0;">${escapeHtml(t.description)}</p>
+                        ${t.review_rating ? `
+                            <p style="margin-top: 12px; font-weight: 500; color: ${ratingColors[t.review_rating]};">
+                                Rating: ${t.review_rating}
+                            </p>
+                            ${t.review_notes ? `<p style="font-size: 0.875rem; color: var(--text-light);">Notes: ${escapeHtml(t.review_notes)}</p>` : ''}
+                        ` : ''}
+                        ${t.feedback_to_volunteer ? `
+                            <div class="message info" style="margin-top: 8px;">
+                                <strong>Feedback to volunteer:</strong> ${escapeHtml(t.feedback_to_volunteer)}
+                            </div>
+                        ` : ''}
+                        <div class="card-footer">
+                            <span style="font-size: 0.875rem; color: var(--text-light);">Created ${formatDate(t.created_at)}</span>
+                            <div style="display: flex; gap: 8px;">
+                                ${t.status === 'open' ? `<button class="btn btn-small btn-secondary" onclick="event.stopPropagation(); openAssign(${t.id})">Assign</button>` : ''}
+                                ${t.status === 'submitted' ? `<button class="btn btn-small btn-primary" onclick="event.stopPropagation(); openReview(${t.id})">Review</button>` : ''}
+                            </div>
                         </div>
                     </div>
                 </div>
             `).join('');
+        }
+
+        function toggleTask(taskId) {
+            const details = document.getElementById('details-' + taskId);
+            const toggle = document.getElementById('toggle-' + taskId);
+            if (details.style.display === 'none') {
+                details.style.display = 'block';
+                toggle.style.transform = 'rotate(90deg)';
+            } else {
+                details.style.display = 'none';
+                toggle.style.transform = 'rotate(0deg)';
+            }
         }
 
         async function loadSkillsDropdown() {

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -127,38 +127,56 @@
                     banner.style.display = 'block';
                     banner.innerHTML = visibleTasks.map(t => `
                         <div class="card" style="border-left: 4px solid var(--secondary); margin-bottom: 12px;">
-                            <div class="card-header">
+                            <div class="card-header" style="cursor: pointer;" onclick="toggleStarterTask(${t.id})">
                                 <div>
-                                    <h3 class="card-title">Starter Task: ${escapeHtml(t.title)}</h3>
+                                    <h3 class="card-title" style="display: flex; align-items: center; gap: 8px;">
+                                        <span id="st-toggle-${t.id}" style="transition: transform 0.2s; display: inline-block;">&#9654;</span>
+                                        Starter Task: ${escapeHtml(t.title)}
+                                    </h3>
                                     <p class="card-meta">
                                         ${t.skill_name ? `Skill: ${escapeHtml(t.skill_name)} · ` : ''}
                                         ${t.estimated_hours ? `~${t.estimated_hours}h · ` : ''}
                                         Status: ${t.status}
+                                        ${t.review_rating ? ` · Rating: ${t.review_rating}` : ''}
                                     </p>
                                 </div>
                                 <span class="status-badge status-${t.status === 'assigned' ? 'in_progress' : t.status === 'submitted' ? 'seeking_help' : 'completed'}">
                                     ${t.status}
                                 </span>
                             </div>
-                            <p style="white-space: pre-wrap; margin: 12px 0;">${escapeHtml(t.description)}</p>
-                            ${t.review_rating ? `
-                                <p style="margin-top: 8px; font-weight: 500; color: ${t.review_rating === 'excellent' ? 'var(--success)' : t.review_rating === 'good' ? 'var(--secondary)' : 'var(--error)'};">
-                                    Rating: ${t.review_rating}
-                                </p>
-                            ` : ''}
-                            ${t.feedback_to_volunteer ? `
-                                <div class="message info">
-                                    <strong>Feedback:</strong> ${escapeHtml(t.feedback_to_volunteer)}
-                                </div>
-                            ` : ''}
-                            ${t.status === 'assigned' ? `
-                                <button class="btn btn-primary btn-small" onclick="submitTask(${t.id})">Mark as Complete</button>
-                            ` : ''}
+                            <div id="st-details-${t.id}" style="display: none;">
+                                <p style="white-space: pre-wrap; margin: 12px 0;">${escapeHtml(t.description)}</p>
+                                ${t.review_rating ? `
+                                    <p style="margin-top: 8px; font-weight: 500; color: ${t.review_rating === 'excellent' ? 'var(--success)' : t.review_rating === 'good' ? 'var(--secondary)' : 'var(--error)'};">
+                                        Rating: ${t.review_rating}
+                                    </p>
+                                ` : ''}
+                                ${t.feedback_to_volunteer ? `
+                                    <div class="message info">
+                                        <strong>Feedback:</strong> ${escapeHtml(t.feedback_to_volunteer)}
+                                    </div>
+                                ` : ''}
+                                ${t.status === 'assigned' ? `
+                                    <button class="btn btn-primary btn-small" onclick="event.stopPropagation(); submitTask(${t.id})">Mark as Complete</button>
+                                ` : ''}
+                            </div>
                         </div>
                     `).join('');
                 }
             } catch (e) {
                 // Starter tasks endpoint might not exist yet, fail silently
+            }
+        }
+
+        function toggleStarterTask(taskId) {
+            const details = document.getElementById('st-details-' + taskId);
+            const toggle = document.getElementById('st-toggle-' + taskId);
+            if (details.style.display === 'none') {
+                details.style.display = 'block';
+                toggle.style.transform = 'rotate(90deg)';
+            } else {
+                details.style.display = 'none';
+                toggle.style.transform = 'rotate(0deg)';
             }
         }
 


### PR DESCRIPTION
Starter task cards now show a compact header (title, skill, status, rating) with a clickable triangle toggle to expand full details (description, review notes, feedback, action buttons). 
 