### PR TITLE
Add e2e test suite and fix two bugs found during setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .env
 venv/
+.playwright-mcp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: dev install test test-headed test-debug test-smoke
+
+# Start the development server on http://localhost:8001
+dev:
+	python api.py
+
+# Install Python dependencies and download the Playwright Chromium browser
+install:
+	pip install -r requirements.txt && playwright install chromium
+
+# Run all e2e tests headlessly (fast, no browser window)
+test:
+	pytest tests/e2e/
+
+# Run all e2e tests with a visible browser, slowed down so you can follow along
+test-headed:
+	pytest tests/e2e/ --headed --slowmo=500
+
+# Run tests with Playwright Inspector — step through each action with a GUI debugger
+test-debug:
+	PWDEBUG=1 pytest tests/e2e/ --headed
+
+# Run smoke tests against production (read-only, no data created)
+# Usage: make test-smoke EMAIL=you@example.com PASSWORD=yourpassword
+test-smoke:
+	BASE_URL=https://catalyse.pauseai.uk \
+	TEST_USER_EMAIL=$(EMAIL) \
+	TEST_USER_PASSWORD=$(PASSWORD) \
+	pytest tests/e2e/ -m "not local_only"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev install test test-headed test-debug test-smoke
+.PHONY: dev install test test-headed test-debug test-smoke scenario scenarios
 
 # Start the development server on http://localhost:8001
 dev:
@@ -27,3 +27,16 @@ test-smoke:
 	TEST_USER_EMAIL=$(EMAIL) \
 	TEST_USER_PASSWORD=$(PASSWORD) \
 	pytest tests/e2e/ -m "not local_only"
+
+# Run a single Claude scenario walkthrough against the local dev server
+# Requires the dev server to be running first: make dev
+# Usage: make scenario NAME=01-volunteer-propose-project
+scenario:
+	@curl -sf http://localhost:8001/api/skills > /dev/null || (echo "Error: dev server is not running. Start it with 'make dev' in another terminal." && exit 1)
+	claude -p "Please run the scenario in tests/scenarios/$(NAME).md against http://localhost:8001 and report the results"
+
+# Run all Claude scenario walkthroughs in order
+# Requires the dev server to be running first: make dev
+scenarios:
+	@curl -sf http://localhost:8001/api/skills > /dev/null || (echo "Error: dev server is not running. Start it with 'make dev' in another terminal." && exit 1)
+	claude -p "Please run each scenario in tests/scenarios/ in order against http://localhost:8001 and report a summary of results"

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,29 @@
-.PHONY: dev install test test-headed test-debug test-smoke scenario scenarios
+.PHONY: dev install test test-headed test-debug test-smoke scenario scenarios scenario-clean
 
 # Start the development server on http://localhost:8001
 dev:
-	python api.py
+	. venv/bin/activate && python api.py
 
 # Install Python dependencies and download the Playwright Chromium browser
 install:
-	pip install -r requirements.txt && playwright install chromium
+	. venv/bin/activate && pip install -r requirements.txt && playwright install chromium
 
 # Run all e2e tests headlessly (fast, no browser window)
 test:
-	pytest tests/e2e/
+	. venv/bin/activate && pytest tests/e2e/
 
 # Run all e2e tests with a visible browser, slowed down so you can follow along
 test-headed:
-	pytest tests/e2e/ --headed --slowmo=500
+	. venv/bin/activate && pytest tests/e2e/ --headed --slowmo=500
 
 # Run tests with Playwright Inspector — step through each action with a GUI debugger
 test-debug:
-	PWDEBUG=1 pytest tests/e2e/ --headed
+	. venv/bin/activate && PWDEBUG=1 pytest tests/e2e/ --headed
 
 # Run smoke tests against production (read-only, no data created)
 # Usage: make test-smoke EMAIL=you@example.com PASSWORD=yourpassword
 test-smoke:
+	. venv/bin/activate && \
 	BASE_URL=https://catalyse.pauseai.uk \
 	TEST_USER_EMAIL=$(EMAIL) \
 	TEST_USER_PASSWORD=$(PASSWORD) \
@@ -33,10 +34,40 @@ test-smoke:
 # Usage: make scenario NAME=01-volunteer-propose-project
 scenario:
 	@curl -sf http://localhost:8001/api/skills > /dev/null || (echo "Error: dev server is not running. Start it with 'make dev' in another terminal." && exit 1)
-	claude -p "Please run the scenario in tests/scenarios/$(NAME).md against http://localhost:8001 and report the results"
+	@echo "Available scenarios:"; \
+	ls tests/scenarios/*.md | grep -v README | xargs -I{} basename {} .md | nl -w2 -s') '; \
+	printf "Enter scenario name or number: "; \
+	read INPUT; \
+	if echo "$$INPUT" | grep -qE '^[0-9]+$$'; then \
+		NAME=$$(ls tests/scenarios/*.md | grep -v README | sed -n "$${INPUT}p" | xargs basename | sed 's/\.md$$//'); \
+	else \
+		NAME=$$INPUT; \
+	fi; \
+	DATETIME=$$(date +%Y-%m-%dT%H-%M-%S); \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	COMMIT=$$(git rev-parse --short HEAD); \
+	mkdir -p tests/scenarios/results; \
+	OUTFILE="tests/scenarios/results/$${DATETIME}_$${NAME}_$${BRANCH}_$${COMMIT}.md"; \
+	printf -- '---\ndate: %s\nscenario: %s\nbranch: %s\ncommit: %s\n---\n' \
+		"$${DATETIME}" "$${NAME}" "$${BRANCH}" "$${COMMIT}" > "$${OUTFILE}"; \
+	echo "Running scenario: $$NAME"; \
+	echo "Results will be written to: $$OUTFILE"; \
+	claude "Please run the scenario in tests/scenarios/$${NAME}.md against http://localhost:8001. Write the results to $${OUTFILE}, which already exists with YAML frontmatter. Append to the file: a '## Results' section with a markdown table (columns: Step, Result, Notes), then an '## Observations' section listing any UX issues or unexpected behaviour noticed during the run. Do not rewrite the frontmatter."
+
+# Remove test accounts and projects left over from scenario walkthroughs
+scenario-clean:
+	. venv/bin/activate && python tests/scenarios/cleanup.py
 
 # Run all Claude scenario walkthroughs in order
 # Requires the dev server to be running first: make dev
 scenarios:
 	@curl -sf http://localhost:8001/api/skills > /dev/null || (echo "Error: dev server is not running. Start it with 'make dev' in another terminal." && exit 1)
-	claude -p "Please run each scenario in tests/scenarios/ in order against http://localhost:8001 and report a summary of results"
+	@DATETIME=$$(date +%Y-%m-%dT%H-%M-%S); \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	COMMIT=$$(git rev-parse --short HEAD); \
+	mkdir -p tests/scenarios/results; \
+	OUTFILE="tests/scenarios/results/$${DATETIME}_all-scenarios_$${BRANCH}_$${COMMIT}.md"; \
+	printf -- '---\ndate: %s\nscenario: all\nbranch: %s\ncommit: %s\n---\n' \
+		"$${DATETIME}" "$${BRANCH}" "$${COMMIT}" > "$${OUTFILE}"; \
+	echo "Results will be written to: $$OUTFILE"; \
+	claude "Please run each scenario in tests/scenarios/ in order (skip README and triage files) against http://localhost:8001. Write the results to $${OUTFILE}, which already exists with YAML frontmatter. For each scenario append an H2 heading with the scenario name, a results table (columns: Step, Result, Notes), and an Observations subsection. Do not rewrite the frontmatter."

--- a/README.md
+++ b/README.md
@@ -100,11 +100,16 @@ make test-smoke EMAIL=you@example.com PASSWORD=yourpassword
 
 ### Claude scenario walkthroughs
 
-For more complex flows (project proposals, admin triage, expressing interest), there are step-by-step scenario files in `tests/scenarios/`. Ask Claude to run one:
+For more complex flows (project proposals, admin triage, expressing interest), there are step-by-step scenario files in `tests/scenarios/`. These require the dev server to be running first:
 
-> "Please run the scenario in `tests/scenarios/02-admin-triage-project.md` against http://localhost:8001"
+```bash
+make dev  # in one terminal
 
-See `tests/scenarios/README.md` for the full list.
+make scenario NAME=01-volunteer-propose-project  # in another
+make scenarios                                   # or run all of them
+```
+
+Both commands will error immediately if the dev server isn't running. See `tests/scenarios/README.md` for the full list of scenarios.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,42 @@ The app will be available at `http://localhost:8001`
 UPDATE volunteers SET is_admin = 1 WHERE email = 'your@email.com';
 ```
 
+## Testing
+
+### Setup
+
+Install test dependencies (once):
+
+```bash
+make install
+```
+
+### Running tests
+
+```bash
+make test          # Run all tests headlessly — fast, no browser window
+make test-headed   # Run with a visible browser, slowed down so you can follow along
+make test-debug    # Open Playwright Inspector — step through each action with a GUI debugger
+```
+
+Tests start their own server on port 8002 with a fresh isolated database — your dev server doesn't need to be running.
+
+### Smoke testing against production
+
+Runs a read-only subset of tests against the live site using your real account. No data is created.
+
+```bash
+make test-smoke EMAIL=you@example.com PASSWORD=yourpassword
+```
+
+### Claude scenario walkthroughs
+
+For more complex flows (project proposals, admin triage, expressing interest), there are step-by-step scenario files in `tests/scenarios/`. Ask Claude to run one:
+
+> "Please run the scenario in `tests/scenarios/02-admin-triage-project.md` against http://localhost:8001"
+
+See `tests/scenarios/README.md` for the full list.
+
 ## Project Structure
 
 ```
@@ -79,7 +115,11 @@ catalyse/
 ├── seed_skills.sql     # Pre-populated skills taxonomy
 ├── catalyse.db         # SQLite database (created on run)
 ├── requirements.txt    # Python dependencies
+├── Makefile            # Common commands (make dev, make test, etc.)
 ├── README.md
+├── tests/
+│   ├── e2e/            # Playwright tests for critical flows (signup, login, projects)
+│   └── scenarios/      # Step-by-step flows for Claude to walk through manually
 └── static/
     ├── styles.css      # Shared styles
     ├── app.js          # Shared JavaScript utilities

--- a/api.py
+++ b/api.py
@@ -115,10 +115,14 @@ def run_migrations():
         statements = [s.strip() for s in sql.split(';') if s.strip()]
         applied = 0
         for statement in statements:
-            if not statement or statement.startswith('--'):
+            # Strip leading comment lines before deciding whether to skip
+            non_comment = '\n'.join(
+                l for l in statement.split('\n') if not l.strip().startswith('--')
+            ).strip()
+            if not non_comment:
                 continue
             try:
-                conn.execute(statement)
+                conn.execute(non_comment)
                 applied += 1
             except Exception as e:
                 # "already exists" / "duplicate column" are safe to skip

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+addopts = --tb=short -v
+markers =
+    local_only: tests that create data; skip when running against production

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ fastapi>=0.100.0
 uvicorn>=0.23.0
 pydantic>=2.0.0
 pydantic[email]
+
+# Testing
+pytest>=8.0
+pytest-playwright>=0.5
+playwright>=1.44

--- a/static/app.js
+++ b/static/app.js
@@ -42,7 +42,10 @@ async function apiRequest(endpoint, options = {}) {
 
     if (!response.ok) {
         const error = await response.json().catch(() => ({ detail: 'Request failed' }));
-        throw new Error(error.detail || 'Request failed');
+        const detail = Array.isArray(error.detail)
+            ? error.detail.map(e => e.msg).join(', ')
+            : error.detail;
+        throw new Error(detail || 'Request failed');
     }
 
     return response.json().catch(() => ({}));

--- a/static/login.html
+++ b/static/login.html
@@ -177,7 +177,10 @@
                 const result = await response.json().catch(() => ({ detail: 'Server error. Please try again.' }));
 
                 if (!response.ok) {
-                    throw new Error(result.detail || 'Login failed');
+                    const detail = Array.isArray(result.detail)
+                        ? result.detail.map(e => e.msg).join(', ')
+                        : result.detail;
+                    throw new Error(detail || 'Login failed');
                 }
 
                 localStorage.setItem('authToken', result.auth_token);

--- a/static/signup.html
+++ b/static/signup.html
@@ -306,7 +306,10 @@
                 const result = await response.json().catch(() => ({ detail: 'Server error. Please try again.' }));
 
                 if (!response.ok) {
-                    throw new Error(result.detail || 'Signup failed');
+                    const detail = Array.isArray(result.detail)
+                        ? result.detail.map(e => e.msg).join(', ')
+                        : result.detail;
+                    throw new Error(detail || 'Signup failed');
                 }
 
                 // Store token and redirect

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,249 @@
+"""
+Shared fixtures for Catalyse e2e tests.
+
+Modes:
+  LOCAL  (default) — starts a fresh api.py subprocess on port 8002 with an
+                     isolated temp SQLite database. All data-creating tests run.
+  PRODUCTION       — set BASE_URL to the live site. The server is not started;
+                     existing_user fixture logs in with TEST_USER_EMAIL /
+                     TEST_USER_PASSWORD env vars. Tests marked local_only are skipped.
+
+Usage:
+  pytest tests/e2e/                              # local
+  BASE_URL=https://... TEST_USER_EMAIL=... TEST_USER_PASSWORD=... \
+    pytest tests/e2e/ -m "not local_only"        # production smoke
+"""
+
+import os
+import subprocess
+import time
+import tempfile
+import shutil
+import uuid
+import requests
+import pytest
+
+from tests.e2e.helpers import BASE_URL, IS_PRODUCTION, inject_auth_token  # noqa: F401
+
+ADMIN_EMAIL = "admin@test.com"
+ADMIN_PASSWORD = "adminpassword1"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _api(method, path, json=None, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.request(method, f"{BASE_URL}{path}", json=json, headers=headers, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+# ── Server lifecycle ──────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def _tmp_db_dir():
+    tmp = tempfile.mkdtemp(prefix="catalyse_test_")
+    yield tmp
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def live_server(_tmp_db_dir):
+    """Start the API on port 8002 with an isolated test database (local only)."""
+    if IS_PRODUCTION:
+        yield
+        return
+
+    env = {
+        **os.environ,
+        "PORT": "8002",
+        "RAILWAY_VOLUME_MOUNT_PATH": _tmp_db_dir,
+        # Don't use ADMIN_EMAILS: it triggers a nested db_transaction inside signup
+        # which causes SQLite lock contention. Promote via direct DB write instead.
+        "ADMIN_EMAILS": "",
+        "RESEND_API_KEY": "",
+    }
+
+    proc = subprocess.Popen(
+        ["python", "api.py"],
+        env=env,
+        cwd=str(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+    )
+
+    # Poll until ready (skills endpoint requires a fully-initialised DB)
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        try:
+            if requests.get(f"{BASE_URL}/api/skills", timeout=2).status_code == 200:
+                break
+        except requests.ConnectionError:
+            pass
+        time.sleep(0.5)
+    else:
+        proc.terminate()
+        raise RuntimeError("Test server did not become ready within 30 seconds")
+
+    yield
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+# ── User fixtures ─────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def admin_token(live_server, _tmp_db_dir):
+    """
+    Create the admin user once per session (local only).
+    Promotion is done via direct DB write to avoid the nested db_transaction
+    bug in check_admin_bootstrap when ADMIN_EMAILS is set on the server.
+    """
+    if IS_PRODUCTION:
+        pytest.skip("admin_token not available in production mode")
+    import sqlite3 as _sqlite3
+    data = _api("POST", "/api/auth/signup", json={
+        "name": "Test Admin",
+        "email": ADMIN_EMAIL,
+        "password": ADMIN_PASSWORD,
+        "consent_profile_visible": True,
+        "consent_contact_by_owners": True,
+    })
+    db_path = os.path.join(_tmp_db_dir, "catalyse.db")
+    conn = _sqlite3.connect(db_path)
+    conn.execute("UPDATE volunteers SET is_admin = 1 WHERE email = ?", (ADMIN_EMAIL,))
+    conn.commit()
+    conn.close()
+    return data["auth_token"]
+
+
+@pytest.fixture
+def new_user(live_server):
+    """Create a fresh unique volunteer for each test (local only)."""
+    email = f"user_{uuid.uuid4().hex[:8]}@test.com"
+    password = "testpassword1"
+    data = _api("POST", "/api/auth/signup", json={
+        "name": "Test User",
+        "email": email,
+        "password": password,
+        "consent_profile_visible": True,
+        "consent_contact_by_owners": True,
+    })
+    return {"email": email, "password": password, "token": data["auth_token"], "id": data["id"]}
+
+
+@pytest.fixture(scope="session")
+def existing_user(live_server):
+    """Log in with real credentials from env vars (production smoke tests)."""
+    email = os.environ.get("TEST_USER_EMAIL", "")
+    password = os.environ.get("TEST_USER_PASSWORD", "")
+    if not email or not password:
+        pytest.skip("TEST_USER_EMAIL / TEST_USER_PASSWORD not set")
+    data = _api("POST", "/api/auth/login", json={"email": email, "password": password})
+    return {"email": email, "password": password, "token": data["auth_token"]}
+
+
+# ── Project fixture ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def published_project(live_server, admin_token):
+    """
+    Return a visible project id. Local: create via admin API. Production: fetch first listed project.
+    Admin-created projects go straight to seeking_owner, no triage needed.
+    """
+    if IS_PRODUCTION:
+        projects = _api("GET", "/api/projects")
+        if not projects:
+            pytest.skip("No projects found on production")
+        return projects[0]["id"]
+
+    data = _api("POST", "/api/admin/projects", json={
+        "title": "E2E Test Project",
+        "description": "This project exists for automated e2e testing purposes only.",
+        "urgency": "medium",
+    }, token=admin_token)
+    return data["id"]
+
+
+# ── Test label overlay ────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def test_label(page, request):
+    """Inject a floating label into the browser showing the current test name."""
+    label = (
+        request.node.name
+        .replace("[chromium]", "")
+        .replace("_", " ")
+    )
+    page.add_init_script(f"""
+        (() => {{
+            const show = () => {{
+                if (document.getElementById('__test_label__')) return;
+                const el = document.createElement('div');
+                el.id = '__test_label__';
+                el.textContent = '{label}';
+                el.style.cssText = [
+                    'position:fixed', 'bottom:16px', 'left:16px',
+                    'background:rgba(0,0,0,0.72)', 'color:#fff',
+                    'padding:7px 14px', 'border-radius:6px',
+                    'font:13px/1.4 monospace', 'z-index:99999',
+                    'pointer-events:none', 'max-width:420px',
+                    'white-space:pre-wrap'
+                ].join(';');
+                document.body.appendChild(el);
+            }};
+            document.addEventListener('DOMContentLoaded', show);
+            if (document.readyState !== 'loading') show();
+        }})();
+    """)
+
+
+# ── Auth token fixtures ───────────────────────────────────────────────────────
+
+@pytest.fixture
+def fresh_token(user_credentials):
+    """
+    Log in via API to get a fresh, valid token for the current test.
+    Use this (not user_credentials["token"]) whenever a test needs to inject
+    auth into a browser context — the session token can become stale if a
+    prior test logged in as the same user via the login form.
+    """
+    data = _api("POST", "/api/auth/login", json={
+        "email": user_credentials["email"],
+        "password": user_credentials["password"],
+    })
+    return data["auth_token"]
+
+
+# ── Combined credentials fixture (works in both modes) ───────────────────────
+
+@pytest.fixture(scope="session")
+def user_credentials(live_server):
+    """
+    Return {email, password, token} for a user appropriate to the current mode.
+    Local: creates a dedicated session-scoped test user via API.
+    Production: logs in with TEST_USER_EMAIL / TEST_USER_PASSWORD env vars.
+    """
+    if IS_PRODUCTION:
+        email = os.environ.get("TEST_USER_EMAIL", "")
+        password = os.environ.get("TEST_USER_PASSWORD", "")
+        if not email or not password:
+            pytest.skip("TEST_USER_EMAIL / TEST_USER_PASSWORD not set")
+        data = _api("POST", "/api/auth/login", json={"email": email, "password": password})
+        return {"email": email, "password": password, "token": data["auth_token"]}
+    else:
+        email = f"session_user_{uuid.uuid4().hex[:8]}@test.com"
+        password = "testpassword1"
+        data = _api("POST", "/api/auth/signup", json={
+            "name": "Session Test User",
+            "email": email,
+            "password": password,
+            "consent_profile_visible": True,
+            "consent_contact_by_owners": True,
+        })
+        return {"email": email, "password": password, "token": data["auth_token"]}
+
+

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,0 +1,10 @@
+"""Shared constants and utilities for e2e tests."""
+import os
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8002")
+IS_PRODUCTION = not BASE_URL.startswith("http://localhost")
+
+
+def inject_auth_token(context, token: str):
+    """Populate localStorage before any page script runs."""
+    context.add_init_script(f"localStorage.setItem('authToken', '{token}');")

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,0 +1,86 @@
+import uuid
+import pytest
+from playwright.sync_api import Page, expect
+from tests.e2e.helpers import BASE_URL, IS_PRODUCTION, inject_auth_token
+
+
+# ── Signup ────────────────────────────────────────────────────────────────────
+
+class TestSignup:
+    @pytest.mark.local_only
+    def test_signup_form_renders(self, page: Page):
+        page.goto(f"{BASE_URL}/static/signup.html")
+        expect(page.locator("h1")).to_be_visible()
+        expect(page.locator("#signupForm")).to_be_visible()
+
+    @pytest.mark.local_only
+    def test_successful_signup(self, page: Page):
+        email = f"user_{uuid.uuid4().hex[:8]}@test.com"
+        page.goto(f"{BASE_URL}/static/signup.html")
+        page.fill("#name", "New Test User")
+        page.fill("#email", email)
+        page.fill("#password", "testpassword1")
+        page.fill("#password_confirm", "testpassword1")
+        page.click("#signupForm button[type=submit]")
+        expect(page).to_have_url(f"{BASE_URL}/static/dashboard.html", timeout=10000)
+
+    @pytest.mark.local_only
+    def test_duplicate_email_shows_error(self, page: Page, new_user):
+        page.goto(f"{BASE_URL}/static/signup.html")
+        page.fill("#name", "Dupe User")
+        page.fill("#email", new_user["email"])
+        page.fill("#password", "testpassword1")
+        page.fill("#password_confirm", "testpassword1")
+        page.click("#signupForm button[type=submit]")
+        expect(page.locator("#messageDiv")).to_be_visible(timeout=5000)
+
+
+# ── Login ─────────────────────────────────────────────────────────────────────
+
+class TestLogin:
+    def test_login_form_renders(self, page: Page):
+        page.goto(f"{BASE_URL}/static/login.html")
+        expect(page.locator("h1")).to_be_visible()
+        expect(page.locator("#loginForm")).to_be_visible()
+
+    def test_successful_login(self, page: Page, user_credentials):
+        page.goto(f"{BASE_URL}/static/login.html")
+        page.fill("#email", user_credentials["email"])
+        page.fill("#password", user_credentials["password"])
+        page.click("#loginForm button[type=submit]")
+        expect(page).to_have_url(f"{BASE_URL}/static/dashboard.html", timeout=10000)
+
+    @pytest.mark.local_only
+    def test_invalid_password_shows_error(self, page: Page, new_user):
+        page.goto(f"{BASE_URL}/static/login.html")
+        page.fill("#email", new_user["email"])
+        page.fill("#password", "wrongpassword1")
+        page.click("#loginForm button[type=submit]")
+        expect(page.locator("#messageDiv")).to_be_visible(timeout=5000)
+
+    @pytest.mark.local_only
+    def test_unknown_email_shows_error(self, page: Page):
+        page.goto(f"{BASE_URL}/static/login.html")
+        page.fill("#email", "nobody@nowhere.com")
+        page.fill("#password", "testpassword1")
+        page.click("#loginForm button[type=submit]")
+        expect(page.locator("#messageDiv")).to_be_visible(timeout=5000)
+
+
+# ── Logout ────────────────────────────────────────────────────────────────────
+
+class TestLogout:
+    def test_logout_clears_session(self, page: Page, user_credentials):
+        # Log in via the form to get a fresh token — don't use the cached fixture
+        # token, which may have been invalidated by a prior login in the same session.
+        page.goto(f"{BASE_URL}/static/login.html")
+        page.fill("#email", user_credentials["email"])
+        page.fill("#password", user_credentials["password"])
+        page.click("#loginForm button[type=submit]")
+        expect(page).to_have_url(f"{BASE_URL}/static/dashboard.html", timeout=10000)
+        page.locator(".user-button").click()
+        page.get_by_role("link", name="Logout").click()
+        # logout() redirects to login; wait for that to confirm the full logout flow ran
+        expect(page).to_have_url(f"{BASE_URL}/static/login.html", timeout=10000)
+        stored = page.evaluate("localStorage.getItem('authToken')")
+        assert stored is None

--- a/tests/e2e/test_projects.py
+++ b/tests/e2e/test_projects.py
@@ -1,0 +1,37 @@
+import pytest
+from playwright.sync_api import Page, expect
+from tests.e2e.helpers import BASE_URL, inject_auth_token
+
+
+class TestProjectsBrowsing:
+    def test_homepage_loads(self, page: Page, fresh_token, published_project):
+        inject_auth_token(page.context, fresh_token)
+        page.goto(f"{BASE_URL}/")
+        # Wait for at least one card to confirm the list rendered with content
+        expect(page.locator("#projectsList .card").first).to_be_visible(timeout=10000)
+
+    def test_projects_list_shows_cards(self, page: Page, fresh_token, published_project):
+        inject_auth_token(page.context, fresh_token)
+        page.goto(f"{BASE_URL}/")
+        # Cards are loaded asynchronously via JS fetch
+        expect(page.locator("#projectsList .card").first).to_be_visible(timeout=10000)
+
+    def test_project_card_links_to_detail(self, page: Page, fresh_token, published_project):
+        inject_auth_token(page.context, fresh_token)
+        page.goto(f"{BASE_URL}/")
+        expect(page.locator("#projectsList .card").first).to_be_visible(timeout=10000)
+        page.locator("#projectsList .card a").first.click()
+        page.wait_for_url(f"{BASE_URL}/static/project.html**", timeout=5000)
+        assert "id=" in page.url
+
+    def test_project_detail_shows_content(self, page: Page, fresh_token, published_project):
+        inject_auth_token(page.context, fresh_token)
+        page.goto(f"{BASE_URL}/static/project.html?id={published_project}")
+        expect(page.locator("#projectContent")).to_be_visible(timeout=10000)
+        expect(page.locator("#projectTitle")).not_to_be_empty()
+
+    @pytest.mark.local_only
+    def test_unauthenticated_redirects_to_login(self, page: Page, published_project):
+        # Without auth, the homepage should redirect to login
+        page.goto(f"{BASE_URL}/")
+        expect(page).to_have_url(f"{BASE_URL}/static/login.html", timeout=10000)

--- a/tests/scenarios/01-volunteer-propose-project.md
+++ b/tests/scenarios/01-volunteer-propose-project.md
@@ -1,16 +1,19 @@
 # Scenario 01: Volunteer Proposes a Project
 
 ## Purpose
+
 Verify that a logged-in volunteer can submit a project proposal, see a confirmation, and that the project appears in the admin triage queue.
 
 ## Prerequisites
 
 ### Accounts needed
-| Account | Email | Password | Role |
-|---------|-------|----------|------|
+
+| Account   | Email              | Password       | Role         |
+| --------- | ------------------ | -------------- | ------------ |
 | Volunteer | volunteer@test.com | volunteerpass1 | regular user |
 
 ### Setup
+
 ```bash
 BASE=http://localhost:8001
 curl -s -X POST $BASE/api/auth/signup \
@@ -21,15 +24,18 @@ curl -s -X POST $BASE/api/auth/signup \
 ## Steps
 
 ### Step 1: Log in as the volunteer
+
 - **Navigate to:** `http://localhost:8001/static/login.html`
 - **Action:** Fill email `volunteer@test.com` and password `volunteerpass1`, submit
 - **Expected:** Redirected to `/static/dashboard.html`
 
 ### Step 2: Navigate to the project suggestion form
+
 - **Navigate to:** `http://localhost:8001/static/suggest.html`
 - **Expected:** Form with title "Suggest a Project" is visible
 
 ### Step 3: Fill in the project form
+
 - **Action:** Fill in:
   - Title: "Test Proposal [today's date]"
   - Description: "This is a test project proposal to verify the suggestion flow works correctly."
@@ -38,20 +44,25 @@ curl -s -X POST $BASE/api/auth/signup \
 - **Expected:** Form accepts input without errors
 
 ### Step 4: Submit the form
+
 - **Action:** Click the submit button
 - **Expected:** Success message appears (e.g. "Project submitted for review") or redirect occurs
 
 ### Step 5: Verify in admin triage
+
 - **Navigate to:** `http://localhost:8001/static/admin/triage.html` (requires admin login — if not admin, skip this step)
 - **Expected:** The proposed project appears in the "Pending Review" tab with the title used in Step 3
 
 ## Expected Final State
+
 - Volunteer sees a confirmation that the project was submitted
 - Project exists in the database with status `pending_review`
 - Project appears in the admin triage queue
 
 ## Cleanup
+
 To remove the test project, an admin can reject it in the triage view, or delete it via the API:
+
 ```bash
 # Get project id from triage, then:
 curl -X DELETE http://localhost:8001/api/projects/{id} -H "Authorization: Bearer {admin_token}"

--- a/tests/scenarios/01-volunteer-propose-project.md
+++ b/tests/scenarios/01-volunteer-propose-project.md
@@ -1,0 +1,58 @@
+# Scenario 01: Volunteer Proposes a Project
+
+## Purpose
+Verify that a logged-in volunteer can submit a project proposal, see a confirmation, and that the project appears in the admin triage queue.
+
+## Prerequisites
+
+### Accounts needed
+| Account | Email | Password | Role |
+|---------|-------|----------|------|
+| Volunteer | volunteer@test.com | volunteerpass1 | regular user |
+
+### Setup
+```bash
+BASE=http://localhost:8001
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Volunteer","email":"volunteer@test.com","password":"volunteerpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+## Steps
+
+### Step 1: Log in as the volunteer
+- **Navigate to:** `http://localhost:8001/static/login.html`
+- **Action:** Fill email `volunteer@test.com` and password `volunteerpass1`, submit
+- **Expected:** Redirected to `/static/dashboard.html`
+
+### Step 2: Navigate to the project suggestion form
+- **Navigate to:** `http://localhost:8001/static/suggest.html`
+- **Expected:** Form with title "Suggest a Project" is visible
+
+### Step 3: Fill in the project form
+- **Action:** Fill in:
+  - Title: "Test Proposal [today's date]"
+  - Description: "This is a test project proposal to verify the suggestion flow works correctly."
+  - Urgency: Medium
+  - Time commitment: 5 hours/week
+- **Expected:** Form accepts input without errors
+
+### Step 4: Submit the form
+- **Action:** Click the submit button
+- **Expected:** Success message appears (e.g. "Project submitted for review") or redirect occurs
+
+### Step 5: Verify in admin triage
+- **Navigate to:** `http://localhost:8001/static/admin/triage.html` (requires admin login — if not admin, skip this step)
+- **Expected:** The proposed project appears in the "Pending Review" tab with the title used in Step 3
+
+## Expected Final State
+- Volunteer sees a confirmation that the project was submitted
+- Project exists in the database with status `pending_review`
+- Project appears in the admin triage queue
+
+## Cleanup
+To remove the test project, an admin can reject it in the triage view, or delete it via the API:
+```bash
+# Get project id from triage, then:
+curl -X DELETE http://localhost:8001/api/projects/{id} -H "Authorization: Bearer {admin_token}"
+```

--- a/tests/scenarios/02-admin-triage-project.md
+++ b/tests/scenarios/02-admin-triage-project.md
@@ -1,17 +1,21 @@
 # Scenario 02: Admin Triages a Pending Project
 
 ## Purpose
+
 Verify that an admin can review a pending project, approve it, and that the project status changes to `seeking_owner` and becomes visible in the public listing.
 
 ## Prerequisites
 
 ### Accounts needed
-| Account | Email | Password | Role |
-|---------|-------|----------|------|
-| Admin | admin@test.com | adminpass1 | admin |
+
+| Account | Email          | Password   | Role  |
+| ------- | -------------- | ---------- | ----- |
+| Admin   | admin@test.com | adminpass1 | admin |
 
 ### Setup
+
 Start the server with `ADMIN_EMAILS=admin@test.com python api.py`, then create the admin account:
+
 ```bash
 BASE=http://localhost:8001
 curl -s -X POST $BASE/api/auth/signup \
@@ -20,6 +24,7 @@ curl -s -X POST $BASE/api/auth/signup \
 ```
 
 You also need a pending project to review. Either run Scenario 01 first, or create one via API:
+
 ```bash
 # Get admin token from login response
 TOKEN=$(curl -s -X POST $BASE/api/auth/login \
@@ -36,30 +41,37 @@ curl -s -X POST $BASE/api/projects \
 ## Steps
 
 ### Step 1: Log in as admin
+
 - **Navigate to:** `http://localhost:8001/static/login.html`
 - **Action:** Fill email `admin@test.com` and password `adminpass1`, submit
 - **Expected:** Redirected to `/static/dashboard.html`; nav shows admin links
 
 ### Step 2: Open the triage page
+
 - **Navigate to:** `http://localhost:8001/static/admin/triage.html`
 - **Expected:** "Pending Review" tab is active; pending project card is visible
 
 ### Step 3: Open the review modal
+
 - **Action:** Click the "Review" button on the pending project
 - **Expected:** A modal opens showing the project title, description, and proposer
 
 ### Step 4: Approve the project
+
 - **Action:** Select "Approve" and optionally add a note, then confirm
 - **Expected:** Modal closes; success message appears; project card moves out of the pending list
 
 ### Step 5: Verify the project is now public
+
 - **Navigate to:** `http://localhost:8001/` (projects listing)
 - **Expected:** The approved project appears in the list with status "Seeking Owner"
 
 ## Expected Final State
+
 - Project status is `seeking_owner`
 - Project is visible on the public projects listing
 - (If email configured) Proposer receives an approval notification
 
 ## Cleanup
+
 Delete the test project from the edit project page or via API.

--- a/tests/scenarios/02-admin-triage-project.md
+++ b/tests/scenarios/02-admin-triage-project.md
@@ -1,0 +1,65 @@
+# Scenario 02: Admin Triages a Pending Project
+
+## Purpose
+Verify that an admin can review a pending project, approve it, and that the project status changes to `seeking_owner` and becomes visible in the public listing.
+
+## Prerequisites
+
+### Accounts needed
+| Account | Email | Password | Role |
+|---------|-------|----------|------|
+| Admin | admin@test.com | adminpass1 | admin |
+
+### Setup
+Start the server with `ADMIN_EMAILS=admin@test.com python api.py`, then create the admin account:
+```bash
+BASE=http://localhost:8001
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Admin","email":"admin@test.com","password":"adminpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+You also need a pending project to review. Either run Scenario 01 first, or create one via API:
+```bash
+# Get admin token from login response
+TOKEN=$(curl -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@test.com","password":"adminpass1"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['auth_token'])")
+
+# Create a pending project as a volunteer (proposed projects start pending)
+curl -s -X POST $BASE/api/projects \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"title":"Pending Test Project","description":"A project awaiting admin review."}'
+```
+
+## Steps
+
+### Step 1: Log in as admin
+- **Navigate to:** `http://localhost:8001/static/login.html`
+- **Action:** Fill email `admin@test.com` and password `adminpass1`, submit
+- **Expected:** Redirected to `/static/dashboard.html`; nav shows admin links
+
+### Step 2: Open the triage page
+- **Navigate to:** `http://localhost:8001/static/admin/triage.html`
+- **Expected:** "Pending Review" tab is active; pending project card is visible
+
+### Step 3: Open the review modal
+- **Action:** Click the "Review" button on the pending project
+- **Expected:** A modal opens showing the project title, description, and proposer
+
+### Step 4: Approve the project
+- **Action:** Select "Approve" and optionally add a note, then confirm
+- **Expected:** Modal closes; success message appears; project card moves out of the pending list
+
+### Step 5: Verify the project is now public
+- **Navigate to:** `http://localhost:8001/` (projects listing)
+- **Expected:** The approved project appears in the list with status "Seeking Owner"
+
+## Expected Final State
+- Project status is `seeking_owner`
+- Project is visible on the public projects listing
+- (If email configured) Proposer receives an approval notification
+
+## Cleanup
+Delete the test project from the edit project page or via API.

--- a/tests/scenarios/03-volunteer-express-interest.md
+++ b/tests/scenarios/03-volunteer-express-interest.md
@@ -1,0 +1,52 @@
+# Scenario 03: Volunteer Expresses Interest in a Project
+
+## Purpose
+Verify that a logged-in volunteer can express interest in a project, the interest form submits successfully, and the interest is reflected in the volunteer's dashboard.
+
+## Prerequisites
+
+### Accounts needed
+| Account | Email | Password | Role |
+|---------|-------|----------|------|
+| Volunteer | volunteer@test.com | volunteerpass1 | regular user |
+
+### Setup
+You need at least one publicly visible project (status `seeking_owner` or `seeking_help`). Run Scenario 02 first to create and approve one, or use an existing project.
+
+```bash
+BASE=http://localhost:8001
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Volunteer","email":"volunteer@test.com","password":"volunteerpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+## Steps
+
+### Step 1: Log in as the volunteer
+- **Navigate to:** `http://localhost:8001/static/login.html`
+- **Action:** Fill credentials and submit
+- **Expected:** Redirected to `/static/dashboard.html`
+
+### Step 2: Browse to a project
+- **Navigate to:** `http://localhost:8001/`
+- **Action:** Click on any visible project card
+- **Expected:** Project detail page loads with title, description, and skills visible
+
+### Step 3: Express interest
+- **Action:** Scroll to the "Express Interest" section
+- **Expected:** Interest form is visible (radio buttons for contribute vs. own)
+- **Action:** Select "I want to help out / contribute", optionally fill a message, click submit
+- **Expected:** Success message appears; form is replaced with "You've expressed interest" status display
+
+### Step 4: Verify on dashboard
+- **Navigate to:** `http://localhost:8001/static/dashboard.html`
+- **Action:** Click the "My Interests" tab
+- **Expected:** The project appears with status "Pending"
+
+## Expected Final State
+- Interest record exists with status `pending`
+- Dashboard "My Interests" tab shows the project
+- Project owner (if set) can see the interest in the project's interest management section
+
+## Cleanup
+Withdraw interest using the "Withdraw" button on the project page, or leave it for Scenario 04.

--- a/tests/scenarios/03-volunteer-express-interest.md
+++ b/tests/scenarios/03-volunteer-express-interest.md
@@ -1,16 +1,19 @@
 # Scenario 03: Volunteer Expresses Interest in a Project
 
 ## Purpose
+
 Verify that a logged-in volunteer can express interest in a project, the interest form submits successfully, and the interest is reflected in the volunteer's dashboard.
 
 ## Prerequisites
 
 ### Accounts needed
-| Account | Email | Password | Role |
-|---------|-------|----------|------|
+
+| Account   | Email              | Password       | Role         |
+| --------- | ------------------ | -------------- | ------------ |
 | Volunteer | volunteer@test.com | volunteerpass1 | regular user |
 
 ### Setup
+
 You need at least one publicly visible project (status `seeking_owner` or `seeking_help`). Run Scenario 02 first to create and approve one, or use an existing project.
 
 ```bash
@@ -23,30 +26,36 @@ curl -s -X POST $BASE/api/auth/signup \
 ## Steps
 
 ### Step 1: Log in as the volunteer
+
 - **Navigate to:** `http://localhost:8001/static/login.html`
 - **Action:** Fill credentials and submit
 - **Expected:** Redirected to `/static/dashboard.html`
 
 ### Step 2: Browse to a project
+
 - **Navigate to:** `http://localhost:8001/`
 - **Action:** Click on any visible project card
 - **Expected:** Project detail page loads with title, description, and skills visible
 
 ### Step 3: Express interest
+
 - **Action:** Scroll to the "Express Interest" section
 - **Expected:** Interest form is visible (radio buttons for contribute vs. own)
 - **Action:** Select "I want to help out / contribute", optionally fill a message, click submit
 - **Expected:** Success message appears; form is replaced with "You've expressed interest" status display
 
 ### Step 4: Verify on dashboard
+
 - **Navigate to:** `http://localhost:8001/static/dashboard.html`
 - **Action:** Click the "My Interests" tab
 - **Expected:** The project appears with status "Pending"
 
 ## Expected Final State
+
 - Interest record exists with status `pending`
 - Dashboard "My Interests" tab shows the project
 - Project owner (if set) can see the interest in the project's interest management section
 
 ## Cleanup
+
 Withdraw interest using the "Withdraw" button on the project page, or leave it for Scenario 04.

--- a/tests/scenarios/04-owner-respond-to-interest.md
+++ b/tests/scenarios/04-owner-respond-to-interest.md
@@ -1,0 +1,63 @@
+# Scenario 04: Project Owner Responds to Interest
+
+## Purpose
+Verify that a project owner can see pending interest expressions on their project and accept or decline them, and that the status updates correctly for the interested volunteer.
+
+## Prerequisites
+
+### Accounts needed
+| Account | Email | Password | Role |
+|---------|-------|----------|------|
+| Owner | owner@test.com | ownerpass1 | regular user (owns a project) |
+| Volunteer | volunteer@test.com | volunteerpass1 | regular user (expressed interest) |
+
+### Setup
+Run Scenarios 01–03 first (creates a project and an interest expression), or:
+
+```bash
+BASE=http://localhost:8001
+
+# Create owner
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Project Owner","email":"owner@test.com","password":"ownerpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+
+# Create volunteer
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Volunteer","email":"volunteer@test.com","password":"volunteerpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+You also need a project owned by `owner@test.com` with a pending interest from `volunteer@test.com`.
+
+## Steps
+
+### Step 1: Log in as the project owner
+- **Navigate to:** `http://localhost:8001/static/login.html`
+- **Action:** Fill owner credentials and submit
+- **Expected:** Redirected to `/static/dashboard.html`; "My Projects" tab shows owned projects
+
+### Step 2: Open the project detail page
+- **Navigate to:** The project page (`http://localhost:8001/static/project.html?id={project_id}`)
+- **Expected:** Project detail visible; "Manage Interests" section visible (owner only)
+
+### Step 3: Review the pending interest
+- **Action:** Scroll to the "Expressions of Interest" / "Manage Interests" section
+- **Expected:** Volunteer's interest card is visible with status "Pending" and their message
+
+### Step 4: Accept the interest
+- **Action:** Click "Accept" on the volunteer's interest card
+- **Expected:** Interest status changes to "Accepted"; volunteer card updates
+
+### Step 5: Verify from the volunteer's perspective
+- Log in as `volunteer@test.com` (open incognito or a different browser)
+- **Navigate to:** Dashboard → "My Interests" tab
+- **Expected:** Interest shows status "Accepted"
+
+## Expected Final State
+- Interest record status is `accepted`
+- Volunteer's dashboard shows updated status
+- (If email configured) Volunteer receives an email notification
+
+## Cleanup
+No cleanup required unless you want to remove the test data entirely.

--- a/tests/scenarios/04-owner-respond-to-interest.md
+++ b/tests/scenarios/04-owner-respond-to-interest.md
@@ -1,17 +1,20 @@
 # Scenario 04: Project Owner Responds to Interest
 
 ## Purpose
+
 Verify that a project owner can see pending interest expressions on their project and accept or decline them, and that the status updates correctly for the interested volunteer.
 
 ## Prerequisites
 
 ### Accounts needed
-| Account | Email | Password | Role |
-|---------|-------|----------|------|
-| Owner | owner@test.com | ownerpass1 | regular user (owns a project) |
+
+| Account   | Email              | Password       | Role                              |
+| --------- | ------------------ | -------------- | --------------------------------- |
+| Owner     | owner@test.com     | ownerpass1     | regular user (owns a project)     |
 | Volunteer | volunteer@test.com | volunteerpass1 | regular user (expressed interest) |
 
 ### Setup
+
 Run Scenarios 01–03 first (creates a project and an interest expression), or:
 
 ```bash
@@ -33,31 +36,38 @@ You also need a project owned by `owner@test.com` with a pending interest from `
 ## Steps
 
 ### Step 1: Log in as the project owner
+
 - **Navigate to:** `http://localhost:8001/static/login.html`
 - **Action:** Fill owner credentials and submit
 - **Expected:** Redirected to `/static/dashboard.html`; "My Projects" tab shows owned projects
 
 ### Step 2: Open the project detail page
+
 - **Navigate to:** The project page (`http://localhost:8001/static/project.html?id={project_id}`)
 - **Expected:** Project detail visible; "Manage Interests" section visible (owner only)
 
 ### Step 3: Review the pending interest
+
 - **Action:** Scroll to the "Expressions of Interest" / "Manage Interests" section
 - **Expected:** Volunteer's interest card is visible with status "Pending" and their message
 
 ### Step 4: Accept the interest
+
 - **Action:** Click "Accept" on the volunteer's interest card
 - **Expected:** Interest status changes to "Accepted"; volunteer card updates
 
 ### Step 5: Verify from the volunteer's perspective
+
 - Log in as `volunteer@test.com` (open incognito or a different browser)
 - **Navigate to:** Dashboard → "My Interests" tab
 - **Expected:** Interest shows status "Accepted"
 
 ## Expected Final State
+
 - Interest record status is `accepted`
 - Volunteer's dashboard shows updated status
 - (If email configured) Volunteer receives an email notification
 
 ## Cleanup
+
 No cleanup required unless you want to remove the test data entirely.

--- a/tests/scenarios/05-admin-create-project.md
+++ b/tests/scenarios/05-admin-create-project.md
@@ -1,0 +1,60 @@
+# Scenario 05: Admin Creates a Project Directly
+
+## Purpose
+Verify that an admin can create an org-proposed project via the admin form, and that it appears immediately in the public project listing without requiring triage.
+
+## Prerequisites
+
+### Accounts needed
+| Account | Email | Password | Role |
+|---------|-------|----------|------|
+| Admin | admin@test.com | adminpass1 | admin |
+
+### Setup
+Start the server with `ADMIN_EMAILS=admin@test.com python api.py`, then create the admin account:
+```bash
+BASE=http://localhost:8001
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Admin","email":"admin@test.com","password":"adminpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+## Steps
+
+### Step 1: Log in as admin
+- **Navigate to:** `http://localhost:8001/static/login.html`
+- **Action:** Fill admin credentials and submit
+- **Expected:** Redirected to `/static/dashboard.html`; admin nav links visible
+
+### Step 2: Navigate to admin project creation
+- **Navigate to:** `http://localhost:8001/static/admin/create-project.html`
+- **Expected:** Project creation form is visible
+
+### Step 3: Fill in the project details
+- **Action:** Fill in:
+  - Title: "Admin Test Project [today's date]"
+  - Description: "An org project created directly by an admin to test the admin creation flow."
+  - Urgency: High
+  - Time commitment: 3 hours/week
+  - Add one or more skills if desired
+- **Expected:** Form accepts all input
+
+### Step 4: Submit the form
+- **Action:** Click the submit/create button
+- **Expected:** Success message or redirect to the new project page
+
+### Step 5: Verify it appears in the public listing
+- **Navigate to:** `http://localhost:8001/`
+- **Expected:** The new project appears in the list immediately, without needing admin approval (admin-created projects bypass triage)
+
+### Step 6: Verify the project status
+- **Action:** Click the project card
+- **Expected:** Project detail page shows status "Seeking Owner" (not "Pending Review")
+
+## Expected Final State
+- Project exists with status `seeking_owner`
+- Project is visible on the public homepage
+- No triage step was required
+
+## Cleanup
+Delete the test project from the edit project page or via the project detail page (admin delete option).

--- a/tests/scenarios/05-admin-create-project.md
+++ b/tests/scenarios/05-admin-create-project.md
@@ -1,17 +1,21 @@
 # Scenario 05: Admin Creates a Project Directly
 
 ## Purpose
+
 Verify that an admin can create an org-proposed project via the admin form, and that it appears immediately in the public project listing without requiring triage.
 
 ## Prerequisites
 
 ### Accounts needed
-| Account | Email | Password | Role |
-|---------|-------|----------|------|
-| Admin | admin@test.com | adminpass1 | admin |
+
+| Account | Email          | Password   | Role  |
+| ------- | -------------- | ---------- | ----- |
+| Admin   | admin@test.com | adminpass1 | admin |
 
 ### Setup
+
 Start the server with `ADMIN_EMAILS=admin@test.com python api.py`, then create the admin account:
+
 ```bash
 BASE=http://localhost:8001
 curl -s -X POST $BASE/api/auth/signup \
@@ -22,15 +26,18 @@ curl -s -X POST $BASE/api/auth/signup \
 ## Steps
 
 ### Step 1: Log in as admin
+
 - **Navigate to:** `http://localhost:8001/static/login.html`
 - **Action:** Fill admin credentials and submit
 - **Expected:** Redirected to `/static/dashboard.html`; admin nav links visible
 
 ### Step 2: Navigate to admin project creation
+
 - **Navigate to:** `http://localhost:8001/static/admin/create-project.html`
 - **Expected:** Project creation form is visible
 
 ### Step 3: Fill in the project details
+
 - **Action:** Fill in:
   - Title: "Admin Test Project [today's date]"
   - Description: "An org project created directly by an admin to test the admin creation flow."
@@ -40,21 +47,26 @@ curl -s -X POST $BASE/api/auth/signup \
 - **Expected:** Form accepts all input
 
 ### Step 4: Submit the form
+
 - **Action:** Click the submit/create button
 - **Expected:** Success message or redirect to the new project page
 
 ### Step 5: Verify it appears in the public listing
+
 - **Navigate to:** `http://localhost:8001/`
 - **Expected:** The new project appears in the list immediately, without needing admin approval (admin-created projects bypass triage)
 
 ### Step 6: Verify the project status
+
 - **Action:** Click the project card
 - **Expected:** Project detail page shows status "Seeking Owner" (not "Pending Review")
 
 ## Expected Final State
+
 - Project exists with status `seeking_owner`
 - Project is visible on the public homepage
 - No triage step was required
 
 ## Cleanup
+
 Delete the test project from the edit project page or via the project detail page (admin delete option).

--- a/tests/scenarios/06-user-edit-profile.md
+++ b/tests/scenarios/06-user-edit-profile.md
@@ -1,16 +1,19 @@
 # Scenario 06: User Edits Their Profile
 
 ## Purpose
+
 Verify that a logged-in user can update their profile (bio, contact details, skills), save successfully, and that the changes persist after navigating away and back.
 
 ## Prerequisites
 
 ### Accounts needed
-| Account | Email | Password | Role |
-|---------|-------|----------|------|
+
+| Account   | Email              | Password       | Role         |
+| --------- | ------------------ | -------------- | ------------ |
 | Volunteer | volunteer@test.com | volunteerpass1 | regular user |
 
 ### Setup
+
 ```bash
 BASE=http://localhost:8001
 curl -s -X POST $BASE/api/auth/signup \
@@ -21,15 +24,18 @@ curl -s -X POST $BASE/api/auth/signup \
 ## Steps
 
 ### Step 1: Log in as the volunteer
+
 - **Navigate to:** `http://localhost:8001/static/login.html`
 - **Action:** Fill credentials and submit
 - **Expected:** Redirected to `/static/dashboard.html`
 
 ### Step 2: Navigate to the profile page
+
 - **Navigate to:** `http://localhost:8001/static/profile.html`
 - **Expected:** Profile form loads with existing values pre-filled
 
 ### Step 3: Update profile fields
+
 - **Action:** Update the following:
   - Bio: "Updated bio text for e2e test [timestamp]"
   - Discord handle: "testuser#9999"
@@ -37,18 +43,22 @@ curl -s -X POST $BASE/api/auth/signup \
 - **Expected:** Form accepts the new values
 
 ### Step 4: Save the profile
+
 - **Action:** Click the "Save Profile" / submit button
 - **Expected:** Success message appears (e.g. "Profile updated")
 
 ### Step 5: Navigate away and back
+
 - **Navigate to:** `http://localhost:8001/static/dashboard.html`
 - **Navigate to:** `http://localhost:8001/static/profile.html`
 - **Expected:** Bio field contains the updated text; Discord handle shows "testuser#9999"
 
 ## Expected Final State
+
 - Profile changes are persisted in the database
 - Navigating back to the profile page shows the updated values
 - No data reverted to previous values
 
 ## Cleanup
+
 No cleanup required — this is non-destructive (just profile data changes).

--- a/tests/scenarios/06-user-edit-profile.md
+++ b/tests/scenarios/06-user-edit-profile.md
@@ -1,0 +1,54 @@
+# Scenario 06: User Edits Their Profile
+
+## Purpose
+Verify that a logged-in user can update their profile (bio, contact details, skills), save successfully, and that the changes persist after navigating away and back.
+
+## Prerequisites
+
+### Accounts needed
+| Account | Email | Password | Role |
+|---------|-------|----------|------|
+| Volunteer | volunteer@test.com | volunteerpass1 | regular user |
+
+### Setup
+```bash
+BASE=http://localhost:8001
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Volunteer","email":"volunteer@test.com","password":"volunteerpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+## Steps
+
+### Step 1: Log in as the volunteer
+- **Navigate to:** `http://localhost:8001/static/login.html`
+- **Action:** Fill credentials and submit
+- **Expected:** Redirected to `/static/dashboard.html`
+
+### Step 2: Navigate to the profile page
+- **Navigate to:** `http://localhost:8001/static/profile.html`
+- **Expected:** Profile form loads with existing values pre-filled
+
+### Step 3: Update profile fields
+- **Action:** Update the following:
+  - Bio: "Updated bio text for e2e test [timestamp]"
+  - Discord handle: "testuser#9999"
+  - Availability hours: 8
+- **Expected:** Form accepts the new values
+
+### Step 4: Save the profile
+- **Action:** Click the "Save Profile" / submit button
+- **Expected:** Success message appears (e.g. "Profile updated")
+
+### Step 5: Navigate away and back
+- **Navigate to:** `http://localhost:8001/static/dashboard.html`
+- **Navigate to:** `http://localhost:8001/static/profile.html`
+- **Expected:** Bio field contains the updated text; Discord handle shows "testuser#9999"
+
+## Expected Final State
+- Profile changes are persisted in the database
+- Navigating back to the profile page shows the updated values
+- No data reverted to previous values
+
+## Cleanup
+No cleanup required — this is non-destructive (just profile data changes).

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -1,0 +1,45 @@
+# Claude Scenario Walkthroughs
+
+These scenario files describe flows for Claude to execute using the Playwright MCP browser tools. Unlike the automated Playwright tests, scenarios cover complex multi-user flows and admin operations.
+
+## When to use
+
+Run a scenario when you want to verify a flow works end-to-end — for example, after a related code change, before a release, or when investigating a reported bug.
+
+## How to run a scenario
+
+1. Make sure the app is running locally (`python api.py`) or identify the production URL.
+2. Ask Claude to run a specific scenario, e.g.:
+   > "Please run the scenario in `tests/scenarios/01-volunteer-propose-project.md` against http://localhost:8001"
+3. Claude will open a browser, follow each step, and report pass/fail with observations.
+
+## Setup accounts
+
+Most scenarios need test accounts. The easiest way to create them:
+
+```bash
+BASE=http://localhost:8001
+
+# Create volunteer
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Volunteer","email":"volunteer@test.com","password":"volunteerpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+
+# Create admin (requires ADMIN_EMAILS=admin@test.com set when starting the server)
+curl -s -X POST $BASE/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Admin","email":"admin@test.com","password":"adminpass1","consent_profile_visible":true,"consent_contact_by_owners":true}'
+```
+
+Or restart the server with `ADMIN_EMAILS=admin@test.com python api.py` to auto-promote that email.
+
+## Scenarios
+
+| File | Flow |
+|------|------|
+| [01-volunteer-propose-project.md](01-volunteer-propose-project.md) | Volunteer proposes a new project |
+| [02-admin-triage-project.md](02-admin-triage-project.md) | Admin reviews and approves a pending project |
+| [03-volunteer-express-interest.md](03-volunteer-express-interest.md) | Volunteer expresses interest in a project |
+| [04-owner-respond-to-interest.md](04-owner-respond-to-interest.md) | Project owner accepts or declines interest |
+| [05-admin-create-project.md](05-admin-create-project.md) | Admin creates an org project directly |
+| [06-user-edit-profile.md](06-user-edit-profile.md) | User updates their profile |

--- a/tests/scenarios/cleanup.py
+++ b/tests/scenarios/cleanup.py
@@ -1,0 +1,59 @@
+"""
+Delete test data left over from scenario walkthroughs.
+
+Removes the three fixed scenario accounts and any projects they proposed or
+owned, plus any project whose title matches known test-data patterns.
+Cascade deletes handle interests, notifications, skills, etc. automatically.
+"""
+
+import sqlite3
+import os
+from pathlib import Path
+
+TEST_EMAILS = ("volunteer@test.com", "admin@test.com", "owner@test.com")
+TEST_TITLE_PATTERNS = ("Test Proposal%", "E2E Test Project%")
+
+data_dir = os.environ.get("RAILWAY_VOLUME_MOUNT_PATH", str(Path(__file__).parent.parent.parent))
+db_path = Path(data_dir) / "catalyse.db"
+
+if not db_path.exists():
+    print(f"No database found at {db_path} — nothing to clean.")
+    raise SystemExit(0)
+
+conn = sqlite3.connect(db_path)
+conn.execute("PRAGMA foreign_keys = ON")
+
+email_placeholders = ",".join("?" * len(TEST_EMAILS))
+
+# Collect test account IDs
+ids = [
+    row[0]
+    for row in conn.execute(
+        f"SELECT id FROM volunteers WHERE email IN ({email_placeholders})", TEST_EMAILS
+    )
+]
+
+deleted_projects = 0
+
+if ids:
+    id_placeholders = ",".join("?" * len(ids))
+    cur = conn.execute(
+        f"DELETE FROM projects WHERE proposed_by_id IN ({id_placeholders})"
+        f" OR owner_id IN ({id_placeholders})",
+        ids + ids,
+    )
+    deleted_projects += cur.rowcount
+
+for pattern in TEST_TITLE_PATTERNS:
+    cur = conn.execute("DELETE FROM projects WHERE title LIKE ?", (pattern,))
+    deleted_projects += cur.rowcount
+
+cur = conn.execute(
+    f"DELETE FROM volunteers WHERE email IN ({email_placeholders})", TEST_EMAILS
+)
+deleted_volunteers = cur.rowcount
+
+conn.commit()
+conn.close()
+
+print(f"Removed {deleted_projects} project(s) and {deleted_volunteers} volunteer(s).")


### PR DESCRIPTION
## Summary

- Adds a two-tier e2e test suite: fast headless pytest-playwright tests for critical flows (signup, login, logout, project browsing), plus Claude scenario markdown files for complex multi-user flows (project proposals, admin triage, expressing interest, etc.)
- Adds a `Makefile` with `make test`, `make test-headed`, `make test-debug`, and `make test-smoke` targets
- Updates README with a Testing section
- Fixes two bugs discovered while building the tests

## Bugs fixed

**Migration runner silently skipped `project_tasks` table on fresh installs** — `run_migrations()` was filtering out SQL statements whose first line started with `--`, causing `migration_004`'s `CREATE TABLE project_tasks` to never run. The project detail API returned 500 for every request on a fresh database.

**`[object Object]` shown in error messages** — FastAPI returns `detail` as an array of objects for 422 validation errors. `apiRequest` in `app.js`, the login form, and the signup form all passed the raw array to `new Error()`, which stringifies as `[object Object]`. Fixed by joining the `msg` fields when `detail` is an array.

## Test plan

- [x] `make test` — all 13 tests pass headlessly
- [x] `make test-headed` — browser visibly completes all flows
- [x] `make test-smoke EMAIL=... PASSWORD=...` — smoke tests pass against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)