### PR TITLE
Fix form discrepancies

### DIFF
--- a/api.py
+++ b/api.py
@@ -1880,13 +1880,14 @@ def create_org_project(
         cursor = conn.execute(
             """INSERT INTO projects (
                 title, description, status, owner_id, proposed_by_id,
-                is_org_proposed, time_commitment_hours_per_week, urgency,
-                collaboration_link
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                is_org_proposed, project_type, estimated_duration,
+                time_commitment_hours_per_week, urgency, collaboration_link
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 data.title, data.description, status,
                 admin["id"] if data.want_to_own else None,
-                admin["id"], True, data.time_commitment_hours_per_week,
+                admin["id"], True, data.project_type, data.estimated_duration,
+                data.time_commitment_hours_per_week,
                 data.urgency, data.collaboration_link
             )
         )

--- a/static/admin/create-project.html
+++ b/static/admin/create-project.html
@@ -35,32 +35,49 @@
             <form id="createForm" class="card">
                 <div class="form-group">
                     <label for="title" class="required">Project Title</label>
-                    <input type="text" id="title" name="title" required>
+                    <input type="text" id="title" name="title" required placeholder="A clear, descriptive name for the project">
                 </div>
 
                 <div class="form-group">
                     <label for="description" class="required">Description</label>
-                    <textarea id="description" name="description" required style="min-height: 200px;"></textarea>
+                    <textarea id="description" name="description" required style="min-height: 200px;"
+                        placeholder="Describe the project: goals, approach, what success looks like, and what kind of help is needed."></textarea>
+                </div>
+
+                <div class="form-group">
+                    <label for="project_type">Project Type</label>
+                    <select id="project_type" name="project_type">
+                        <option value="">Select a project type...</option>
+                        <option value="sprint">Sprint (1-2 weeks) - Focused burst of work with clear deliverable</option>
+                        <option value="container">Time-boxed (1-3 months) - Defined scope with end date</option>
+                        <option value="ongoing">Ongoing - Continuous work without fixed end date</option>
+                        <option value="one_off">One-off task - Single deliverable, minimal coordination</option>
+                    </select>
                 </div>
 
                 <div class="grid grid-2">
                     <div class="form-group">
-                        <label for="time_commitment">Time Commitment (hours/week)</label>
-                        <input type="number" id="time_commitment" name="time_commitment" min="1" max="40">
+                        <label for="time_commitment">Hours per Week</label>
+                        <input type="number" id="time_commitment" name="time_commitment" min="1" max="40" placeholder="e.g., 5">
                     </div>
                     <div class="form-group">
                         <label for="urgency">Urgency</label>
                         <select id="urgency" name="urgency">
-                            <option value="low">Low</option>
-                            <option value="medium" selected>Medium</option>
-                            <option value="high">High</option>
+                            <option value="low">Low - Nice to have</option>
+                            <option value="medium" selected>Medium - Should do soon</option>
+                            <option value="high">High - Urgent / time-sensitive</option>
                         </select>
                     </div>
                 </div>
 
+                <div class="form-group" id="durationGroup" style="display: none;">
+                    <label for="estimated_duration">Estimated Duration</label>
+                    <input type="text" id="estimated_duration" name="estimated_duration" placeholder="e.g., 6 weeks, 2 months">
+                </div>
+
                 <div class="form-group">
-                    <label for="collaboration_link">Collaboration Link</label>
-                    <input type="url" id="collaboration_link" name="collaboration_link" placeholder="Notion doc, etc.">
+                    <label for="collaboration_link">Collaboration Doc / Link (optional)</label>
+                    <input type="text" id="collaboration_link" name="collaboration_link" placeholder="e.g., https://docs.google.com/... or description of plans">
                 </div>
 
                 <h3 style="margin-top: 24px;">Skills Needed</h3>
@@ -96,6 +113,12 @@
             }
 
             renderSkillSelector('skillSelector');
+
+            // Show/hide duration field based on project type
+            document.getElementById('project_type').addEventListener('change', (e) => {
+                const showDuration = ['sprint', 'container'].includes(e.target.value);
+                document.getElementById('durationGroup').style.display = showDuration ? 'block' : 'none';
+            });
         }
 
         document.getElementById('createForm').addEventListener('submit', async (e) => {
@@ -114,6 +137,8 @@
                 const data = {
                     title: form.title.value.trim(),
                     description: form.description.value.trim(),
+                    project_type: form.project_type.value || null,
+                    estimated_duration: form.estimated_duration.value.trim() || null,
                     time_commitment_hours_per_week: form.time_commitment.value ? parseInt(form.time_commitment.value) : null,
                     urgency: form.urgency.value,
                     collaboration_link: form.collaboration_link.value.trim() || null,

--- a/static/admin/triage.html
+++ b/static/admin/triage.html
@@ -174,7 +174,9 @@
                             <p class="card-meta">
                                 Proposed by: ${p.proposer_name ? escapeHtml(p.proposer_name) : 'Unknown'}
                                 · ${formatDate(p.created_at)}
+                                ${p.project_type ? ` · ${{sprint:'Sprint',container:'Time-boxed',ongoing:'Ongoing',one_off:'One-off'}[p.project_type] || p.project_type}` : ''}
                                 ${p.time_commitment_hours_per_week ? ` · ${p.time_commitment_hours_per_week}h/week` : ''}
+                                ${p.estimated_duration ? ` · ${p.estimated_duration}` : ''}
                             </p>
                         </div>
                         <span class="status-badge status-${p.status}">${formatStatus(p.status)}</span>

--- a/static/index.html
+++ b/static/index.html
@@ -181,6 +181,7 @@
                     </div>
                     <div class="card-meta">
                         ${project.is_org_proposed ? '<span class="org-badge">PauseAI</span>' : ''}
+                        ${project.project_type ? ({'sprint':'Sprint','container':'Time-boxed','ongoing':'Ongoing','one_off':'One-off'}[project.project_type] || project.project_type) + ' · ' : ''}
                         ${project.owner ? `Owner: ${escapeHtml(project.owner.name)}` : 'No owner yet'}
                         ${project.time_commitment_hours_per_week ? ` · ${project.time_commitment_hours_per_week}h/week` : ''}
                         <span class="urgency urgency-${project.urgency}">· ${project.urgency} priority</span>

--- a/static/project.html
+++ b/static/project.html
@@ -281,6 +281,9 @@
             // Meta info
             let meta = [];
             if (project.is_org_proposed) meta.push('<span class="org-badge">PauseAI Official</span>');
+            const typeLabels = { sprint: 'Sprint', container: 'Time-boxed', ongoing: 'Ongoing', one_off: 'One-off' };
+            if (project.project_type) meta.push(typeLabels[project.project_type] || project.project_type);
+            if (project.estimated_duration) meta.push(project.estimated_duration);
             if (project.time_commitment_hours_per_week) meta.push(`${project.time_commitment_hours_per_week}h/week`);
             meta.push(`<span class="urgency urgency-${project.urgency}">${formatUrgency(project.urgency)} priority</span>`);
             meta.push(`Added ${formatDate(project.created_at)}`);


### PR DESCRIPTION
API:
- Fix create_org_project to include project_type and estimated_duration in INSERT

Project detail page:
- Show project type and estimated duration in meta info line

Projects listing page:
- Show project type in card meta info

Triage page:
- Show project type and estimated duration in proposal cards