### PR TITLE
Fix signup 500 for users in ADMIN_EMAILS, add error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,20 @@ Currently uses simple email-based login with tokens. For production:
 - Add email verification / magic links
 - Set token expiration
 
+## Error Codes
+
+When a server error occurs, users see a message ending with `Error Code: X`. Codes are intentionally opaque to avoid exposing implementation details. Reference:
+
+| Code | Location | Cause |
+|------|----------|-------|
+| A | Email/password signup | Failed during admin bootstrap step |
+| B | Email/password signup | Failed during admin invite auto-accept step |
+| C | Google SSO signup | Failed during admin bootstrap step |
+| D | Google SSO signup | Failed during admin invite auto-accept step |
+| E | Anywhere | Unexpected error not covered by the above |
+
+Full exception details (including stack trace) are logged server-side alongside the code.
+
 ## License
 
 MIT - Built for PauseAI UK

--- a/api.py
+++ b/api.py
@@ -9,12 +9,13 @@ import secrets
 import hashlib
 import json
 import base64
+import traceback
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, List, Dict, Any
 from contextlib import contextmanager
 
-from fastapi import FastAPI, HTTPException, Depends, Header, Query, Response
+from fastapi import FastAPI, HTTPException, Depends, Header, Query, Response, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, EmailStr, Field
@@ -38,6 +39,31 @@ app = FastAPI(
     description="Volunteer & Project Matching for PauseAI UK",
     version="1.0.0"
 )
+
+
+class AppError(Exception):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+@app.exception_handler(AppError)
+async def app_error_handler(request: Request, exc: AppError):
+    print(f"[ERROR] {request.method} {request.url.path} — {exc.code}: {exc.message}")
+    traceback.print_exc()
+    detail = f"{exc.message} Error Code: {exc.code}"
+    return JSONResponse(status_code=500, content={"detail": detail})
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    print(f"[ERROR] {request.method} {request.url.path} — {type(exc).__name__}: {exc}")
+    traceback.print_exc()
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Something went wrong. Please try again or contact us. Error Code: E"}
+    )
 
 # Use RAILWAY_VOLUME_MOUNT_PATH for persistent storage if available,
 # otherwise store next to the app (local dev)
@@ -630,27 +656,37 @@ def signup(data: VolunteerSignup) -> Dict:
             )
 
         # Check for admin bootstrap via ADMIN_EMAILS env var
-        check_admin_bootstrap(data.email, volunteer_id)
+        try:
+            check_admin_bootstrap(data.email, volunteer_id, conn=conn)
+        except Exception as e:
+            print(f"[SIGNUP ERROR] admin bootstrap failed for {data.email}: {type(e).__name__}: {e}")
+            raise AppError("A", "Something went wrong creating your account. Please try again or contact us.")
 
         # Auto-accept any pending admin invites for this email
-        pending_invite = conn.execute(
-            """SELECT * FROM admin_invites
-               WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
-            (data.email, datetime.now().isoformat())
-        ).fetchone()
-        print(f"[ADMIN_INVITE] Signup check for {data.email}: pending_invite={'found id=' + str(pending_invite['id']) if pending_invite else 'none'}")
-        if pending_invite:
-            conn.execute(
-                "UPDATE volunteers SET is_admin = 1 WHERE id = ?",
-                (volunteer_id,)
-            )
-            conn.execute(
-                """UPDATE admin_invites
-                   SET status = 'accepted', accepted_by_id = ?, accepted_at = ?
-                   WHERE id = ?""",
-                (volunteer_id, datetime.now().isoformat(), pending_invite["id"])
-            )
-            print(f"[ADMIN_INVITE] Auto-accepted invite for {data.email} on signup")
+        try:
+            pending_invite = conn.execute(
+                """SELECT * FROM admin_invites
+                   WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
+                (data.email, datetime.now().isoformat())
+            ).fetchone()
+            print(f"[ADMIN_INVITE] Signup check for {data.email}: pending_invite={'found id=' + str(pending_invite['id']) if pending_invite else 'none'}")
+            if pending_invite:
+                conn.execute(
+                    "UPDATE volunteers SET is_admin = 1 WHERE id = ?",
+                    (volunteer_id,)
+                )
+                conn.execute(
+                    """UPDATE admin_invites
+                       SET status = 'accepted', accepted_by_id = ?, accepted_at = ?
+                       WHERE id = ?""",
+                    (volunteer_id, datetime.now().isoformat(), pending_invite["id"])
+                )
+                print(f"[ADMIN_INVITE] Auto-accepted invite for {data.email} on signup")
+        except AppError:
+            raise
+        except Exception as e:
+            print(f"[SIGNUP ERROR] admin invite check failed for {data.email}: {type(e).__name__}: {e}")
+            raise AppError("B", "Something went wrong creating your account. Please try again or contact us.")
 
         # Send welcome email (non-blocking, don't fail signup if email fails)
         send_welcome_email(to=data.email, name=data.name)
@@ -662,7 +698,7 @@ def signup(data: VolunteerSignup) -> Dict:
         }
 
 
-def check_admin_bootstrap(email: str, volunteer_id: int) -> bool:
+def check_admin_bootstrap(email: str, volunteer_id: int, conn=None) -> bool:
     """
     Check if email is in ADMIN_EMAILS env var and promote to admin if so.
     Returns True if user was promoted.
@@ -678,11 +714,17 @@ def check_admin_bootstrap(email: str, volunteer_id: int) -> bool:
     print(f"[ADMIN_BOOTSTRAP] Parsed allowed_emails={allowed_emails}, checking against {email.lower()}")
 
     if email.lower() in allowed_emails:
-        with db_transaction() as conn:
+        if conn is not None:
             conn.execute(
                 "UPDATE volunteers SET is_admin = 1 WHERE id = ? AND is_admin = 0",
                 (volunteer_id,)
             )
+        else:
+            with db_transaction() as new_conn:
+                new_conn.execute(
+                    "UPDATE volunteers SET is_admin = 1 WHERE id = ? AND is_admin = 0",
+                    (volunteer_id,)
+                )
         return True
     return False
 
@@ -866,20 +908,30 @@ def google_auth(data: GoogleAuthRequest) -> Dict:
             volunteer_id = cursor.lastrowid
 
             # Check admin bootstrap
-            check_admin_bootstrap(email, volunteer_id)
+            try:
+                check_admin_bootstrap(email, volunteer_id, conn=conn)
+            except Exception as e:
+                print(f"[GOOGLE_SIGNUP ERROR] admin bootstrap failed for {email}: {type(e).__name__}: {e}")
+                raise AppError("C", "Something went wrong creating your account. Please try again or contact us.")
 
             # Auto-accept pending admin invites
-            pending_invite = conn.execute(
-                """SELECT * FROM admin_invites
-                   WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
-                (email, datetime.now().isoformat())
-            ).fetchone()
-            if pending_invite:
-                conn.execute("UPDATE volunteers SET is_admin = 1 WHERE id = ?", (volunteer_id,))
-                conn.execute(
-                    """UPDATE admin_invites SET status = 'accepted', accepted_by_id = ?, accepted_at = ? WHERE id = ?""",
-                    (volunteer_id, datetime.now().isoformat(), pending_invite["id"])
-                )
+            try:
+                pending_invite = conn.execute(
+                    """SELECT * FROM admin_invites
+                       WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
+                    (email, datetime.now().isoformat())
+                ).fetchone()
+                if pending_invite:
+                    conn.execute("UPDATE volunteers SET is_admin = 1 WHERE id = ?", (volunteer_id,))
+                    conn.execute(
+                        """UPDATE admin_invites SET status = 'accepted', accepted_by_id = ?, accepted_at = ? WHERE id = ?""",
+                        (volunteer_id, datetime.now().isoformat(), pending_invite["id"])
+                    )
+            except AppError:
+                raise
+            except Exception as e:
+                print(f"[GOOGLE_SIGNUP ERROR] admin invite check failed for {email}: {type(e).__name__}: {e}")
+                raise AppError("D", "Something went wrong creating your account. Please try again or contact us.")
 
         # Send welcome email
         send_welcome_email(to=email, name=name)

--- a/static/signup.html
+++ b/static/signup.html
@@ -173,7 +173,9 @@
                     </select>
                 </div>
 
-                <div style="margin-top: 24px;">
+                <div id="submitMessageDiv" class="message" style="display: none; margin-top: 24px;"></div>
+
+                <div style="margin-top: 12px;">
                     <button type="submit" class="btn btn-primary" style="width: 100%;">
                         Create Account
                     </button>
@@ -331,6 +333,7 @@
 
             } catch (error) {
                 showMessage(error.message, 'error');
+                showMessage(error.message, 'error', 'submitMessageDiv');
                 submitBtn.disabled = false;
                 submitBtn.textContent = 'Create Account';
             }

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -25,6 +25,27 @@ class TestSignup:
         expect(page).to_have_url(f"{BASE_URL}/static/dashboard.html", timeout=10000)
 
     @pytest.mark.local_only
+    def test_server_error_shows_error_code(self, page: Page):
+        """500 responses with an error code surface that code in the UI."""
+        page.route(
+            "**/api/auth/signup",
+            lambda route: route.fulfill(
+                status=500,
+                content_type="application/json",
+                body='{"detail": "Something went wrong creating your account. Please try again or contact us. Error Code: A"}'
+            )
+        )
+        page.goto(f"{BASE_URL}/static/signup.html")
+        page.fill("#name", "Test User")
+        page.fill("#email", "test@example.com")
+        page.fill("#password", "testpassword1")
+        page.fill("#password_confirm", "testpassword1")
+        page.click("#signupForm button[type=submit]")
+        msg = page.locator("#submitMessageDiv")
+        expect(msg).to_be_visible(timeout=5000)
+        expect(msg).to_contain_text("Error Code: A")
+
+    @pytest.mark.local_only
     def test_duplicate_email_shows_error(self, page: Page, new_user):
         page.goto(f"{BASE_URL}/static/signup.html")
         page.fill("#name", "Dupe User")


### PR DESCRIPTION
## Summary

- **Bug fix**: `check_admin_bootstrap` was opening a second SQLite connection inside an already-open write transaction, causing a `database is locked` error and 500 for any user whose email is in `ADMIN_EMAILS`. Fixed by passing the existing `conn` through so both operations share the same transaction.
- **Error codes**: Added `AppError` exception class with opaque single-letter codes (A–D) included in user-facing error messages (e.g. _"Something went wrong... Error Code: A"_) for easy diagnosis without exposing internals. A catch-all global exception handler logs full tracebacks server-side.
- **UX**: Error message now also appears next to the submit button on the signup form, which is important given how long the form is.
- **Test**: E2e test asserting error codes surface correctly in the browser.
- **Docs**: README section mapping each error code to its cause.

## Test plan

- [ ] Run `make test` — all e2e tests pass including new `test_server_error_shows_error_code`
- [ ] Verify the affected user (email in `ADMIN_EMAILS`) can now sign up successfully
- [ ] Confirm error messages appear near the submit button on the signup form

🤖 Generated with [Claude Code](https://claude.com/claude-code)