### PR TITLE
fix: use dark text on orange backgrounds for legibility

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -141,7 +141,7 @@ nav a:hover {
 
 nav a.active {
     background: var(--primary);
-    color: white;
+    color: #111827;
 }
 
 .nav-auth {
@@ -199,7 +199,7 @@ p {
 
 .btn-primary {
     background: var(--primary);
-    color: white;
+    color: #111827;
 }
 
 .btn-primary:hover {
@@ -495,6 +495,9 @@ p {
 [data-theme="dark"] a {
     color: var(--primary);
 }
+[data-theme="dark"] a.btn-primary {
+    color: #111827;
+}
 [data-theme="dark"] .btn-outline {
     border-color: #4B5563;
     color: #D1D5DB;
@@ -515,7 +518,7 @@ p {
     color: var(--primary);
 }
 [data-theme="dark"] nav a.active {
-    color: white;
+    color: #111827;
     background: var(--primary);
 }
 [data-theme="dark"] .tabs {
@@ -971,7 +974,7 @@ textarea {
 /* Notification badge */
 .notification-badge {
     background: var(--primary);
-    color: white;
+    color: #111827;
     font-size: 0.75rem;
     padding: 2px 8px;
     border-radius: 10px;
@@ -1075,7 +1078,7 @@ textarea {
     gap: 4px;
     padding: 2px 8px;
     background: var(--primary);
-    color: white;
+    color: #111827;
     border-radius: 4px;
     font-size: 0.75rem;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- White text on brand orange (`#FF9416` / `#FFa633`) had poor contrast in both light and dark mode
- Switches all orange-background elements (`.btn-primary`, active nav link, notification badge, org badge) to `#111827`
- Fixes a dark-mode specificity bug where `[data-theme="dark"] a { color: var(--primary) }` caused anchor-based buttons to render orange text on an orange background (invisible)

## Test plan
- [x] Check `.btn-primary` buttons in light and dark mode — text should be dark and legible
- [x] Check active nav link in both modes
- [x] Check notification badge and org badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)