### PR TITLE
feat: notify project owners and admins if someone contributing to their project or a project owner deletes their account

### DIFF
--- a/api.py
+++ b/api.py
@@ -1210,6 +1210,75 @@ def change_email(
     return {"message": "Email changed successfully"}
 
 
+def _send_account_deletion_notifications(conn, deleted_volunteer_id: int, deleted_volunteer_name: str):
+    """Notify affected parties when a volunteer deletes their account."""
+    # Project owners with tasks assigned to the deleted user
+    affected = conn.execute(
+        """SELECT p.owner_id, v.name AS owner_name, v.email AS owner_email,
+                  p.id AS project_id, p.title AS project_title,
+                  COUNT(st.id) AS task_count
+           FROM starter_tasks st
+           JOIN projects p ON st.project_id = p.id
+           JOIN volunteers v ON p.owner_id = v.id
+           WHERE st.assigned_to_id = ?
+             AND st.status NOT IN ('completed', 'reviewed')
+             AND p.owner_id != ?
+             AND v.deleted_at IS NULL
+           GROUP BY p.id""",
+        (deleted_volunteer_id, deleted_volunteer_id)
+    ).fetchall()
+
+    for row in affected:
+        task_word = "task" if row["task_count"] == 1 else "tasks"
+        create_notification(
+            conn, row["owner_id"], "task_assignee_deleted",
+            "Task assignee deleted their account",
+            f"{row['task_count']} {task_word} in '{row['project_title']}' assigned to {deleted_volunteer_name} need a new assignee.",
+            f"/static/project.html?id={row['project_id']}"
+        )
+        try:
+            if row["owner_email"]:
+                send_project_notification_email(
+                    to=row["owner_email"], name=row["owner_name"],
+                    subject=f"Task assignee deleted their account — '{row['project_title']}'",
+                    message=f"<strong>{deleted_volunteer_name}</strong> has deleted their account. They had {row['task_count']} {task_word} assigned to them in your project <strong>{row['project_title']}</strong>. Please reassign or unassign as needed.",
+                    project_title=row["project_title"], project_id=row["project_id"]
+                )
+        except Exception as e:
+            print(f"[NOTIFY ERROR] Task assignee deletion email failed: {e}")
+
+    # Admins: notify about each project losing its owner
+    owned_projects = conn.execute(
+        """SELECT id, title FROM projects
+           WHERE owner_id = ? AND status NOT IN ('completed', 'archived')""",
+        (deleted_volunteer_id,)
+    ).fetchall()
+
+    if owned_projects:
+        admins = conn.execute(
+            "SELECT id, name, email FROM volunteers WHERE is_admin = 1 AND deleted_at IS NULL AND id != ?",
+            (deleted_volunteer_id,)
+        ).fetchall()
+        for project in owned_projects:
+            for admin in admins:
+                create_notification(
+                    conn, admin["id"], "project_owner_deleted",
+                    "Project owner deleted their account",
+                    f"'{project['title']}' needs a new owner — {deleted_volunteer_name} has deleted their account.",
+                    f"/static/project.html?id={project['id']}"
+                )
+                try:
+                    if admin["email"]:
+                        send_project_notification_email(
+                            to=admin["email"], name=admin["name"],
+                            subject=f"Project owner deleted their account — '{project['title']}'",
+                            message=f"<strong>{deleted_volunteer_name}</strong> has deleted their account. They were the owner of <strong>{project['title']}</strong>. Please assign a new owner or archive the project.",
+                            project_title=project["title"], project_id=project["id"]
+                        )
+                except Exception as e:
+                    print(f"[NOTIFY ERROR] Project owner deletion admin email failed: {e}")
+
+
 @app.post("/api/auth/delete-account")
 def delete_account(
     data: DeleteAccountRequest,
@@ -1234,6 +1303,8 @@ def delete_account(
                VALUES (?, ?, 'completed')""",
             (volunteer["id"], volunteer["email"])
         )
+
+        _send_account_deletion_notifications(conn, volunteer["id"], volunteer["name"])
 
         # Soft delete - anonymize personal data but keep for referential integrity
         conn.execute(
@@ -3835,6 +3906,8 @@ def request_account_deletion(volunteer: Dict = Depends(require_auth)) -> Dict:
             "INSERT INTO deletion_requests (volunteer_id, volunteer_email) VALUES (?, ?)",
             (volunteer["id"], volunteer.get("email"))
         )
+
+        _send_account_deletion_notifications(conn, volunteer["id"], volunteer["name"])
 
         # Soft delete the volunteer
         conn.execute(

--- a/api.py
+++ b/api.py
@@ -1212,8 +1212,8 @@ def change_email(
 
 def _send_account_deletion_notifications(conn, deleted_volunteer_id: int, deleted_volunteer_name: str):
     """Notify affected parties when a volunteer deletes their account."""
-    # Project owners with tasks assigned to the deleted user
-    affected = conn.execute(
+    # Projects with unfinished tasks assigned to the deleted user, grouped by project owner
+    task_rows = conn.execute(
         """SELECT p.owner_id, v.name AS owner_name, v.email AS owner_email,
                   p.id AS project_id, p.title AS project_title,
                   COUNT(st.id) AS task_count
@@ -1228,55 +1228,99 @@ def _send_account_deletion_notifications(conn, deleted_volunteer_id: int, delete
         (deleted_volunteer_id, deleted_volunteer_id)
     ).fetchall()
 
-    for row in affected:
-        task_word = "task" if row["task_count"] == 1 else "tasks"
-        create_notification(
-            conn, row["owner_id"], "task_assignee_deleted",
-            "Task assignee deleted their account",
-            f"{row['task_count']} {task_word} in '{row['project_title']}' assigned to {deleted_volunteer_name} need a new assignee.",
-            f"/static/project.html?id={row['project_id']}"
-        )
-        try:
-            if row["owner_email"]:
-                send_project_notification_email(
-                    to=row["owner_email"], name=row["owner_name"],
-                    subject=f"Task assignee deleted their account — '{row['project_title']}'",
-                    message=f"<strong>{deleted_volunteer_name}</strong> has deleted their account. They had {row['task_count']} {task_word} assigned to them in your project <strong>{row['project_title']}</strong>. Please reassign or unassign as needed.",
-                    project_title=row["project_title"], project_id=row["project_id"]
-                )
-        except Exception as e:
-            print(f"[NOTIFY ERROR] Task assignee deletion email failed: {e}")
-
-    # Admins: notify about each project losing its owner
+    # Active projects owned by the deleted user
     owned_projects = conn.execute(
         """SELECT id, title FROM projects
            WHERE owner_id = ? AND status NOT IN ('completed', 'archived')""",
         (deleted_volunteer_id,)
     ).fetchall()
 
-    if owned_projects:
+    if not task_rows and not owned_projects:
+        return
+
+    # Build per-owner task map
+    owner_task_map = {}
+    for row in task_rows:
+        oid = row["owner_id"]
+        if oid not in owner_task_map:
+            owner_task_map[oid] = {"name": row["owner_name"], "email": row["owner_email"], "task_projects": []}
+        owner_task_map[oid]["task_projects"].append({
+            "project_id": row["project_id"],
+            "project_title": row["project_title"],
+            "task_count": row["task_count"],
+        })
+
+    ownerless = [{"project_id": p["id"], "project_title": p["title"]} for p in owned_projects]
+
+    # Build unified recipient map — admins and task-project owners may overlap
+    recipients = {}
+    for owner_id, data in owner_task_map.items():
+        recipients[owner_id] = {
+            "name": data["name"], "email": data["email"],
+            "task_projects": data["task_projects"], "ownerless_projects": [],
+        }
+
+    if ownerless:
         admins = conn.execute(
             "SELECT id, name, email FROM volunteers WHERE is_admin = 1 AND deleted_at IS NULL AND id != ?",
             (deleted_volunteer_id,)
         ).fetchall()
-        for project in owned_projects:
-            for admin in admins:
+        for admin in admins:
+            aid = admin["id"]
+            if aid not in recipients:
+                recipients[aid] = {"name": admin["name"], "email": admin["email"], "task_projects": [], "ownerless_projects": []}
+            recipients[aid]["ownerless_projects"] = ownerless
+
+    # Send per-project in-app notifications, but only one email per recipient
+    for recipient_id, r in recipients.items():
+        for p in r["task_projects"]:
+            word = "task" if p["task_count"] == 1 else "tasks"
+            try:
                 create_notification(
-                    conn, admin["id"], "project_owner_deleted",
-                    "Project owner deleted their account",
-                    f"'{project['title']}' needs a new owner — {deleted_volunteer_name} has deleted their account.",
-                    f"/static/project.html?id={project['id']}"
+                    conn, recipient_id, "account_deleted_impact",
+                    f"{deleted_volunteer_name} has deleted their account",
+                    f"{p['task_count']} {word} in '{p['project_title']}' assigned to {deleted_volunteer_name} need a new assignee.",
+                    f"/static/project.html?id={p['project_id']}"
                 )
-                try:
-                    if admin["email"]:
-                        send_project_notification_email(
-                            to=admin["email"], name=admin["name"],
-                            subject=f"Project owner deleted their account — '{project['title']}'",
-                            message=f"<strong>{deleted_volunteer_name}</strong> has deleted their account. They were the owner of <strong>{project['title']}</strong>. Please assign a new owner or archive the project.",
-                            project_title=project["title"], project_id=project["id"]
-                        )
-                except Exception as e:
-                    print(f"[NOTIFY ERROR] Project owner deletion admin email failed: {e}")
+            except Exception as e:
+                print(f"[NOTIFY ERROR] Account deletion notification failed: {e}")
+
+        for p in r["ownerless_projects"]:
+            try:
+                create_notification(
+                    conn, recipient_id, "account_deleted_impact",
+                    f"{deleted_volunteer_name} has deleted their account",
+                    f"'{p['project_title']}' needs a new owner.",
+                    f"/static/project.html?id={p['project_id']}"
+                )
+            except Exception as e:
+                print(f"[NOTIFY ERROR] Account deletion notification failed: {e}")
+
+        try:
+            if r["email"]:
+                all_projects = r["task_projects"] + r["ownerless_projects"]
+                msg_parts = [f"<p><strong>{deleted_volunteer_name}</strong> has deleted their account.</p>"]
+                if r["task_projects"]:
+                    rows_html = "".join(
+                        f"<li>{p['task_count']} {'task' if p['task_count'] == 1 else 'tasks'} in <strong>{p['project_title']}</strong></li>"
+                        for p in r["task_projects"]
+                    )
+                    msg_parts.append(f"<p>The following tasks need a new assignee:</p><ul>{rows_html}</ul>")
+                if r["ownerless_projects"]:
+                    rows_html = "".join(
+                        f"<li><strong>{p['project_title']}</strong></li>"
+                        for p in r["ownerless_projects"]
+                    )
+                    msg_parts.append(f"<p>The following projects need a new owner:</p><ul>{rows_html}</ul>")
+                send_project_notification_email(
+                    to=r["email"], name=r["name"],
+                    subject=f"{deleted_volunteer_name} has deleted their account",
+                    message="".join(msg_parts),
+                    project_title=all_projects[0]["project_title"],
+                    project_id=all_projects[0]["project_id"]
+                )
+        except Exception as e:
+            print(f"[NOTIFY ERROR] Account deletion email failed: {e}")
 
 
 @app.post("/api/auth/delete-account")

--- a/api.py
+++ b/api.py
@@ -329,7 +329,6 @@ class ChangeEmailRequest(BaseModel):
 
 class DeleteAccountRequest(BaseModel):
     password: str
-    confirmation: str = Field(..., pattern="^DELETE$")  # Must type "DELETE"
 
 
 # --- Projects ---
@@ -1368,6 +1367,11 @@ def delete_account(
                 updated_at = ?
                WHERE id = ?""",
             (datetime.now().isoformat(), datetime.now().isoformat(), volunteer["id"])
+        )
+
+        conn.execute(
+            "DELETE FROM volunteer_skills WHERE volunteer_id = ?",
+            (volunteer["id"],)
         )
 
     return {"message": "Your account has been deleted. We're sorry to see you go."}
@@ -3939,45 +3943,6 @@ def export_my_data(volunteer: Dict = Depends(require_auth)) -> Dict:
         "messages_sent": rows_to_list(messages_sent),
         "messages_received": rows_to_list(messages_received)
     }
-
-
-@app.delete("/api/privacy/delete-account")
-def request_account_deletion(volunteer: Dict = Depends(require_auth)) -> Dict:
-    """Request account deletion (GDPR right to erasure)."""
-    with db_transaction() as conn:
-        # Log the deletion request
-        conn.execute(
-            "INSERT INTO deletion_requests (volunteer_id, volunteer_email) VALUES (?, ?)",
-            (volunteer["id"], volunteer.get("email"))
-        )
-
-        _send_account_deletion_notifications(conn, volunteer["id"], volunteer["name"])
-
-        # Soft delete the volunteer
-        conn.execute(
-            """UPDATE volunteers SET
-               deleted_at = ?,
-               email = NULL,
-               discord_handle = NULL,
-               signal_number = NULL,
-               whatsapp_number = NULL,
-               bio = NULL,
-               other_skills = NULL,
-               auth_token = NULL,
-               name = 'Deleted User'
-               WHERE id = ?""",
-            (datetime.now().isoformat(), volunteer["id"])
-        )
-
-        # Remove from skill associations
-        conn.execute(
-            "DELETE FROM volunteer_skills WHERE volunteer_id = ?",
-            (volunteer["id"],)
-        )
-
-        return {
-            "message": "Your account has been deleted. Your data has been anonymized."
-        }
 
 
 # ============================================

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -42,15 +42,9 @@
                 <p style="color: var(--text-light); margin-bottom: 16px;">
                     Permanently delete your account and all associated data. This action cannot be undone.
                 </p>
-                <ul style="margin-bottom: 16px; padding-left: 20px; color: var(--text-light);">
-                    <li>Your profile will be removed from the volunteer directory</li>
-                    <li>Your contact information will be erased</li>
-                    <li>Your name will be anonymized on any remaining project references</li>
-                    <li>Messages you've sent will show "Deleted User"</li>
-                </ul>
-                <button id="deleteBtn" class="btn btn-outline" style="border-color: var(--error); color: var(--error);">
-                    Delete My Account
-                </button>
+                <a href="/static/settings.html" class="btn btn-outline" style="border-color: var(--error); color: var(--error);">
+                    Go to Account Settings to Delete
+                </a>
             </div>
 
             <div class="card">
@@ -166,28 +160,6 @@
         </div>
     </main>
 
-    <!-- Delete Confirmation Modal -->
-    <div id="deleteModal" class="modal-overlay" style="display: none;">
-        <div class="modal">
-            <div class="modal-header">
-                <h2>Confirm Account Deletion</h2>
-                <button class="modal-close" onclick="closeModal('deleteModal')">&times;</button>
-            </div>
-            <div class="modal-body">
-                <p style="color: var(--error); font-weight: 500; margin-bottom: 16px;">
-                    This action cannot be undone.
-                </p>
-                <p>Are you sure you want to permanently delete your account? All your data will be removed.</p>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-outline" onclick="closeModal('deleteModal')">Cancel</button>
-                <button id="confirmDeleteBtn" class="btn" style="background: var(--error); color: white;">
-                    Yes, Delete My Account
-                </button>
-            </div>
-        </div>
-    </div>
-
     <script src="/static/app.js"></script>
     <script>
         let currentUser = null;
@@ -229,34 +201,6 @@
 
             btn.disabled = false;
             btn.textContent = 'Download My Data';
-        });
-
-        document.getElementById('deleteBtn').addEventListener('click', () => {
-            openModal('deleteModal');
-        });
-
-        document.getElementById('confirmDeleteBtn').addEventListener('click', async () => {
-            const btn = document.getElementById('confirmDeleteBtn');
-            btn.disabled = true;
-            btn.textContent = 'Deleting...';
-
-            try {
-                await apiRequest('/api/privacy/delete-account', { method: 'DELETE' });
-
-                localStorage.removeItem('authToken');
-
-                closeModal('deleteModal');
-                showMessage('Your account has been deleted. Goodbye!', 'success');
-
-                setTimeout(() => {
-                    window.location.href = '/';
-                }, 2000);
-
-            } catch (error) {
-                showMessage(error.message, 'error');
-                btn.disabled = false;
-                btn.textContent = 'Yes, Delete My Account';
-            }
         });
 
         init();

--- a/static/settings.html
+++ b/static/settings.html
@@ -116,13 +116,13 @@
 
                 <form id="deleteForm">
                     <div class="form-group">
-                        <label for="delete_password" class="required">Enter your password to confirm</label>
+                        <label for="delete_password" class="required">Enter your password</label>
                         <input type="password" id="delete_password" name="password" required>
                     </div>
 
                     <div class="form-group">
-                        <label for="delete_confirm" class="required">Type DELETE to confirm</label>
-                        <input type="text" id="delete_confirm" name="confirmation" required placeholder="DELETE" pattern="DELETE">
+                        <label for="delete_password_confirm" class="required">Confirm your password</label>
+                        <input type="password" id="delete_password_confirm" name="password_confirm" required>
                     </div>
 
                     <button type="submit" class="btn" style="background: var(--error); color: white; width: 100%;">
@@ -225,8 +225,8 @@
 
             const form = e.target;
 
-            if (form.confirmation.value !== 'DELETE') {
-                showMessage('Please type DELETE to confirm', 'error');
+            if (form.password.value !== form.password_confirm.value) {
+                showMessage('Passwords do not match', 'error');
                 return;
             }
 
@@ -237,16 +237,12 @@
             try {
                 await apiRequest('/api/auth/delete-account', {
                     method: 'POST',
-                    body: JSON.stringify({
-                        password: form.password.value,
-                        confirmation: form.confirmation.value
-                    })
+                    body: JSON.stringify({ password: form.password.value })
                 });
 
-                // Clear auth and redirect
                 localStorage.removeItem('authToken');
-                alert('Your account has been deleted. We\'re sorry to see you go.');
-                window.location.href = '/';
+                showMessage('Your account has been deleted. We\'re sorry to see you go.', 'success');
+                setTimeout(() => { window.location.href = '/'; }, 2000);
 
             } catch (error) {
                 showMessage(error.message, 'error');


### PR DESCRIPTION
## Summary

Notifies project owners and admins when a volunteer who contributes to their project (or is a project owner themselves) deletes their account, so they can respond accordingly.

Also consolidates two duplicate delete-account endpoints that had diverged since being introduced in the same sync commit:
- `POST /api/auth/delete-account` (settings page) — required password, but missed `volunteer_skills` cleanup
- `DELETE /api/privacy/delete-account` (privacy page) — no password check, incomplete field anonymisation

The surviving endpoint (`POST /api/auth/delete-account`) now covers full field anonymisation (`name`, `email`, `bio`, `discord_handle`, `signal_number`, `whatsapp_number`, `contact_notes`, `location`, `other_skills`, `auth_token`, `password_hash`), removes skill associations, and records the deletion request as `completed`. The settings page modal now asks for password confirmation (entered twice); the privacy page links to settings instead of having its own weaker delete flow.