### PR TITLE
Fix JSON.parse error on signup: handle non-JSON server responses grac…

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -45,7 +45,7 @@ async function apiRequest(endpoint, options = {}) {
         throw new Error(error.detail || 'Request failed');
     }
 
-    return response.json();
+    return response.json().catch(() => ({}));
 }
 
 // Utility functions

--- a/static/forgot-password.html
+++ b/static/forgot-password.html
@@ -84,7 +84,7 @@
                     })
                 });
 
-                const result = await response.json();
+                const result = await response.json().catch(() => ({}));
 
                 // Always show success (prevents email enumeration)
                 form.style.display = 'none';

--- a/static/login.html
+++ b/static/login.html
@@ -130,7 +130,7 @@
                     body: JSON.stringify({ credential: response.credential })
                 });
 
-                const data = await result.json();
+                const data = await result.json().catch(() => ({ detail: 'Server error. Please try again.' }));
 
                 if (!result.ok) {
                     throw new Error(data.detail || 'Google sign-in failed');
@@ -174,7 +174,7 @@
                     })
                 });
 
-                const result = await response.json();
+                const result = await response.json().catch(() => ({ detail: 'Server error. Please try again.' }));
 
                 if (!response.ok) {
                     throw new Error(result.detail || 'Login failed');

--- a/static/signup.html
+++ b/static/signup.html
@@ -303,7 +303,7 @@
                     body: JSON.stringify(data)
                 });
 
-                const result = await response.json();
+                const result = await response.json().catch(() => ({ detail: 'Server error. Please try again.' }));
 
                 if (!response.ok) {
                     throw new Error(result.detail || 'Signup failed');


### PR DESCRIPTION
…efully

The signup form crashed with 'JSON.parse: unexpected character' when the server returned a 500 with a non-JSON body (e.g. when the email_digest column didn't exist yet). The root cause (missing column) was already fixed, but the frontend should handle this gracefully regardless.

Fixed all response.json() calls across the app to use .catch() fallbacks:
- signup.html: signup form submission
- login.html: login form and Google auth handler
- forgot-password.html: password reset form
- app.js: shared apiRequest success path (error path was already safe)

Now if the server ever returns non-JSON (500 from proxy, empty body, etc.), users see "Server error. Please try again." instead of a cryptic JSON parse error.

https://claude.ai/code/session_01FtHs7y4tJjbWBSJKmhpQu1