### PR TITLE
Replace description placeholder text with persistent writing guide

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -644,6 +644,43 @@ textarea {
     margin-top: 4px;
 }
 
+.description-guide {
+    background: var(--bg-secondary, #f9fafb);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.8125rem;
+    margin-bottom: 8px;
+}
+
+.description-guide dl {
+    margin: 0;
+    columns: 2;
+    column-gap: 24px;
+}
+
+.description-guide dt {
+    font-weight: 600;
+    color: var(--text-primary);
+    break-after: avoid;
+}
+
+.description-guide dd {
+    margin: 0 0 8px 0;
+    color: var(--text-light);
+    line-height: 1.4;
+    break-inside: avoid;
+}
+
+.description-guide dd:last-child {
+    margin-bottom: 0;
+}
+
+[data-theme="dark"] .description-guide {
+    background: var(--bg-secondary, #1f2937);
+    border-color: var(--border-color, #374151);
+}
+
 .form-error {
     font-size: 0.875rem;
     color: var(--error);

--- a/static/suggest.html
+++ b/static/suggest.html
@@ -21,7 +21,7 @@
     </header>
 
     <main class="container page">
-        <div style="max-width: 700px; margin: 0 auto;">
+        <div style="max-width: 850px; margin: 0 auto;">
             <h1>Suggest a Project</h1>
             <p style="color: var(--text-light); margin-bottom: 24px;">
                 Have an idea for something PauseAI UK should do? Propose it here!
@@ -45,29 +45,21 @@
 
                 <div class="form-group">
                     <label for="description" class="required">Description</label>
-                    <textarea id="description" name="description" required style="min-height: 280px;"
-                        placeholder="Help us understand your project idea:
-
-GOAL & IMPACT
-- What problem does this solve or opportunity does it create?
-- What does success look like? How would we measure it?
-
-APPROACH & ACTIVITIES
-- What are the key steps or activities involved?
-- Do you have a rough sense of how this would work?
-
-FEASIBILITY
-- What are the main uncertainties or risks?
-- What resources, access, or dependencies are needed?
-- Is there existing work we could build on?
-
-TEAM & COLLABORATION
-- What kinds of contributors would be ideal? (skills, experience, availability)
-- How do you imagine the team working together? (async, regular syncs, etc.)
-
-CHALLENGE YOUR IDEA
-- What's the best argument against doing this?
-- What's your Theory of Change? (How does this project lead to the impact you want?)"></textarea>
+                    <aside class="description-guide">
+                        <dl>
+                            <dt>Goal &amp; Impact</dt>
+                            <dd>What problem does this solve? What does success look like and how would you measure it?</dd>
+                            <dt>Approach &amp; Activities</dt>
+                            <dd>What are the key steps? Do you have a rough sense of how this would work?</dd>
+                            <dt>Feasibility</dt>
+                            <dd>Main uncertainties or risks? Resources or dependencies needed? Existing work to build on?</dd>
+                            <dt>Team &amp; Collaboration</dt>
+                            <dd>What skills and availability are ideal? How do you imagine the team working together?</dd>
+                            <dt>Challenge Your Idea</dt>
+                            <dd>What's the best argument against doing this? What's your Theory of Change?</dd>
+                        </dl>
+                    </aside>
+                    <textarea id="description" name="description" required style="min-height: 280px;" placeholder="Describe your project idea..."></textarea>
                     <p class="form-hint">The more detail you provide, the easier it is to find the right contributors and get started.</p>
                 </div>
 


### PR DESCRIPTION
## Summary

- The description field on the Suggest a Project page had detailed writing instructions as placeholder text — they disappeared on typing and couldn't be copied
- Replaced with a persistent two-column guide panel sitting between the label and the textarea, always visible and selectable while writing
- Widened the form from 700px to 850px to give the layout more breathing room
- On mobile, the guide stacks above the textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)