### PR TITLE
Show profile save confirmation next to the Save button

### DIFF
--- a/static/profile.html
+++ b/static/profile.html
@@ -123,7 +123,9 @@
                     </select>
                 </div>
 
-                <div style="margin-top: 32px; display: flex; gap: 12px;">
+                <div id="saveMessage" class="message" style="display: none; margin-top: 24px;"></div>
+
+                <div style="margin-top: 24px; display: flex; gap: 12px;">
                     <button type="submit" class="btn btn-primary">Save Changes</button>
                     <a href="/static/dashboard.html" class="btn btn-outline">Cancel</a>
                 </div>
@@ -210,10 +212,13 @@
                     body: JSON.stringify(data)
                 });
 
-                showMessage('Profile updated!', 'success');
+                showMessage('Profile updated!', 'success', 'saveMessage');
+                // Also scroll the message into view to ensure visibility
+                document.getElementById('saveMessage').scrollIntoView({ behavior: 'smooth', block: 'center' });
 
             } catch (error) {
-                showMessage(error.message, 'error');
+                showMessage(error.message, 'error', 'saveMessage');
+                document.getElementById('saveMessage').scrollIntoView({ behavior: 'smooth', block: 'center' });
             }
 
             submitBtn.disabled = false;


### PR DESCRIPTION
… page

The success/error message was displaying in the top messageDiv which wasn't visible from the bottom of the long profile form. Users thought nothing happened when they clicked Save Changes.

- Added a saveMessage div right above the Save Changes button
- Submit handler now targets this div instead of the page-top one
- Also scrolls the message into view for extra visibility

https://claude.ai/code/session_01FtHs7y4tJjbWBSJKmhpQu1