### PR TITLE
Show deployed commit SHA in footer

### DIFF
--- a/api.py
+++ b/api.py
@@ -45,6 +45,12 @@ _data_dir = os.environ.get("RAILWAY_VOLUME_MOUNT_PATH", str(Path(__file__).paren
 DATABASE_PATH = Path(_data_dir) / "catalyse.db"
 
 
+@app.get("/api/version")
+def get_version():
+    sha = os.environ.get("RAILWAY_GIT_COMMIT_SHA", "dev")
+    return {"sha": sha}
+
+
 def get_db():
     """Get database connection with row factory."""
     conn = sqlite3.connect(DATABASE_PATH)

--- a/static/index.html
+++ b/static/index.html
@@ -280,8 +280,18 @@
             <a href="/static/privacy.html" style="color: var(--text-light); margin: 0 12px;">Privacy & Data</a> ·
             <a href="#" onclick="openBugReportModal(); return false;" style="color: var(--text-light); margin: 0 12px;">Report a Bug</a> ·
             <a href="mailto:matilda@pauseai.info" style="color: var(--text-light); margin: 0 12px;">Contact</a> ·
-            <span style="margin: 0 12px;">PauseAI UK</span>
+            <span style="margin: 0 12px;">PauseAI UK</span> ·
+            <span id="version-sha" style="margin: 0 12px; font-family: monospace;"></span>
         </div>
     </footer>
+    <script>
+        fetch('/api/version').then(r => r.json()).then(d => {
+            const el = document.getElementById('version-sha');
+            if (d.sha && d.sha !== 'dev') {
+                el.textContent = d.sha.slice(0, 7);
+                el.title = d.sha;
+            }
+        }).catch(() => {});
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds `GET /api/version` endpoint returning `RAILWAY_GIT_COMMIT_SHA` (falls back to `"dev"` locally)
- Displays the first 7 chars of the SHA in the site footer; hover reveals the full SHA
- Hidden in local dev where the env var is not set

## Test plan
- [ ] Deploy to Railway and confirm the 7-char SHA appears in the footer
- [ ] Hover the SHA to confirm full SHA shown in tooltip
- [ ] Confirm nothing appears in local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)