### PR TITLE
Require tasks before projects can be created or started

### DIFF
--- a/api.py
+++ b/api.py
@@ -16,6 +16,7 @@ from typing import Optional, List, Dict, Any
 from contextlib import contextmanager
 
 from fastapi import FastAPI, HTTPException, Depends, Header, Query, Response, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, EmailStr, Field
@@ -68,6 +69,75 @@ async def app_error_handler(request: Request, exc: AppError):
     traceback.print_exc()
     detail = f"{exc.message} Error Code: {exc.code}"
     return JSONResponse(status_code=500, content={"detail": detail})
+
+
+_FIELD_LABELS = {
+    # Auth / account
+    "name": "Name",
+    "email": "Email",
+    "password": "Password",
+    "new_password": "New password",
+    "current_password": "Current password",
+    "whatsapp_number": "WhatsApp number",
+    "page_url": "Page URL",
+    # Projects
+    "title": "Title",
+    "description": "Description",
+    "project_type": "Project type",
+    "urgency": "Urgency",
+    "time_commitment_hours_per_week": "Hours per week",
+    "estimated_duration": "Estimated duration",
+    "collaboration_link": "Collaboration link",
+    "country": "Country",
+    "local_group": "Local group",
+    "tasks": "Tasks",
+    # Messaging / content
+    "message": "Message",
+    "subject": "Subject",
+    "content": "Content",
+    # IDs that would otherwise get " id" appended
+    "category_id": "Category",
+    "volunteer_id": "Volunteer",
+    "skill_id": "Skill",
+}
+
+
+def _friendly_validation_error(err: dict) -> str:
+    loc = err.get("loc", [])
+    field = loc[-1] if loc else ""
+    label = _FIELD_LABELS.get(str(field), str(field).replace("_", " ").capitalize())
+    error_type = err.get("type", "")
+    ctx = err.get("ctx", {})
+
+    if error_type == "missing":
+        return f"{label} is required"
+    if error_type == "string_too_short":
+        n = ctx.get("min_length", 1)
+        return f"{label} must be at least {n} character{'s' if n != 1 else ''}"
+    if error_type == "string_too_long":
+        n = ctx.get("max_length", "")
+        return f"{label} must be no more than {n} characters"
+    if error_type in ("int_parsing", "float_parsing"):
+        return f"{label} must be a number"
+    if error_type == "value_error":
+        return f"{label}: {ctx.get('error', err.get('msg', 'invalid value'))}"
+    if error_type == "enum":
+        allowed = ", ".join(str(v) for v in ctx.get("expected", []))
+        return f"{label} must be one of: {allowed}" if allowed else f"{label} is not a valid option"
+
+    # Fallback: strip Pydantic's boilerplate and sentence-case what remains
+    msg = err.get("msg", "Invalid value")
+    msg = msg.removeprefix("Value error, ").removeprefix("String ")
+    return f"{label}: {msg[0].lower()}{msg[1:]}" if msg else f"{label}: invalid value"
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_error_handler(request: Request, exc: RequestValidationError):
+    errors = [
+        {"loc": list(e["loc"]), "msg": _friendly_validation_error(e), "type": e.get("type")}
+        for e in exc.errors()
+    ]
+    return JSONResponse(status_code=422, content={"detail": errors})
 
 
 @app.exception_handler(Exception)
@@ -263,6 +333,11 @@ class DeleteAccountRequest(BaseModel):
 
 
 # --- Projects ---
+class InitialTaskData(BaseModel):
+    title: str = Field(..., min_length=1, max_length=300)
+    description: Optional[str] = None
+
+
 class ProjectCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=300)
     description: str = Field(..., min_length=10)
@@ -278,6 +353,7 @@ class ProjectCreate(BaseModel):
     local_group: Optional[str] = None
     is_seeking_help: bool = True
     is_seeking_owner: bool = False
+    tasks: List[InitialTaskData] = []
 
 
 class ProjectUpdate(BaseModel):
@@ -1872,6 +1948,9 @@ def create_project(
     volunteer: Dict = Depends(require_auth)
 ) -> Dict:
     """Create a new project (volunteer-proposed)."""
+    if not data.tasks:
+        raise HTTPException(status_code=400, detail="At least one task is required to submit a project proposal")
+
     with db_transaction() as conn:
         status = "pending_review"
         owner_id = volunteer["id"] if data.want_to_own else None
@@ -1908,6 +1987,13 @@ def create_project(
             conn.execute(
                 "INSERT INTO project_skills (project_id, skill_id, is_required) VALUES (?, ?, ?)",
                 (project_id, skill_id, is_required)
+            )
+
+        # Add initial tasks
+        for task in data.tasks:
+            conn.execute(
+                "INSERT INTO project_tasks (project_id, title, description, created_by_id) VALUES (?, ?, ?, ?)",
+                (project_id, task.title, task.description, volunteer["id"])
             )
 
         # Notify admins (in-app + email)
@@ -1963,12 +2049,24 @@ def update_project(
         updates = []
         params = []
 
+        # Enforce: cannot move to in_progress without at least one open task
+        if data.status == 'in_progress' and project["status"] != 'in_progress':
+            open_task_count = conn.execute(
+                "SELECT COUNT(*) FROM project_tasks WHERE project_id = ? AND status != 'done'",
+                (project_id,)
+            ).fetchone()[0]
+            if open_task_count == 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="A project cannot be moved to In Progress without at least one open task"
+                )
+
         # Check which columns exist for seeking flags
         proj_columns = {row["name"] for row in conn.execute("PRAGMA table_info(projects)").fetchall()}
         has_seeking_flags = "is_seeking_help" in proj_columns
 
         # Define which statuses owners can set (vs admin-only statuses)
-        owner_allowed_statuses = {"seeking_owner", "seeking_help", "in_progress", "on_hold", "completed"}
+        owner_allowed_statuses = {"seeking_owner", "seeking_help", "needs_tasks", "in_progress", "on_hold", "completed"}
 
         for field in ["title", "description", "status", "project_type", "estimated_duration",
                       "time_commitment_hours_per_week", "urgency", "collaboration_link", "country", "local_group", "owner_id"]:
@@ -2023,6 +2121,7 @@ def update_project(
         if data.status and data.status != project["status"]:
             status_label = {
                 'seeking_owner': 'Seeking Owner', 'seeking_help': 'Seeking Help',
+                'needs_tasks': 'Needs Tasks',
                 'in_progress': 'In Progress', 'on_hold': 'On Hold',
                 'completed': 'Completed', 'archived': 'Archived'
             }.get(data.status, data.status)
@@ -3446,11 +3545,13 @@ def respond_to_interest(
             f"/static/project.html?id={project_id}"
         )
 
-        # If accepting as owner, update project
+        # If accepting as owner, assign them and move to needs_tasks so they can
+        # set up tasks before starting (unless the project is already in_progress)
         if data.status == "accepted" and interest["interest_type"] == "want_to_own":
+            new_status = 'in_progress' if project["status"] == 'in_progress' else 'needs_tasks'
             conn.execute(
-                "UPDATE projects SET owner_id = ?, status = 'in_progress' WHERE id = ?",
-                (interest["volunteer_id"], project_id)
+                "UPDATE projects SET owner_id = ?, status = ? WHERE id = ?",
+                (interest["volunteer_id"], new_status, project_id)
             )
 
         # Email the volunteer

--- a/migration_009_needs_tasks_status.sql
+++ b/migration_009_needs_tasks_status.sql
@@ -1,0 +1,59 @@
+-- Migration 009: Add needs_tasks project status
+--
+-- When a volunteer's want_to_own interest is accepted, the project now
+-- moves to 'needs_tasks' instead of 'in_progress', giving the new owner
+-- a chance to add tasks before the project starts.
+--
+-- SQLite requires table recreation to update CHECK constraints.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE projects_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending_review' CHECK(status IN (
+        'pending_review',
+        'needs_discussion',
+        'seeking_owner',
+        'seeking_help',
+        'needs_tasks',
+        'in_progress',
+        'on_hold',
+        'completed',
+        'archived'
+    )),
+    owner_id INTEGER REFERENCES volunteers(id) ON DELETE SET NULL,
+    proposed_by_id INTEGER REFERENCES volunteers(id) ON DELETE SET NULL,
+    is_org_proposed BOOLEAN DEFAULT FALSE,
+    project_type TEXT CHECK(project_type IN ('sprint', 'container', 'ongoing', 'one_off')),
+    estimated_duration TEXT,
+    time_commitment_hours_per_week INTEGER,
+    urgency TEXT CHECK(urgency IN ('low', 'medium', 'high')) DEFAULT 'medium',
+    review_notes TEXT,
+    reviewed_by_id INTEGER REFERENCES volunteers(id),
+    reviewed_at TIMESTAMP,
+    feedback_to_proposer TEXT,
+    collaboration_link TEXT,
+    outcome TEXT CHECK(outcome IN ('successful', 'partial', 'not_completed', 'ongoing')),
+    outcome_notes TEXT,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    country TEXT,
+    is_seeking_help BOOLEAN DEFAULT FALSE,
+    is_seeking_owner BOOLEAN DEFAULT FALSE,
+    local_group TEXT
+);
+
+INSERT INTO projects_new SELECT * FROM projects;
+DROP TABLE projects;
+ALTER TABLE projects_new RENAME TO projects;
+
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
+CREATE INDEX IF NOT EXISTS idx_projects_owner ON projects(owner_id);
+CREATE INDEX IF NOT EXISTS idx_projects_proposed_by ON projects(proposed_by_id);
+CREATE INDEX IF NOT EXISTS idx_projects_country ON projects(country);
+CREATE INDEX IF NOT EXISTS idx_projects_local_group ON projects(local_group);
+
+PRAGMA foreign_keys=ON;

--- a/static/accept-invite.html
+++ b/static/accept-invite.html
@@ -87,6 +87,7 @@
             } catch (error) {
                 document.getElementById('error').style.display = 'block';
                 document.getElementById('errorMessage').textContent = error.message;
+                showToast(error.message, 'error');
             }
         }
 

--- a/static/admin/team.html
+++ b/static/admin/team.html
@@ -126,7 +126,7 @@
                 invites = await apiRequest('/api/admin/invites');
                 renderInvites();
             } catch (error) {
-                console.error('Failed to load invites:', error);
+                showToast('Failed to load invites', 'error');
             }
         }
 

--- a/static/admin/triage.html
+++ b/static/admin/triage.html
@@ -345,6 +345,7 @@
                 `).join('');
             } catch (error) {
                 document.getElementById('interestsList').innerHTML = `<p class="error">${error.message}</p>`;
+                showToast(error.message, 'error');
             }
         }
 

--- a/static/app.js
+++ b/static/app.js
@@ -199,10 +199,13 @@ async function apiRequest(endpoint, options = {}) {
 
     if (!response.ok) {
         const error = await response.json().catch(() => ({ detail: 'Request failed' }));
-        const detail = Array.isArray(error.detail)
+        const isFieldErrors = Array.isArray(error.detail);
+        const message = isFieldErrors
             ? error.detail.map(e => e.msg).join(', ')
-            : error.detail;
-        throw new Error(detail || 'Request failed');
+            : (error.detail || 'Request failed');
+        const err = new Error(message);
+        if (isFieldErrors) err.fieldErrors = error.detail;
+        throw err;
     }
 
     return response.json().catch(() => ({}));
@@ -248,6 +251,7 @@ function formatStatus(status) {
     const labels = {
         'seeking_owner': 'Seeking Owner',
         'seeking_help': 'Seeking Help',
+        'needs_tasks': 'Needs Tasks',
         'in_progress': 'In Progress',
         'on_hold': 'On Hold',
         'completed': 'Completed',
@@ -270,8 +274,57 @@ function formatUrgency(urgency) {
     return urgency.charAt(0).toUpperCase() + urgency.slice(1);
 }
 
-// Message display
+// Field-level validation error display
+function clearFieldErrors(container = document) {
+    container.querySelectorAll('.field-error-msg').forEach(el => el.remove());
+    container.querySelectorAll('.input-error').forEach(el => el.classList.remove('input-error'));
+}
+
+function showFieldErrors(fieldErrors, container = document, fieldMap = {}) {
+    if (!fieldErrors || !fieldErrors.length) return;
+    let firstInput = null;
+    for (const err of fieldErrors) {
+        const fieldName = err.loc && err.loc[err.loc.length - 1];
+        if (!fieldName) continue;
+        const elId = fieldMap[fieldName] || fieldName;
+        const input = container.querySelector(`#${elId}, [name="${elId}"]`);
+        if (!input) continue;
+        input.classList.add('input-error');
+        const msg = document.createElement('p');
+        msg.className = 'field-error-msg';
+        msg.textContent = err.msg;
+        const group = input.closest('.form-group');
+        if (group) group.appendChild(msg);
+        else input.after(msg);
+        if (!firstInput) firstInput = input;
+    }
+    if (firstInput) firstInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+// Toast notifications (bottom-right desktop, bottom-centre mobile)
+function showToast(text, type = 'error', duration = 5000) {
+    let container = document.getElementById('toastContainer');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'toastContainer';
+        document.body.appendChild(container);
+    }
+
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.textContent = text;
+    container.appendChild(toast);
+
+    // Animate out then remove
+    setTimeout(() => {
+        toast.classList.add('toast-hiding');
+        toast.addEventListener('animationend', () => toast.remove(), { once: true });
+    }, duration);
+}
+
+// Message display — errors also appear as toasts
 function showMessage(text, type, containerId = 'messageDiv') {
+    if (type === 'error') showToast(text, 'error');
     const div = document.getElementById(containerId);
     if (!div) return;
     div.textContent = text;
@@ -724,7 +777,7 @@ function initBugReportButton() {
             document.getElementById('bugReportSuccess').style.display = 'block';
 
         } catch (error) {
-            alert('Failed to submit: ' + error.message);
+            showToast(error.message, 'error');
         }
 
         btn.disabled = false;

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -360,6 +360,7 @@
                 renderNotifications(notifications);
             } catch (error) {
                 document.getElementById('notificationsList').innerHTML = `<p class="error">${error.message}</p>`;
+                showToast(error.message, 'error');
             }
         }
 

--- a/static/edit-project.html
+++ b/static/edit-project.html
@@ -60,6 +60,7 @@
                 <div class="form-group">
                     <label for="status">Project Status</label>
                     <select id="status" name="status">
+                        <option value="needs_tasks">Needs Tasks</option>
                         <option value="in_progress">In Progress</option>
                         <option value="on_hold">On Hold</option>
                         <option value="completed">Completed</option>
@@ -231,6 +232,7 @@
                 const adminStatuses = [
                     { value: 'seeking_owner', label: 'Seeking Owner' },
                     { value: 'seeking_help', label: 'Seeking Help' },
+                    { value: 'needs_tasks', label: 'Needs Tasks' },
                     { value: 'in_progress', label: 'In Progress' },
                     { value: 'on_hold', label: 'On Hold' },
                     { value: 'completed', label: 'Completed' },
@@ -317,6 +319,8 @@
                     window.location.href = `/static/project.html?id=${project.id}`;
                 }, 1000);
             } catch (error) {
+                clearFieldErrors(form);
+                showFieldErrors(error.fieldErrors, form);
                 showMessage(error.message, 'error');
                 btn.disabled = false;
                 btn.textContent = 'Save Changes';

--- a/static/profile.html
+++ b/static/profile.html
@@ -229,6 +229,8 @@
                 document.getElementById('saveMessage').scrollIntoView({ behavior: 'smooth', block: 'center' });
 
             } catch (error) {
+                clearFieldErrors(form);
+                showFieldErrors(error.fieldErrors, form);
                 showMessage(error.message, 'error', 'saveMessage');
                 document.getElementById('saveMessage').scrollIntoView({ behavior: 'smooth', block: 'center' });
             }

--- a/static/project.html
+++ b/static/project.html
@@ -151,14 +151,16 @@
                 <h2>Manage Project Status</h2>
                 <div class="form-group">
                     <label for="statusSelect">Change Status</label>
-                    <select id="statusSelect">
+                    <select id="statusSelect" onchange="onStatusSelectChange()">
                         <option value="seeking_help">Seeking Help</option>
+                        <option value="needs_tasks">Needs Tasks</option>
                         <option value="in_progress">In Progress</option>
                         <option value="on_hold">On Hold</option>
                         <option value="completed">Completed</option>
                     </select>
                 </div>
                 <button class="btn btn-primary btn-small" onclick="updateProjectStatus()">Update Status</button>
+                <p id="inProgressHint" style="display: none; font-size: 0.8rem; color: var(--text-light); margin-top: 8px;">Moving to In Progress requires at least one open task.</p>
 
                 <div style="margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--border);">
                     <h3>Transfer Ownership</h3>
@@ -496,6 +498,7 @@
                     select.innerHTML = `
                         <option value="seeking_owner">Seeking Owner</option>
                         <option value="seeking_help">Seeking Help</option>
+                        <option value="needs_tasks">Needs Tasks</option>
                         <option value="in_progress">In Progress</option>
                         <option value="on_hold">On Hold</option>
                         <option value="completed">Completed</option>
@@ -504,6 +507,7 @@
                 }
 
                 select.value = project.status;
+                onStatusSelectChange();
                 loadTransferOptions();
             }
 
@@ -532,6 +536,11 @@
             } catch (error) {
                 showMessage(error.message, 'error');
             }
+        }
+
+        function onStatusSelectChange() {
+            const hint = document.getElementById('inProgressHint');
+            if (hint) hint.style.display = document.getElementById('statusSelect').value === 'in_progress' ? 'block' : 'none';
         }
 
         async function updateProjectStatus() {

--- a/static/settings.html
+++ b/static/settings.html
@@ -171,6 +171,8 @@
                 document.getElementById('currentEmail').textContent = `Current email: ${currentUser.email}`;
 
             } catch (error) {
+                clearFieldErrors(form);
+                showFieldErrors(error.fieldErrors, form);
                 showMessage(error.message, 'error');
             }
 
@@ -209,6 +211,8 @@
                 form.reset();
 
             } catch (error) {
+                clearFieldErrors(form);
+                showFieldErrors(error.fieldErrors, form);
                 showMessage(error.message, 'error');
             }
 

--- a/static/signup.html
+++ b/static/signup.html
@@ -332,6 +332,8 @@
                 }, 1000);
 
             } catch (error) {
+                clearFieldErrors(form);
+                showFieldErrors(error.fieldErrors, form);
                 showMessage(error.message, 'error');
                 showMessage(error.message, 'error', 'submitMessageDiv');
                 submitBtn.disabled = false;

--- a/static/styles.css
+++ b/static/styles.css
@@ -367,6 +367,11 @@ p {
     color: #1E40AF;
 }
 
+.status-needs_tasks {
+    background: #FEF9C3;
+    color: #713F12;
+}
+
 .status-in_progress {
     background: #D1FAE5;
     color: #065F46;
@@ -416,6 +421,7 @@ p {
 /* Dark mode badge overrides */
 [data-theme="dark"] .status-seeking_owner { background: #78350F; color: #FDE68A; }
 [data-theme="dark"] .status-seeking_help { background: #1E3A5F; color: #93C5FD; }
+[data-theme="dark"] .status-needs_tasks { background: #713F12; color: #FEF08A; }
 [data-theme="dark"] .status-in_progress { background: #064E3B; color: #6EE7B7; }
 [data-theme="dark"] .status-on_hold { background: #374151; color: #9CA3AF; }
 [data-theme="dark"] .status-completed { background: #064E3B; color: #6EE7B7; }
@@ -1561,4 +1567,102 @@ textarea {
         flex-direction: column;
         text-align: center;
     }
+}
+
+/* ============================================
+   TOASTS
+   ============================================ */
+
+#toastContainer {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 360px;
+    pointer-events: none;
+}
+
+@media (max-width: 640px) {
+    #toastContainer {
+        right: 12px;
+        left: 12px;
+        bottom: 16px;
+        max-width: none;
+    }
+}
+
+.toast {
+    padding: 12px 16px;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.4;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    animation: toast-in 0.2s ease forwards;
+    pointer-events: auto;
+}
+
+.toast-hiding {
+    animation: toast-out 0.2s ease forwards;
+}
+
+.toast-error {
+    background: #FEE2E2;
+    color: #991B1B;
+    border-left: 4px solid #DC2626;
+}
+
+.toast-success {
+    background: #D1FAE5;
+    color: #065F46;
+    border-left: 4px solid #10B981;
+}
+
+.toast-info {
+    background: #DBEAFE;
+    color: #1E40AF;
+    border-left: 4px solid #3B82F6;
+}
+
+@keyframes toast-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes toast-out {
+    from { opacity: 1; transform: translateY(0); }
+    to   { opacity: 0; transform: translateY(10px); }
+}
+
+[data-theme="dark"] .toast-error   { background: #7F1D1D; color: #FCA5A5; border-color: #EF4444; }
+[data-theme="dark"] .toast-success { background: #064E3B; color: #6EE7B7; border-color: #10B981; }
+[data-theme="dark"] .toast-info    { background: #1E3A5F; color: #93C5FD; border-color: #3B82F6; }
+
+/* ============================================
+   FIELD-LEVEL VALIDATION ERRORS
+   ============================================ */
+
+.field-error-msg {
+    color: #DC2626;
+    font-size: 0.8rem;
+    margin-top: 4px;
+    display: block;
+}
+
+input.input-error,
+textarea.input-error,
+select.input-error {
+    border-color: #DC2626 !important;
+    box-shadow: 0 0 0 1px #DC2626;
+}
+
+[data-theme="dark"] .field-error-msg { color: #FCA5A5; }
+[data-theme="dark"] input.input-error,
+[data-theme="dark"] textarea.input-error,
+[data-theme="dark"] select.input-error {
+    border-color: #EF4444 !important;
+    box-shadow: 0 0 0 1px #EF4444;
 }

--- a/static/suggest.html
+++ b/static/suggest.html
@@ -147,7 +147,15 @@
                     </label>
                 </div>
 
-                <div class="message info" style="margin-top: 20px;">
+                <h3 style="margin-top: 32px;">Initial Tasks <span style="color: var(--error, #DC2626); font-weight: 400;">*</span></h3>
+                <p class="form-hint" style="margin-bottom: 16px;">Break the project into at least one concrete task. This helps reviewers understand the scope and gives volunteers something to pick up.</p>
+
+                <div id="taskList"></div>
+
+                <button type="button" class="btn btn-outline btn-small" onclick="addTask()" style="margin-top: 8px;">+ Add another task</button>
+                <p id="taskError" class="form-hint" style="color: var(--error, #DC2626); display: none; margin-top: 8px;">At least one task with a title is required.</p>
+
+                <div class="message info" style="margin-top: 24px;">
                     <span>Your project will be reviewed by PauseAI UK team leads before being published. We'll reach out if we have questions or suggestions.</span>
                 </div>
 
@@ -164,6 +172,52 @@
     <script>
         let currentUser = null;
 
+        let taskCount = 0;
+
+        function addTask(title = '', description = '') {
+            const idx = taskCount++;
+            const list = document.getElementById('taskList');
+            const div = document.createElement('div');
+            div.id = `task-${idx}`;
+            div.style.cssText = 'border: 1px solid var(--border); border-radius: 8px; padding: 16px; margin-bottom: 12px; position: relative;';
+            div.innerHTML = `
+                <button type="button" onclick="removeTask(${idx})" title="Remove task"
+                    style="position: absolute; top: 10px; right: 12px; background: none; border: none; cursor: pointer; font-size: 1.1rem; color: var(--text-light); line-height: 1;">&times;</button>
+                <div class="form-group" style="margin-bottom: 10px;">
+                    <label class="required">Task title</label>
+                    <input type="text" class="task-title" value="${escapeAttr(title)}" placeholder="e.g. Draft copy for homepage" maxlength="300">
+                </div>
+                <div class="form-group" style="margin-bottom: 0;">
+                    <label>Description (optional)</label>
+                    <textarea class="task-description" rows="2" placeholder="More detail about what needs doing...">${escapeHtml(description)}</textarea>
+                </div>`;
+            list.appendChild(div);
+            updateRemoveButtons();
+        }
+
+        function removeTask(idx) {
+            const el = document.getElementById(`task-${idx}`);
+            if (el) el.remove();
+            updateRemoveButtons();
+        }
+
+        function updateRemoveButtons() {
+            const tasks = document.querySelectorAll('#taskList > div');
+            tasks.forEach(t => {
+                const btn = t.querySelector('button[title="Remove task"]');
+                if (btn) btn.style.display = tasks.length === 1 ? 'none' : '';
+            });
+        }
+
+        function escapeAttr(s) { return s.replace(/"/g, '&quot;'); }
+
+        function getTasksFromForm() {
+            return Array.from(document.querySelectorAll('#taskList > div')).map(div => ({
+                title: div.querySelector('.task-title').value.trim(),
+                description: div.querySelector('.task-description').value.trim() || null
+            })).filter(t => t.title);
+        }
+
         async function init() {
             currentUser = await initAuthNav();
 
@@ -176,6 +230,7 @@
             renderSkillSelector('skillSelector');
             renderCountrySelect('country');
             renderLocalGroupSelect('local_group');
+            addTask();
         }
 
         document.getElementById('country').addEventListener('change', (e) => {
@@ -191,6 +246,15 @@
 
         document.getElementById('suggestForm').addEventListener('submit', async (e) => {
             e.preventDefault();
+
+            const tasks = getTasksFromForm();
+            const taskError = document.getElementById('taskError');
+            if (tasks.length === 0) {
+                taskError.style.display = 'block';
+                document.getElementById('taskList').scrollIntoView({ behavior: 'smooth', block: 'center' });
+                return;
+            }
+            taskError.style.display = 'none';
 
             const form = e.target;
             const submitBtn = form.querySelector('button[type="submit"]');
@@ -217,7 +281,8 @@
                     skill_required_map: skillRequiredMap,
                     want_to_own: form.want_to_own.checked,
                     is_seeking_help: form.is_seeking_help.checked,
-                    is_seeking_owner: form.is_seeking_owner.checked
+                    is_seeking_owner: form.is_seeking_owner.checked,
+                    tasks
                 };
 
                 const result = await apiRequest('/api/projects', {
@@ -240,11 +305,22 @@
                 }, 2000);
 
             } catch (error) {
-                showMessage(error.message, 'error');
+                clearFieldErrors(form);
+                if (error.fieldErrors) {
+                    showFieldErrors(error.fieldErrors, form, FIELD_ID_MAP);
+                    showToast('Submission failed – check the fields for issues', 'error');
+                } else {
+                    showToast(error.message, 'error');
+                }
                 submitBtn.disabled = false;
                 submitBtn.textContent = 'Submit Project Proposal';
             }
         });
+
+        // Maps Pydantic field names → form element IDs where they differ
+        const FIELD_ID_MAP = {
+            time_commitment_hours_per_week: 'time_commitment',
+        };
 
         init();
     </script>

--- a/static/suggest.html
+++ b/static/suggest.html
@@ -133,18 +133,21 @@
                             <input type="checkbox" id="is_seeking_help" name="is_seeking_help" checked>
                             <span>Help / contributors</span>
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="is_seeking_owner" name="is_seeking_owner">
-                            <span>An owner / lead</span>
-                        </label>
                     </div>
                 </div>
 
                 <div class="form-group" style="margin-top: 8px;">
-                    <label class="checkbox-label">
-                        <input type="checkbox" id="want_to_own" name="want_to_own">
-                        <span><strong>I want to lead this project</strong> - I'll be the owner and coordinate the work</span>
-                    </label>
+                    <label>Project ownership:</label>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="radio" id="ownership_seeking" name="ownership" value="seeking">
+                            <span>This project needs an owner / lead</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="radio" id="ownership_want_to_own" name="ownership" value="want_to_own">
+                            <span><strong>I want to lead this project</strong> - I'll be the owner and coordinate the work</span>
+                        </label>
+                    </div>
                 </div>
 
                 <h3 style="margin-top: 32px;">Initial Tasks <span style="color: var(--error, #DC2626); font-weight: 400;">*</span></h3>
@@ -279,9 +282,9 @@
                     local_group: form.local_group.value || null,
                     skill_ids: skillIds,
                     skill_required_map: skillRequiredMap,
-                    want_to_own: form.want_to_own.checked,
+                    want_to_own: form.ownership.value === 'want_to_own',
                     is_seeking_help: form.is_seeking_help.checked,
-                    is_seeking_owner: form.is_seeking_owner.checked,
+                    is_seeking_owner: form.ownership.value === 'seeking',
                     tasks
                 };
 


### PR DESCRIPTION
## Summary

- Projects now require at least one task at proposal time (enforce in the API and the suggest form UI)
- A project cannot be moved to **In Progress** without at least one open task
- When a want-to-own interest is accepted, the project moves to a new **Needs Tasks** status so the owner can set up tasks before starting (unless the project is already in progress)
- Added toast notifications and inline field-level validation errors across all forms

## DB change

Run `migration_009_needs_tasks_status.sql` — recreates the `projects` table to add `needs_tasks` to the `status` CHECK constraint.

## Test plan

- [x] Submit a project proposal with no tasks → blocked client-side and server-side (400)
- [x] Submit a proposal with tasks → tasks appear on the project page
- [x] Try to move a project to In Progress with no open tasks → blocked with a clear error
- [x] Accept a want-to-own interest → project moves to Needs Tasks, not In Progress
- [x] Add tasks then move to In Progress → succeeds
- [x] Check Needs Tasks badge renders correctly in light and dark mode
- [x] Trigger a validation error on any form → field highlighted with inline message and toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)