### PR TITLE
feat: project tasks, comments, and inactivity reminders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev install build serve test test-headed test-debug test-smoke scenario scenarios scenario-clean
+.PHONY: dev install build serve test test-headed test-debug test-smoke scenario scenarios scenario-clean preview-emails preview-emails-plaintext
 
 # Start the development server on http://localhost:8001
 dev:
@@ -61,6 +61,14 @@ scenario:
 	echo "Running scenario: $$NAME"; \
 	echo "Results will be written to: $$OUTFILE"; \
 	claude "Please run the scenario in tests/scenarios/$${NAME}.md against http://localhost:8001. Write the results to $${OUTFILE}, which already exists with YAML frontmatter. Append to the file: a '## Results' section with a markdown table (columns: Step, Result, Notes), then an '## Observations' section listing any UX issues or unexpected behaviour noticed during the run. Do not rewrite the frontmatter."
+
+# Preview all email templates in the browser at http://localhost:8765
+preview-emails:
+	. venv/bin/activate && python preview_emails.py
+
+# Print all email templates as plain markdown to stdout
+preview-emails-plaintext:
+	. venv/bin/activate && python preview_emails_plaintext.py
 
 # Remove test accounts and projects left over from scenario walkthroughs
 scenario-clean:

--- a/api.py
+++ b/api.py
@@ -2408,39 +2408,37 @@ def update_project_task(
 ) -> Dict:
     """Update a project task. Owner/admin can edit all fields. Volunteers can claim open tasks."""
     conn = get_db()
-    project = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
-    task = conn.execute(
-        "SELECT * FROM project_tasks WHERE id = ? AND project_id = ?", (task_id, project_id)
-    ).fetchone()
-
-    if not project or not task:
-        conn.close()
-        raise HTTPException(status_code=404, detail="Project or task not found")
-
-    is_owner = project["owner_id"] == volunteer["id"]
-    is_admin = volunteer.get("is_admin")
-    is_assignee = task["assigned_to_id"] == volunteer["id"]
-
-    # Volunteers can claim open tasks or mark their own assigned tasks as done
-    if not (is_owner or is_admin):
-        if data.status == 'assigned' and data.assigned_to_id == volunteer["id"] and task["status"] == "open":
-            pass  # Allow self-claim
-        elif data.status == 'done' and is_assignee and task["status"] == "assigned":
-            pass  # Allow marking own task done
-        else:
-            conn.close()
-            raise HTTPException(status_code=403, detail="Not authorized to update this task")
-
-    if data.assigned_to_id is not None:
-        assignee_is_contributor = conn.execute(
-            "SELECT 1 FROM project_interests WHERE project_id = ? AND volunteer_id = ? AND status = 'accepted'",
-            (project_id, data.assigned_to_id)
+    try:
+        project = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
+        task = conn.execute(
+            "SELECT * FROM project_tasks WHERE id = ? AND project_id = ?", (task_id, project_id)
         ).fetchone()
-        assignee_is_owner = project["owner_id"] == data.assigned_to_id
-        conn.close()
-        if not (assignee_is_contributor or assignee_is_owner):
-            raise HTTPException(status_code=400, detail="Assignee is not a contributor to this project")
-    else:
+
+        if not project or not task:
+            raise HTTPException(status_code=404, detail="Project or task not found")
+
+        is_owner = project["owner_id"] == volunteer["id"]
+        is_admin = volunteer.get("is_admin")
+        is_assignee = task["assigned_to_id"] == volunteer["id"]
+
+        # Volunteers can claim open tasks or mark their own assigned tasks as done
+        if not (is_owner or is_admin):
+            if data.status == 'assigned' and data.assigned_to_id == volunteer["id"] and task["status"] == "open":
+                pass  # Allow self-claim
+            elif data.status == 'done' and is_assignee and task["status"] == "assigned":
+                pass  # Allow marking own task done
+            else:
+                raise HTTPException(status_code=403, detail="Not authorized to update this task")
+
+        if data.assigned_to_id is not None:
+            assignee_is_contributor = conn.execute(
+                "SELECT 1 FROM project_interests WHERE project_id = ? AND volunteer_id = ? AND status = 'accepted'",
+                (project_id, data.assigned_to_id)
+            ).fetchone()
+            assignee_is_owner = project["owner_id"] == data.assigned_to_id
+            if not (assignee_is_contributor or assignee_is_owner):
+                raise HTTPException(status_code=400, detail="Assignee is not a contributor to this project")
+    finally:
         conn.close()
 
     with db_transaction() as conn:

--- a/api.py
+++ b/api.py
@@ -418,6 +418,10 @@ class ProjectUpdateCreate(BaseModel):
     content: str = Field(..., min_length=1)
 
 
+class TaskCommentCreate(BaseModel):
+    content: str = Field(..., min_length=1)
+
+
 # --- Admin Notes ---
 class AdminNoteCreate(BaseModel):
     content: str = Field(..., min_length=1)
@@ -2501,6 +2505,69 @@ def delete_project_task(
         if result.rowcount == 0:
             raise HTTPException(status_code=404, detail="Task not found")
         return {"message": "Task deleted"}
+
+
+@app.get("/api/projects/{project_id}/tasks/{task_id}/comments")
+def list_task_comments(
+    project_id: int,
+    task_id: int,
+    current_volunteer: Optional[Dict] = Depends(get_current_volunteer)
+) -> List[Dict]:
+    """List comments on a task."""
+    conn = get_db()
+    task = conn.execute(
+        "SELECT * FROM project_tasks WHERE id = ? AND project_id = ?", (task_id, project_id)
+    ).fetchone()
+    if not task:
+        conn.close()
+        raise HTTPException(status_code=404, detail="Task not found")
+    comments = conn.execute(
+        """SELECT ptc.*, v.name as author_name
+           FROM project_task_comments ptc
+           LEFT JOIN volunteers v ON ptc.author_id = v.id
+           WHERE ptc.task_id = ?
+           ORDER BY ptc.created_at ASC""",
+        (task_id,)
+    ).fetchall()
+    conn.close()
+    return [row_to_dict(c) for c in comments]
+
+
+@app.post("/api/projects/{project_id}/tasks/{task_id}/comments")
+def add_task_comment(
+    project_id: int,
+    task_id: int,
+    data: TaskCommentCreate,
+    volunteer: Dict = Depends(require_auth)
+) -> Dict:
+    """Add a comment to a task. Must be a project contributor, owner, or admin."""
+    conn = get_db()
+    project = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
+    task = conn.execute(
+        "SELECT * FROM project_tasks WHERE id = ? AND project_id = ?", (task_id, project_id)
+    ).fetchone()
+
+    if not project or not task:
+        conn.close()
+        raise HTTPException(status_code=404, detail="Project or task not found")
+
+    is_owner = project["owner_id"] == volunteer["id"]
+    is_admin = volunteer.get("is_admin")
+    is_contributor = conn.execute(
+        "SELECT 1 FROM project_interests WHERE project_id = ? AND volunteer_id = ? AND status = 'accepted'",
+        (project_id, volunteer["id"])
+    ).fetchone()
+    conn.close()
+
+    if not (is_owner or is_admin or is_contributor):
+        raise HTTPException(status_code=403, detail="Only project contributors can comment on tasks")
+
+    with db_transaction() as conn:
+        cursor = conn.execute(
+            "INSERT INTO project_task_comments (task_id, author_id, content) VALUES (?, ?, ?)",
+            (task_id, volunteer["id"], data.content)
+        )
+        return {"id": cursor.lastrowid, "message": "Comment added"}
 
 
 # ============================================

--- a/api.py
+++ b/api.py
@@ -2461,10 +2461,17 @@ def update_project_task(
                 params.append(datetime.now().isoformat())
             elif data.status == "open":
                 updates.append("assigned_to_id = NULL")
+                updates.append("assigned_at = NULL")
+                updates.append("nudge_sent_at = NULL")
+                updates.append("final_warning_sent_at = NULL")
                 updates.append("completed_at = NULL")
         if data.assigned_to_id is not None:
             updates.append("assigned_to_id = ?")
             params.append(data.assigned_to_id)
+            updates.append("assigned_at = ?")
+            params.append(datetime.now().isoformat())
+            updates.append("nudge_sent_at = NULL")
+            updates.append("final_warning_sent_at = NULL")
 
         if updates:
             updates.append("updated_at = ?")
@@ -2566,6 +2573,10 @@ def add_task_comment(
         cursor = conn.execute(
             "INSERT INTO project_task_comments (task_id, author_id, content) VALUES (?, ?, ?)",
             (task_id, volunteer["id"], data.content)
+        )
+        conn.execute(
+            "UPDATE project_tasks SET nudge_sent_at = NULL, final_warning_sent_at = NULL WHERE id = ?",
+            (task_id,)
         )
         return {"id": cursor.lastrowid, "message": "Comment added"}
 
@@ -4133,6 +4144,10 @@ def startup():
         start_digest_scheduler()
     except Exception as e:
         print(f"[STARTUP] Digest scheduler failed to start: {e}")
+    try:
+        start_inactivity_scheduler()
+    except Exception as e:
+        print(f"[STARTUP] Inactivity scheduler failed to start: {e}")
 
 
 def start_backup_scheduler():
@@ -4178,6 +4193,29 @@ def start_digest_scheduler():
     thread = threading.Thread(target=digest_loop, daemon=True)
     thread.start()
     print(f"[DIGEST] Scheduler started (email configured: {is_email_configured()})")
+
+
+def start_inactivity_scheduler():
+    """Start a background thread that checks for inactive tasks daily."""
+    import threading
+    import time
+    from digest_service import check_task_inactivity
+    from email_service import is_email_configured
+
+    def inactivity_loop():
+        # Wait 2 minutes after startup before first check
+        time.sleep(120)
+        while True:
+            try:
+                check_task_inactivity()
+            except Exception as e:
+                print(f"[INACTIVITY ERROR] Unexpected error in inactivity loop: {e}")
+            # Sleep 24 hours
+            time.sleep(24 * 60 * 60)
+
+    thread = threading.Thread(target=inactivity_loop, daemon=True)
+    thread.start()
+    print(f"[INACTIVITY] Scheduler started (email configured: {is_email_configured()})")
 
 
 # ============================================

--- a/api.py
+++ b/api.py
@@ -2408,9 +2408,9 @@ def update_project_task(
     task = conn.execute(
         "SELECT * FROM project_tasks WHERE id = ? AND project_id = ?", (task_id, project_id)
     ).fetchone()
-    conn.close()
 
     if not project or not task:
+        conn.close()
         raise HTTPException(status_code=404, detail="Project or task not found")
 
     is_owner = project["owner_id"] == volunteer["id"]
@@ -2424,7 +2424,20 @@ def update_project_task(
         elif data.status == 'done' and is_assignee and task["status"] == "assigned":
             pass  # Allow marking own task done
         else:
+            conn.close()
             raise HTTPException(status_code=403, detail="Not authorized to update this task")
+
+    if data.assigned_to_id is not None:
+        assignee_is_contributor = conn.execute(
+            "SELECT 1 FROM project_interests WHERE project_id = ? AND volunteer_id = ? AND status = 'accepted'",
+            (project_id, data.assigned_to_id)
+        ).fetchone()
+        assignee_is_owner = project["owner_id"] == data.assigned_to_id
+        conn.close()
+        if not (assignee_is_contributor or assignee_is_owner):
+            raise HTTPException(status_code=400, detail="Assignee is not a contributor to this project")
+    else:
+        conn.close()
 
     with db_transaction() as conn:
         updates = []

--- a/digest_service.py
+++ b/digest_service.py
@@ -7,9 +7,9 @@ Two modes:
 - Fortnightly digest: summary of new projects every two weeks
 
 Also handles task inactivity reminders (legitimate interest basis):
-- 7 days without a comment: nudge email to assignee
-- 14 days: final warning email to assignee
-- 21 days: task unassigned, project owner notified
+- 14 days without a comment: nudge email to assignee
+- 21 days: final warning email to assignee
+- 28 days: task unassigned, project owner notified
 """
 
 import sqlite3
@@ -210,9 +210,9 @@ def send_fortnightly_digest():
 def check_task_inactivity():
     """
     Daily check for inactive assigned tasks. Applies three escalating actions:
-    - 7+ days inactive: send nudge email to assignee
-    - 14+ days inactive: send final warning email to assignee
-    - 21+ days inactive: unassign the task, notify project owner
+    - 14+ days inactive: send nudge email to assignee
+    - 21+ days inactive: send final warning email to assignee
+    - 7 days after final warning (28+ days total): unassign the task, notify project owner
     Activity is reset whenever a comment is posted on the task.
     """
     if not is_email_configured():
@@ -295,7 +295,7 @@ def check_task_inactivity():
                 )
             surrendered += 1
 
-        elif days_inactive >= 14 and not t["final_warning_sent_at"]:
+        elif days_inactive >= 21 and not t["final_warning_sent_at"]:
             surrender_date = f"{(now + timedelta(days=7)).day} {(now + timedelta(days=7)).strftime('%B %Y')}"
             if t["assignee_email"]:
                 send_task_final_warning_email(
@@ -314,7 +314,7 @@ def check_task_inactivity():
                 update_conn.close()
             final_warned += 1
 
-        elif days_inactive >= 7 and not t["nudge_sent_at"]:
+        elif days_inactive >= 14 and not t["nudge_sent_at"]:
             if t["assignee_email"]:
                 send_task_nudge_email(
                     t["assignee_email"], t["assignee_name"], t["title"],

--- a/digest_service.py
+++ b/digest_service.py
@@ -12,7 +12,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import os
 
-from email_service import send_digest_email, is_email_configured
+from email_service import (
+    send_digest_email,
+    is_email_configured,
+    send_task_nudge_email,
+    send_task_final_warning_email,
+    send_task_surrendered_owner_email,
+)
 
 
 # Database location (same logic as api.py)
@@ -193,6 +199,117 @@ def send_fortnightly_digest():
             sent += 1
 
     print(f"[DIGEST] Sent fortnightly digest to {sent}/{len(volunteers)} volunteers ({len(project_list)} projects)")
+
+
+def check_task_inactivity():
+    """
+    Daily check for inactive assigned tasks. Applies three escalating actions:
+    - 7+ days inactive: send nudge email to assignee
+    - 14+ days inactive: send final warning email to assignee
+    - 21+ days inactive: unassign the task, notify project owner
+    Activity is reset whenever a comment is posted on the task.
+    """
+    if not is_email_configured():
+        print("[INACTIVITY] Email not configured, skipping task inactivity check")
+        return
+
+    conn = get_db()
+    try:
+        # Check columns exist (migration may not have run yet)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(project_tasks)").fetchall()}
+        if "assigned_at" not in cols:
+            print("[INACTIVITY] assigned_at column not found, skipping")
+            return
+
+        now = datetime.now()
+
+        tasks = conn.execute(
+            """SELECT pt.id, pt.project_id, pt.title,
+                      pt.assigned_at, pt.nudge_sent_at, pt.final_warning_sent_at,
+                      pt.assigned_to_id,
+                      v.name AS assignee_name, v.email AS assignee_email,
+                      p.title AS project_title, p.owner_id,
+                      ov.name AS owner_name, ov.email AS owner_email,
+                      (SELECT MAX(created_at) FROM project_task_comments
+                       WHERE task_id = pt.id) AS last_comment_at
+               FROM project_tasks pt
+               JOIN projects p ON pt.project_id = p.id
+               JOIN volunteers v ON pt.assigned_to_id = v.id
+               JOIN volunteers ov ON p.owner_id = ov.id
+               WHERE pt.status = 'assigned'
+               AND pt.assigned_at IS NOT NULL
+               AND v.deleted_at IS NULL"""
+        ).fetchall()
+    finally:
+        conn.close()
+
+    nudged = final_warned = surrendered = 0
+
+    for t in tasks:
+        last_activity_str = t["last_comment_at"] or t["assigned_at"]
+        try:
+            last_activity = datetime.fromisoformat(last_activity_str)
+        except (ValueError, TypeError):
+            continue
+        days_inactive = (now - last_activity).days
+
+        if days_inactive >= 21:
+            # Surrender: unassign task, notify owner
+            update_conn = get_db()
+            try:
+                update_conn.execute(
+                    """UPDATE project_tasks
+                       SET status = 'open', assigned_to_id = NULL, assigned_at = NULL,
+                           nudge_sent_at = NULL, final_warning_sent_at = NULL,
+                           updated_at = ?
+                       WHERE id = ?""",
+                    (now.isoformat(), t["id"])
+                )
+                update_conn.commit()
+            finally:
+                update_conn.close()
+            if t["owner_email"]:
+                send_task_surrendered_owner_email(
+                    t["owner_email"], t["owner_name"], t["assignee_name"],
+                    t["title"], t["project_title"], t["project_id"]
+                )
+            surrendered += 1
+
+        elif days_inactive >= 14 and not t["final_warning_sent_at"]:
+            if t["assignee_email"]:
+                send_task_final_warning_email(
+                    t["assignee_email"], t["assignee_name"], t["title"],
+                    t["project_title"], t["project_id"], t["id"], days_inactive
+                )
+            update_conn = get_db()
+            try:
+                update_conn.execute(
+                    "UPDATE project_tasks SET final_warning_sent_at = ? WHERE id = ?",
+                    (now.isoformat(), t["id"])
+                )
+                update_conn.commit()
+            finally:
+                update_conn.close()
+            final_warned += 1
+
+        elif days_inactive >= 7 and not t["nudge_sent_at"]:
+            if t["assignee_email"]:
+                send_task_nudge_email(
+                    t["assignee_email"], t["assignee_name"], t["title"],
+                    t["project_title"], t["project_id"], t["id"], days_inactive
+                )
+            update_conn = get_db()
+            try:
+                update_conn.execute(
+                    "UPDATE project_tasks SET nudge_sent_at = ? WHERE id = ?",
+                    (now.isoformat(), t["id"])
+                )
+                update_conn.commit()
+            finally:
+                update_conn.close()
+            nudged += 1
+
+    print(f"[INACTIVITY] Done — nudged: {nudged}, final warnings: {final_warned}, surrendered: {surrendered}")
 
 
 if __name__ == "__main__":

--- a/digest_service.py
+++ b/digest_service.py
@@ -258,8 +258,17 @@ def check_task_inactivity():
         except (ValueError, TypeError):
             continue
         days_inactive = (now - last_activity).days
+        activity_phrase = "you last updated this task" if t["last_comment_at"] else "you were assigned this task"
+        last_activity_date = f"{last_activity.day} {last_activity.strftime('%B %Y')}"
 
-        if days_inactive >= 21:
+        days_since_final_warning = None
+        if t["final_warning_sent_at"]:
+            try:
+                days_since_final_warning = (now - datetime.fromisoformat(t["final_warning_sent_at"])).days
+            except (ValueError, TypeError):
+                pass
+
+        if days_since_final_warning is not None and days_since_final_warning >= 7:
             # Surrender: unassign task, notify owner
             update_conn = get_db()
             try:
@@ -287,10 +296,12 @@ def check_task_inactivity():
             surrendered += 1
 
         elif days_inactive >= 14 and not t["final_warning_sent_at"]:
+            surrender_date = f"{(now + timedelta(days=7)).day} {(now + timedelta(days=7)).strftime('%B %Y')}"
             if t["assignee_email"]:
                 send_task_final_warning_email(
                     t["assignee_email"], t["assignee_name"], t["title"],
-                    t["project_title"], t["project_id"], t["id"], days_inactive
+                    t["project_title"], t["project_id"], t["id"], days_inactive,
+                    activity_phrase, last_activity_date, surrender_date
                 )
             update_conn = get_db()
             try:
@@ -307,7 +318,8 @@ def check_task_inactivity():
             if t["assignee_email"]:
                 send_task_nudge_email(
                     t["assignee_email"], t["assignee_name"], t["title"],
-                    t["project_title"], t["project_id"], t["id"], days_inactive
+                    t["project_title"], t["project_id"], t["id"], days_inactive,
+                    activity_phrase, last_activity_date
                 )
             update_conn = get_db()
             try:

--- a/digest_service.py
+++ b/digest_service.py
@@ -5,6 +5,11 @@ Sends project notification emails to volunteers who opted in.
 Two modes:
 - Skill match: immediate notification when a project matching their skills is approved
 - Fortnightly digest: summary of new projects every two weeks
+
+Also handles task inactivity reminders (legitimate interest basis):
+- 7 days without a comment: nudge email to assignee
+- 14 days: final warning email to assignee
+- 21 days: task unassigned, project owner notified
 """
 
 import sqlite3

--- a/digest_service.py
+++ b/digest_service.py
@@ -23,6 +23,7 @@ from email_service import (
     send_task_nudge_email,
     send_task_final_warning_email,
     send_task_surrendered_owner_email,
+    send_task_surrendered_assignee_email,
 )
 
 
@@ -273,6 +274,11 @@ def check_task_inactivity():
                 update_conn.commit()
             finally:
                 update_conn.close()
+            if t["assignee_email"]:
+                send_task_surrendered_assignee_email(
+                    t["assignee_email"], t["assignee_name"],
+                    t["title"], t["project_title"], t["project_id"]
+                )
             if t["owner_email"]:
                 send_task_surrendered_owner_email(
                     t["owner_email"], t["owner_name"], t["assignee_name"],

--- a/email_service.py
+++ b/email_service.py
@@ -21,6 +21,13 @@ RESEND_API_KEY = os.environ.get("RESEND_API_KEY")
 FROM_EMAIL = os.environ.get("FROM_EMAIL", "Catalyse <noreply@catalyse.pauseai.uk>")
 APP_URL = os.environ.get("APP_URL", "http://localhost:8000")
 
+_STYLES = """
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }
+    .container { max-width: 500px; margin: 0 auto; padding: 20px; }
+    .button { display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }
+    .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 13px; color: #718096; }
+"""
+
 
 def is_email_configured() -> bool:
     """Check if email sending is properly configured."""
@@ -68,425 +75,6 @@ def send_email(to: str, subject: str, html: str) -> bool:
         return False
 
 
-# ============================================
-# EMAIL TEMPLATES
-# ============================================
-
-# TODO: make email templates use a consistent style and container
-
-def send_password_reset_email(to: str, reset_token: str, name: str = "there") -> bool:
-    """Send password reset email."""
-    reset_url = f"{APP_URL}/static/reset-password.html?token={reset_token}"
-
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>Reset Your Password</h2>
-            <p>Hi {name},</p>
-            <p>We received a request to reset your password for your Catalyse account. Click the button below to choose a new password:</p>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{reset_url}" class="button">Reset Password</a>
-            </p>
-            <p>This link will expire in <strong>1 hour</strong>.</p>
-            <p>If you didn't request this, you can safely ignore this email. Your password won't be changed.</p>
-            <div class="footer">
-                <p>Catalyse - PauseAI UK Volunteer Platform</p>
-                <p style="font-size: 12px;">If the button doesn't work, copy this link:<br>{reset_url}</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-
-    return send_email(to, "Reset your Catalyse password", html)
-
-
-def send_admin_invite_email(to: str, invite_token: str, invited_by: str) -> bool:
-    """Send admin invite email."""
-    invite_url = f"{APP_URL}/static/accept-invite.html?token={invite_token}"
-
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>You're Invited to be a Catalyse Admin</h2>
-            <p>Hi!</p>
-            <p><strong>{invited_by}</strong> has invited you to become an admin on Catalyse, the PauseAI UK volunteer coordination platform.</p>
-            <p>As an admin, you'll be able to:</p>
-            <ul>
-                <li>Review and approve volunteer-proposed projects</li>
-                <li>Manage skills and starter tasks</li>
-                <li>View volunteer profiles and add notes</li>
-                <li>Invite other admins</li>
-            </ul>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{invite_url}" class="button">Accept Invitation</a>
-            </p>
-            <p>This invitation expires in <strong>7 days</strong>.</p>
-            <p>You'll need to sign up or log in with this email address to accept.</p>
-            <div class="footer">
-                <p>Catalyse - PauseAI UK Volunteer Platform</p>
-                <p style="font-size: 12px;">If the button doesn't work, copy this link:<br>{invite_url}</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-
-    return send_email(to, f"{invited_by} invited you to be a Catalyse admin", html)
-
-
-def send_welcome_email(to: str, name: str) -> bool:
-    """Send welcome email after signup."""
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>Welcome to Catalyse!</h2>
-            <p>Hi {name},</p>
-            <p>Thanks for joining the PauseAI UK volunteer community! We're excited to have you.</p>
-            <p>Here's what you can do now:</p>
-            <ul>
-                <li><strong>Browse projects</strong> - Find opportunities that match your skills</li>
-                <li><strong>Complete your profile</strong> - Help project owners find you</li>
-                <li><strong>Express interest</strong> - Let project owners know you want to help</li>
-            </ul>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}" class="button">Explore Projects</a>
-            </p>
-            <div class="footer">
-                <p>Catalyse - PauseAI UK Volunteer Platform</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-
-    return send_email(to, "Welcome to Catalyse!", html)
-
-
-def send_project_notification_email(to: str, name: str, subject: str,
-                                     message: str, project_title: str,
-                                     project_id: int, extra_html: str = "") -> bool:
-    """Send a project-related notification email to a volunteer."""
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>{subject}</h2>
-            <p>Hi {name},</p>
-            <p>{message}</p>
-            {extra_html}
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Project</a>
-            </p>
-            <div class="footer">
-                <p>Catalyse - PauseAI Volunteer Platform</p>
-                <p style="font-size: 12px;">
-                    <a href="{APP_URL}/static/profile.html">Manage notification preferences</a>
-                </p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-
-    return send_email(to, subject, html)
-
-
-def send_digest_email(to: str, name: str, projects: list, is_match: bool = False) -> bool:
-    """Send a project digest email to a volunteer."""
-    if not projects:
-        return False
-
-    match_intro = "Here are new projects that match your skills:" if is_match else "Here's what's new on Catalyse:"
-
-    project_html = ""
-    for p in projects:
-        skills_html = ", ".join(p.get("skill_names", [])[:5])
-        match_pct = p.get("match_percent")
-        match_badge = f' <span style="background: #D1FAE5; color: #065F46; padding: 2px 8px; border-radius: 10px; font-size: 12px;">{match_pct}% match</span>' if match_pct else ""
-        desc = p.get("description", "")
-
-        project_html += f"""
-            <div style="padding: 16px; margin-bottom: 12px; background: #f7fafc; border-radius: 8px; border-left: 4px solid #FF9416;">
-                <a href="{APP_URL}/static/project.html?id={p['id']}" style="font-weight: bold; color: #1A202C; text-decoration: none; font-size: 16px;">
-                    {p['title']}
-                </a>{match_badge}
-                <p style="color: #4A5568; margin: 8px 0 4px 0; font-size: 14px;">
-                    {desc[:150]}{'...' if len(desc) > 150 else ''}
-                </p>
-                {f'<p style="font-size: 12px; color: #718096;">Skills: {skills_html}</p>' if skills_html else ''}
-            </div>
-        """
-
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2 style="color: #FF9416;">Catalyse Project Update</h2>
-            <p>Hi {name},</p>
-            <p>{match_intro}</p>
-
-            {project_html}
-
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}" class="button">Browse All Projects</a>
-            </p>
-
-            <div class="footer">
-                <p>Catalyse - PauseAI Volunteer Platform</p>
-                <p style="font-size: 12px;">You're receiving this because you opted in to project notifications.
-                <a href="{APP_URL}/static/profile.html">Change your preferences</a> at any time.</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-
-    subject = "New projects matching your skills" if is_match else "What's new on Catalyse"
-    return send_email(to, subject, html)
-
-
-def send_task_nudge_email(to: str, name: str, task_title: str, project_title: str,
-                          project_id: int, task_id: int, days_inactive: int,
-                          activity_phrase: str, last_activity_date: str) -> bool:
-    """Send a 1-week inactivity nudge to a task assignee."""
-    subject = f"Update needed: {task_title}"
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>How's it going?</h2>
-            <p>Hi {name},</p>
-            <p>It's been {days_inactive} days since {activity_phrase} <strong>{task_title}</strong> in the project <strong>{project_title}</strong> (on {last_activity_date}).</p>
-            <p>Could you leave a quick comment with a progress update? This helps the project owner stay informed and keeps things moving.</p>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}#task-{task_id}" class="button">View Task</a>
-            </p>
-            <div class="footer">
-                <p>Catalyse - PauseAI Volunteer Platform</p>
-                <p style="font-size: 12px;">You're receiving this because you have an active task on Catalyse. If you can no longer work on this task, please release it so someone else can pick it up.</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-    return send_email(to, subject, html)
-
-
-def send_task_final_warning_email(to: str, name: str, task_title: str, project_title: str,
-                                   project_id: int, task_id: int, days_inactive: int,
-                                   activity_phrase: str, last_activity_date: str,
-                                   surrender_date: str) -> bool:
-    """Send a 2-week final warning to a task assignee before automatic surrender."""
-    subject = f"Final reminder: {task_title}"
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .warning {{ background: #FFF3CD; border-left: 4px solid #FF9416; padding: 12px 16px; border-radius: 4px; margin: 16px 0; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>Final reminder needed</h2>
-            <p>Hi {name},</p>
-            <p>It's now been {days_inactive} days since {activity_phrase} <strong>{task_title}</strong> in <strong>{project_title}</strong> (on {last_activity_date}).</p>
-            <div class="warning">
-                <strong>If there is no update by {surrender_date}, you will be automatically removed from this task</strong> so someone else can take it on.
-            </div>
-            <p>Please leave a comment with a progress update — even a brief one — to keep the task assigned to you.</p>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}#task-{task_id}" class="button">View Task</a>
-            </p>
-            <div class="footer">
-                <p>Catalyse - PauseAI Volunteer Platform</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-    return send_email(to, subject, html)
-
-
-def send_task_surrendered_owner_email(to: str, owner_name: str, volunteer_name: str,
-                                       task_title: str, project_title: str, project_id: int) -> bool:
-    """Notify a project owner that an inactive volunteer has been removed from a task."""
-    subject = f"Task unassigned due to inactivity: {task_title}"
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>Task unassigned due to inactivity</h2>
-            <p>Hi {owner_name},</p>
-            <p><strong>{volunteer_name}</strong> has been removed from the task <strong>{task_title}</strong> in your project <strong>{project_title}</strong> after three weeks of inactivity despite reminders.</p>
-            <p>The task is now open and can be claimed by another contributor.</p>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Project</a>
-            </p>
-            <div class="footer">
-                <p>Catalyse - PauseAI Volunteer Platform</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-    return send_email(to, subject, html)
-
-
-def send_task_surrendered_assignee_email(to: str, name: str, task_title: str,
-                                          project_title: str, project_id: int) -> bool:
-    """Notify a volunteer that they have been removed from a task due to inactivity."""
-    subject = f"You've been removed from a task: {task_title}"
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>You've been removed from a task</h2>
-            <p>Hi {name},</p>
-            <p>As there has been no activity for three weeks, you have been removed from the task <strong>{task_title}</strong> in the project <strong>{project_title}</strong>.</p>
-            <p>The task is now open for someone else to claim. If you'd still like to work on it, you're welcome to claim it again.</p>
-            <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Project</a>
-            </p>
-            <div class="footer">
-                <p>Catalyse - PauseAI Volunteer Platform</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-    return send_email(to, subject, html)
-
-
-def send_relay_message(to: str, to_name: str, from_name: str, from_email: str,
-                       subject: str, message: str, project_title: str = None) -> bool:
-    """Send a relay message from one volunteer to another via the platform."""
-    project_context = f" about the project <strong>{project_title}</strong>" if project_title else ""
-
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <style>
-            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
-            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
-            .message-box {{ background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin: 16px 0; white-space: pre-wrap; }}
-            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h2>Message from {from_name}</h2>
-            <p>Hi {to_name},</p>
-            <p><strong>{from_name}</strong> has sent you a message via Catalyse{project_context}:</p>
-            <div class="message-box">
-                <p style="font-weight: 500; margin-bottom: 8px;">{subject}</p>
-                <p>{message}</p>
-            </div>
-            <p>You can reply directly to this email to respond to {from_name}.</p>
-            <div class="footer">
-                <p>Catalyse - PauseAI UK Volunteer Platform</p>
-                <p style="font-size: 12px;">This message was sent via the Catalyse platform. If you no longer wish to receive messages,
-                update your contact preferences in your <a href="{APP_URL}/static/profile.html">profile settings</a>.</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
-
-    return send_email_with_reply_to(to, f"[Catalyse] {subject}", html, reply_to=from_email)
-
-
 def send_email_with_reply_to(to: str, subject: str, html: str, reply_to: str = None) -> bool:
     """Send an email via Resend API with optional reply-to header."""
     if not RESEND_API_KEY:
@@ -527,3 +115,426 @@ def send_email_with_reply_to(to: str, subject: str, html: str, reply_to: str = N
     except Exception as e:
         print(f"[EMAIL ERROR] Unexpected: {e}")
         return False
+
+
+# ============================================
+# EMAIL TEMPLATES
+# ============================================
+
+def _footer(buttons: list[tuple[str, str]] = None) -> str:
+    """Render the standard email footer.
+
+    buttons: list of (label, url) pairs matching the buttons in the email body.
+    Each entry generates a plain-text link fallback line.
+    """
+    fallbacks = ""
+    for label, url in (buttons or []):
+        fallbacks += (
+            f'<p style="font-size: 12px;">If the "{label}" button doesn\'t work, copy this link: '
+            f'<a href="{url}" style="color: #718096; word-break: break-all;">{url}</a></p>'
+        )
+    return f"""
+        <div class="footer">
+            <p>Catalyse - PauseAI Volunteer Platform - This is an automated email</p>
+            {fallbacks}
+            <p style="font-size: 12px;"><a href="{APP_URL}/static/profile.html">Manage notification preferences</a></p>
+        </div>
+    """
+
+
+def compose_password_reset_email(reset_token: str, name: str = "there") -> tuple[str, str]:
+    reset_url = f"{APP_URL}/static/reset-password.html?token={reset_token}"
+    subject = "Reset your Catalyse password"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Reset Your Password</h2>
+            <p>Hi {name},</p>
+            <p>We received a request to reset your password for your Catalyse account. Click the button below to choose a new password:</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{reset_url}" class="button">Reset Password</a>
+            </p>
+            <p>This link will expire in <strong>1 hour</strong>.</p>
+            <p>If you didn't request this, you can safely ignore this email. Your password won't be changed.</p>
+            {_footer([("Reset Password", reset_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_password_reset_email(to: str, reset_token: str, name: str = "there") -> bool:
+    """Send password reset email."""
+    subject, html = compose_password_reset_email(reset_token, name)
+    return send_email(to, subject, html)
+
+
+def compose_admin_invite_email(invite_token: str, invited_by: str) -> tuple[str, str]:
+    invite_url = f"{APP_URL}/static/accept-invite.html?token={invite_token}"
+    subject = f"{invited_by} invited you to be a Catalyse admin"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>You're Invited to be a Catalyse Admin</h2>
+            <p>Hi!</p>
+            <p><strong>{invited_by}</strong> has invited you to become an admin on Catalyse, the PauseAI volunteer coordination platform.</p>
+            <p>As an admin, you'll be able to:</p>
+            <ul>
+                <li>Review and approve volunteer-proposed projects</li>
+                <li>Manage skills and starter tasks</li>
+                <li>View volunteer profiles and add notes</li>
+                <li>Invite other admins</li>
+            </ul>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{invite_url}" class="button">Accept Invitation</a>
+            </p>
+            <p>This invitation expires in <strong>7 days</strong>.</p>
+            <p>You'll need to sign up or log in with this email address to accept.</p>
+            {_footer([("Accept Invitation", invite_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_admin_invite_email(to: str, invite_token: str, invited_by: str) -> bool:
+    """Send admin invite email."""
+    subject, html = compose_admin_invite_email(invite_token, invited_by)
+    return send_email(to, subject, html)
+
+
+def compose_welcome_email(name: str) -> tuple[str, str]:
+    subject = "Welcome to Catalyse!"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Welcome to Catalyse!</h2>
+            <p>Hi {name},</p>
+            <p>Thanks for joining the PauseAI volunteer community! We're excited to have you.</p>
+            <p>Here's what you can do now:</p>
+            <ul>
+                <li><strong>Browse projects</strong> - Find opportunities that match your skills</li>
+                <li><strong>Complete your profile</strong> - Help project owners find you</li>
+                <li><strong>Express interest</strong> - Let project owners know you want to help</li>
+            </ul>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{APP_URL}" class="button">Explore Projects</a>
+            </p>
+            {_footer([("Explore Projects", APP_URL)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_welcome_email(to: str, name: str) -> bool:
+    """Send welcome email after signup."""
+    subject, html = compose_welcome_email(name)
+    return send_email(to, subject, html)
+
+
+def compose_project_notification_email(name: str, subject: str, message: str,
+                                        project_title: str, project_id: int,
+                                        extra_html: str = "") -> tuple[str, str]:
+    project_url = f"{APP_URL}/static/project.html?id={project_id}"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>{subject}</h2>
+            <p>Hi {name},</p>
+            <p>{message}</p>
+            {extra_html}
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{project_url}" class="button">View Project</a>
+            </p>
+            {_footer([("View Project", project_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_project_notification_email(to: str, name: str, subject: str,
+                                     message: str, project_title: str,
+                                     project_id: int, extra_html: str = "") -> bool:
+    """Send a project-related notification email to a volunteer."""
+    subject, html = compose_project_notification_email(
+        name, subject, message, project_title, project_id, extra_html
+    )
+    return send_email(to, subject, html)
+
+
+def compose_digest_email(name: str, projects: list, is_match: bool = False) -> tuple[str, str]:
+    match_intro = "Here are new projects that match your skills:" if is_match else "Here's what's new on Catalyse:"
+
+    project_html = ""
+    for p in projects:
+        skills_html = ", ".join(p.get("skill_names", [])[:5])
+        match_pct = p.get("match_percent")
+        match_badge = f' <span style="background: #D1FAE5; color: #065F46; padding: 2px 8px; border-radius: 10px; font-size: 12px;">{match_pct}% match</span>' if match_pct else ""
+        desc = p.get("description", "")
+
+        project_html += f"""
+            <div style="padding: 16px; margin-bottom: 12px; background: #f7fafc; border-radius: 8px; border-left: 4px solid #FF9416;">
+                <a href="{APP_URL}/static/project.html?id={p['id']}" style="font-weight: bold; color: #1A202C; text-decoration: none; font-size: 16px;">
+                    {p['title']}
+                </a>{match_badge}
+                <p style="color: #4A5568; margin: 8px 0 4px 0; font-size: 14px;">
+                    {desc[:150]}{'...' if len(desc) > 150 else ''}
+                </p>
+                {f'<p style="font-size: 12px; color: #718096;">Skills: {skills_html}</p>' if skills_html else ''}
+            </div>
+        """
+
+    subject = "New projects matching your skills" if is_match else "What's new on Catalyse"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            {_STYLES}
+            .container {{ max-width: 600px; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2 style="color: #FF9416;">Catalyse Project Update</h2>
+            <p>Hi {name},</p>
+            <p>{match_intro}</p>
+            {project_html}
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{APP_URL}" class="button">Browse All Projects</a>
+            </p>
+            {_footer([("Browse All Projects", APP_URL)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_digest_email(to: str, name: str, projects: list, is_match: bool = False) -> bool:
+    """Send a project digest email to a volunteer."""
+    if not projects:
+        return False
+    subject, html = compose_digest_email(name, projects, is_match)
+    return send_email(to, subject, html)
+
+
+def compose_task_nudge_email(name: str, task_title: str, project_title: str,
+                              project_id: int, task_id: int, days_inactive: int,
+                              activity_phrase: str, last_activity_date: str) -> tuple[str, str]:
+    task_url = f"{APP_URL}/static/project.html?id={project_id}#task-{task_id}"
+    subject = f"How's it going with {task_title}?"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>How's it going?</h2>
+            <p>Hi {name},</p>
+            <p>It's been {days_inactive} days since {activity_phrase} <strong>{task_title}</strong> in the project <strong>{project_title}</strong> (on {last_activity_date}).</p>
+            <p>Could you leave a quick comment with a progress update? Even a brief note — like "ticking along, awaiting XYZ, will post another update in 2 weeks" — is really helpful so the project team knows things are in good hands.</p>
+            <p>If you don't have capacity for the task right now, it's much better to update the project page with an ETA than for the team not to know what's happening.</p>
+            <p>We'll send another reminder in a week if we haven't heard from you — it's important that things move along smoothly so everyone can make progress.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{task_url}" class="button">Leave an update</a>
+            </p>
+            <p>If you can no longer work on this task, please release it so someone else can pick it up.</p>
+            <p>If you need support, please contact your project owner or admin.</p>
+            {_footer([("Leave an update", task_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_task_nudge_email(to: str, name: str, task_title: str, project_title: str,
+                          project_id: int, task_id: int, days_inactive: int,
+                          activity_phrase: str, last_activity_date: str) -> bool:
+    """Send a 2-week inactivity nudge to a task assignee."""
+    subject, html = compose_task_nudge_email(
+        name, task_title, project_title, project_id, task_id,
+        days_inactive, activity_phrase, last_activity_date
+    )
+    return send_email(to, subject, html)
+
+
+def compose_task_final_warning_email(name: str, task_title: str, project_title: str,
+                                      project_id: int, task_id: int, days_inactive: int,
+                                      activity_phrase: str, last_activity_date: str,
+                                      surrender_date: str) -> tuple[str, str]:
+    task_url = f"{APP_URL}/static/project.html?id={project_id}#task-{task_id}"
+    subject = f"A quick nudge about {task_title}"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            {_STYLES}
+            .warning {{ background: #FFF3CD; border-left: 4px solid #FF9416; padding: 12px 16px; border-radius: 4px; margin: 16px 0; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>One more nudge</h2>
+            <p>Hi {name},</p>
+            <p>It's now been {days_inactive} days since {activity_phrase} <strong>{task_title}</strong> in <strong>{project_title}</strong> (on {last_activity_date}).</p>
+            <div class="warning">
+                <strong>If there is no update by {surrender_date}, we'll open the task to other contributors</strong> so the project can keep moving forward.
+            </div>
+            <p>Even a quick note is fine — anything to let the project team know you're still on it. If life has got busy, no worries at all, but it would really help to either leave an update or release the task so someone else can step in.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{task_url}" class="button">Leave an update</a>
+            </p>
+            <p>If you need support, please contact your project owner or a platform admin.</p>
+            {_footer([("Leave an update", task_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_task_final_warning_email(to: str, name: str, task_title: str, project_title: str,
+                                   project_id: int, task_id: int, days_inactive: int,
+                                   activity_phrase: str, last_activity_date: str,
+                                   surrender_date: str) -> bool:
+    """Send a 3-week final warning to a task assignee before automatic surrender."""
+    subject, html = compose_task_final_warning_email(
+        name, task_title, project_title, project_id, task_id,
+        days_inactive, activity_phrase, last_activity_date, surrender_date
+    )
+    return send_email(to, subject, html)
+
+
+def compose_task_surrendered_owner_email(owner_name: str, volunteer_name: str,
+                                          task_title: str, project_title: str,
+                                          project_id: int) -> tuple[str, str]:
+    project_url = f"{APP_URL}/static/project.html?id={project_id}"
+    subject = f"Task unassigned due to inactivity: {task_title}"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Task unassigned due to inactivity</h2>
+            <p>Hi {owner_name},</p>
+            <p><strong>{volunteer_name}</strong> has been removed from the task <strong>{task_title}</strong> in your project <strong>{project_title}</strong> after four weeks without an update, despite reminders.</p>
+            <p>The task is now open and can be claimed by another contributor.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{project_url}" class="button">View Project</a>
+            </p>
+            <p>If you need support, please contact your project owner or a platform admin.</p>
+            {_footer([("View Project", project_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_task_surrendered_owner_email(to: str, owner_name: str, volunteer_name: str,
+                                       task_title: str, project_title: str, project_id: int) -> bool:
+    """Notify a project owner that an inactive volunteer has been removed from a task."""
+    subject, html = compose_task_surrendered_owner_email(
+        owner_name, volunteer_name, task_title, project_title, project_id
+    )
+    return send_email(to, subject, html)
+
+
+def compose_task_surrendered_assignee_email(name: str, task_title: str,
+                                             project_title: str, project_id: int) -> tuple[str, str]:
+    project_url = f"{APP_URL}/static/project.html?id={project_id}"
+    subject = f"Update on your task: {task_title}"
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>{_STYLES}</style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Task now open to other contributors</h2>
+            <p>Hi {name},</p>
+            <p>Because we haven't received updates from you on the task <strong>{task_title}</strong> in <strong>{project_title}</strong> for four weeks, we've opened the task to other contributors and removed you from it.</p>
+            <p>We hope things are going well — if you'd still like to contribute, you're always welcome to claim the task again or pick up something else on the project.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{project_url}" class="button">View Project</a>
+            </p>
+            <p>If you need support, please contact your project owner or a platform admin.</p>
+            {_footer([("View Project", project_url)])}
+        </div>
+    </body>
+    </html>"""
+    return subject, html
+
+
+def send_task_surrendered_assignee_email(to: str, name: str, task_title: str,
+                                          project_title: str, project_id: int) -> bool:
+    """Notify a volunteer that they have been removed from a task due to inactivity."""
+    subject, html = compose_task_surrendered_assignee_email(
+        name, task_title, project_title, project_id
+    )
+    return send_email(to, subject, html)
+
+
+def compose_relay_message(to_name: str, from_name: str, from_email: str,
+                           subject: str, message: str, project_title: str = None) -> tuple[str, str]:
+    project_context = f" about the project <strong>{project_title}</strong>" if project_title else ""
+    html = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            {_STYLES}
+            .message-box {{ background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin: 16px 0; white-space: pre-wrap; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Message from {from_name}</h2>
+            <p>Hi {to_name},</p>
+            <p><strong>{from_name}</strong> has sent you a message via Catalyse{project_context}:</p>
+            <div class="message-box">
+                <p style="font-weight: 500; margin-bottom: 8px;">{subject}</p>
+                <p>{message}</p>
+            </div>
+            <p>You can reply directly to this email to respond to {from_name}.</p>
+            {_footer()}
+        </div>
+    </body>
+    </html>"""
+    return f"[Catalyse] {subject}", html
+
+
+def send_relay_message(to: str, to_name: str, from_name: str, from_email: str,
+                       subject: str, message: str, project_title: str = None) -> bool:
+    """Send a relay message from one volunteer to another via the platform."""
+    email_subject, html = compose_relay_message(
+        to_name, from_name, from_email, subject, message, project_title
+    )
+    return send_email_with_reply_to(to, email_subject, html, reply_to=from_email)

--- a/email_service.py
+++ b/email_service.py
@@ -320,7 +320,7 @@ def send_task_nudge_email(to: str, name: str, task_title: str, project_title: st
             <p>It's been {days_inactive} days since there was any activity on your task <strong>{task_title}</strong> in the project <strong>{project_title}</strong>.</p>
             <p>Could you leave a quick comment with a progress update? This helps the project owner stay informed and keeps things moving.</p>
             <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Task</a>
+                <a href="{APP_URL}/static/project.html?id={project_id}#task-{task_id}" class="button">View Task</a>
             </p>
             <div class="footer">
                 <p>Catalyse - PauseAI Volunteer Platform</p>
@@ -360,7 +360,7 @@ def send_task_final_warning_email(to: str, name: str, task_title: str, project_t
             </div>
             <p>Please leave a comment with a progress update — even a brief one — to keep the task assigned to you.</p>
             <p style="text-align: center; margin: 32px 0;">
-                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Task</a>
+                <a href="{APP_URL}/static/project.html?id={project_id}#task-{task_id}" class="button">View Task</a>
             </p>
             <div class="footer">
                 <p>Catalyse - PauseAI Volunteer Platform</p>

--- a/email_service.py
+++ b/email_service.py
@@ -407,6 +407,41 @@ def send_task_surrendered_owner_email(to: str, owner_name: str, volunteer_name: 
     return send_email(to, subject, html)
 
 
+def send_task_surrendered_assignee_email(to: str, name: str, task_title: str,
+                                          project_title: str, project_id: int) -> bool:
+    """Notify a volunteer that they have been removed from a task due to inactivity."""
+    subject = f"You've been removed from a task: {task_title}"
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
+            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
+            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
+            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>You've been removed from a task</h2>
+            <p>Hi {name},</p>
+            <p>As there has been no activity for three weeks, you have been removed from the task <strong>{task_title}</strong> in the project <strong>{project_title}</strong>.</p>
+            <p>The task is now open for someone else to claim. If you'd still like to work on it, you're welcome to claim it again.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Project</a>
+            </p>
+            <div class="footer">
+                <p>Catalyse - PauseAI Volunteer Platform</p>
+            </div>
+        </div>
+    </body>
+    </html>
+    """
+    return send_email(to, subject, html)
+
+
 def send_relay_message(to: str, to_name: str, from_name: str, from_email: str,
                        subject: str, message: str, project_title: str = None) -> bool:
     """Send a relay message from one volunteer to another via the platform."""

--- a/email_service.py
+++ b/email_service.py
@@ -72,6 +72,8 @@ def send_email(to: str, subject: str, html: str) -> bool:
 # EMAIL TEMPLATES
 # ============================================
 
+# TODO: make email templates use a consistent style and container
+
 def send_password_reset_email(to: str, reset_token: str, name: str = "there") -> bool:
     """Send password reset email."""
     reset_url = f"{APP_URL}/static/reset-password.html?token={reset_token}"
@@ -298,7 +300,8 @@ def send_digest_email(to: str, name: str, projects: list, is_match: bool = False
 
 
 def send_task_nudge_email(to: str, name: str, task_title: str, project_title: str,
-                          project_id: int, task_id: int, days_inactive: int) -> bool:
+                          project_id: int, task_id: int, days_inactive: int,
+                          activity_phrase: str, last_activity_date: str) -> bool:
     """Send a 1-week inactivity nudge to a task assignee."""
     subject = f"Update needed: {task_title}"
     html = f"""
@@ -317,7 +320,7 @@ def send_task_nudge_email(to: str, name: str, task_title: str, project_title: st
         <div class="container">
             <h2>How's it going?</h2>
             <p>Hi {name},</p>
-            <p>It's been {days_inactive} days since there was any activity on your task <strong>{task_title}</strong> in the project <strong>{project_title}</strong>.</p>
+            <p>It's been {days_inactive} days since {activity_phrase} <strong>{task_title}</strong> in the project <strong>{project_title}</strong> (on {last_activity_date}).</p>
             <p>Could you leave a quick comment with a progress update? This helps the project owner stay informed and keeps things moving.</p>
             <p style="text-align: center; margin: 32px 0;">
                 <a href="{APP_URL}/static/project.html?id={project_id}#task-{task_id}" class="button">View Task</a>
@@ -334,7 +337,9 @@ def send_task_nudge_email(to: str, name: str, task_title: str, project_title: st
 
 
 def send_task_final_warning_email(to: str, name: str, task_title: str, project_title: str,
-                                   project_id: int, task_id: int, days_inactive: int) -> bool:
+                                   project_id: int, task_id: int, days_inactive: int,
+                                   activity_phrase: str, last_activity_date: str,
+                                   surrender_date: str) -> bool:
     """Send a 2-week final warning to a task assignee before automatic surrender."""
     subject = f"Final reminder: {task_title}"
     html = f"""
@@ -354,9 +359,9 @@ def send_task_final_warning_email(to: str, name: str, task_title: str, project_t
         <div class="container">
             <h2>Final reminder needed</h2>
             <p>Hi {name},</p>
-            <p>It's now been {days_inactive} days since there was any activity on your task <strong>{task_title}</strong> in <strong>{project_title}</strong>.</p>
+            <p>It's now been {days_inactive} days since {activity_phrase} <strong>{task_title}</strong> in <strong>{project_title}</strong> (on {last_activity_date}).</p>
             <div class="warning">
-                <strong>If there is no update within the next week, you will be automatically removed from this task</strong> so someone else can take it on.
+                <strong>If there is no update by {surrender_date}, you will be automatically removed from this task</strong> so someone else can take it on.
             </div>
             <p>Please leave a comment with a progress update — even a brief one — to keep the task assigned to you.</p>
             <p style="text-align: center; margin: 32px 0;">

--- a/email_service.py
+++ b/email_service.py
@@ -297,6 +297,116 @@ def send_digest_email(to: str, name: str, projects: list, is_match: bool = False
     return send_email(to, subject, html)
 
 
+def send_task_nudge_email(to: str, name: str, task_title: str, project_title: str,
+                          project_id: int, task_id: int, days_inactive: int) -> bool:
+    """Send a 1-week inactivity nudge to a task assignee."""
+    subject = f"Update needed: {task_title}"
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
+            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
+            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
+            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>How's it going?</h2>
+            <p>Hi {name},</p>
+            <p>It's been {days_inactive} days since there was any activity on your task <strong>{task_title}</strong> in the project <strong>{project_title}</strong>.</p>
+            <p>Could you leave a quick comment with a progress update? This helps the project owner stay informed and keeps things moving.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Task</a>
+            </p>
+            <div class="footer">
+                <p>Catalyse - PauseAI Volunteer Platform</p>
+                <p style="font-size: 12px;">You're receiving this because you have an active task on Catalyse. If you can no longer work on this task, please release it so someone else can pick it up.</p>
+            </div>
+        </div>
+    </body>
+    </html>
+    """
+    return send_email(to, subject, html)
+
+
+def send_task_final_warning_email(to: str, name: str, task_title: str, project_title: str,
+                                   project_id: int, task_id: int, days_inactive: int) -> bool:
+    """Send a 2-week final warning to a task assignee before automatic surrender."""
+    subject = f"Final reminder: {task_title}"
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
+            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
+            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
+            .warning {{ background: #FFF3CD; border-left: 4px solid #FF9416; padding: 12px 16px; border-radius: 4px; margin: 16px 0; }}
+            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Final reminder needed</h2>
+            <p>Hi {name},</p>
+            <p>It's now been {days_inactive} days since there was any activity on your task <strong>{task_title}</strong> in <strong>{project_title}</strong>.</p>
+            <div class="warning">
+                <strong>If there is no update within the next week, you will be automatically removed from this task</strong> so someone else can take it on.
+            </div>
+            <p>Please leave a comment with a progress update — even a brief one — to keep the task assigned to you.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Task</a>
+            </p>
+            <div class="footer">
+                <p>Catalyse - PauseAI Volunteer Platform</p>
+            </div>
+        </div>
+    </body>
+    </html>
+    """
+    return send_email(to, subject, html)
+
+
+def send_task_surrendered_owner_email(to: str, owner_name: str, volunteer_name: str,
+                                       task_title: str, project_title: str, project_id: int) -> bool:
+    """Notify a project owner that an inactive volunteer has been removed from a task."""
+    subject = f"Task unassigned due to inactivity: {task_title}"
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }}
+            .container {{ max-width: 500px; margin: 0 auto; padding: 20px; }}
+            .button {{ display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }}
+            .footer {{ margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h2>Task unassigned due to inactivity</h2>
+            <p>Hi {owner_name},</p>
+            <p><strong>{volunteer_name}</strong> has been removed from the task <strong>{task_title}</strong> in your project <strong>{project_title}</strong> after three weeks of inactivity despite reminders.</p>
+            <p>The task is now open and can be claimed by another contributor.</p>
+            <p style="text-align: center; margin: 32px 0;">
+                <a href="{APP_URL}/static/project.html?id={project_id}" class="button">View Project</a>
+            </p>
+            <div class="footer">
+                <p>Catalyse - PauseAI Volunteer Platform</p>
+            </div>
+        </div>
+    </body>
+    </html>
+    """
+    return send_email(to, subject, html)
+
+
 def send_relay_message(to: str, to_name: str, from_name: str, from_email: str,
                        subject: str, message: str, project_title: str = None) -> bool:
     """Send a relay message from one volunteer to another via the platform."""

--- a/migration_010_task_comments.sql
+++ b/migration_010_task_comments.sql
@@ -1,0 +1,14 @@
+-- Migration 010: Task Comments
+-- Allows project contributors and owners to comment on tasks
+
+CREATE TABLE IF NOT EXISTS project_task_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL REFERENCES project_tasks(id) ON DELETE CASCADE,
+    author_id INTEGER REFERENCES volunteers(id) ON DELETE SET NULL,
+
+    content TEXT NOT NULL,
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_task_comments_task ON project_task_comments(task_id);

--- a/migration_011_task_inactivity.sql
+++ b/migration_011_task_inactivity.sql
@@ -1,0 +1,6 @@
+-- Migration 011: Task inactivity tracking
+-- Supports automated inactivity nudges, final warnings, and task surrender
+
+ALTER TABLE project_tasks ADD COLUMN assigned_at TIMESTAMP;
+ALTER TABLE project_tasks ADD COLUMN nudge_sent_at TIMESTAMP;
+ALTER TABLE project_tasks ADD COLUMN final_warning_sent_at TIMESTAMP;

--- a/preview_emails.py
+++ b/preview_emails.py
@@ -1,0 +1,368 @@
+"""
+Email preview server. Run with:
+
+    python preview_emails.py
+
+Then open http://localhost:8765 in your browser.
+"""
+
+import html as html_module
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+# Point APP_URL at localhost so links in emails resolve locally.
+os.environ.setdefault("APP_URL", "http://localhost:8000")
+
+from email_service import (
+    compose_password_reset_email,
+    compose_admin_invite_email,
+    compose_welcome_email,
+    compose_project_notification_email,
+    compose_digest_email,
+    compose_task_nudge_email,
+    compose_task_final_warning_email,
+    compose_task_surrendered_owner_email,
+    compose_task_surrendered_assignee_email,
+    compose_relay_message,
+)
+
+PORT = 8765
+
+# ---------------------------------------------------------------------------
+# Each entry: label, params dict (for display), compose callable -> (subject, html)
+# ---------------------------------------------------------------------------
+
+PREVIEWS = [
+    {
+        "key": "nudge",
+        "label": "Task nudge",
+        "params": {
+            "name": "Alex Johnson",
+            "task_title": "Write fundraising copy",
+            "project_title": "Climate Action Newsletter",
+            "days_inactive": 14,
+            "activity_phrase": "you were assigned this task",
+            "last_activity_date": "16 April 2026",
+        },
+        "compose": lambda: compose_task_nudge_email(
+            name="Alex Johnson",
+            task_title="Write fundraising copy",
+            project_title="Climate Action Newsletter",
+            project_id=1,
+            task_id=42,
+            days_inactive=14,
+            activity_phrase="you were assigned this task",
+            last_activity_date="16 April 2026",
+        ),
+    },
+    {
+        "key": "final-warning",
+        "label": "Final warning",
+        "params": {
+            "name": "Alex Johnson",
+            "task_title": "Write fundraising copy",
+            "project_title": "Climate Action Newsletter",
+            "days_inactive": 21,
+            "activity_phrase": "you last updated this task",
+            "last_activity_date": "9 April 2026",
+            "surrender_date": "7 May 2026",
+        },
+        "compose": lambda: compose_task_final_warning_email(
+            name="Alex Johnson",
+            task_title="Write fundraising copy",
+            project_title="Climate Action Newsletter",
+            project_id=1,
+            task_id=42,
+            days_inactive=21,
+            activity_phrase="you last updated this task",
+            last_activity_date="9 April 2026",
+            surrender_date="7 May 2026",
+        ),
+    },
+    {
+        "key": "surrendered-assignee",
+        "label": "Surrendered — assignee",
+        "params": {
+            "name": "Alex Johnson",
+            "task_title": "Write fundraising copy",
+            "project_title": "Climate Action Newsletter",
+        },
+        "compose": lambda: compose_task_surrendered_assignee_email(
+            name="Alex Johnson",
+            task_title="Write fundraising copy",
+            project_title="Climate Action Newsletter",
+            project_id=1,
+        ),
+    },
+    {
+        "key": "surrendered-owner",
+        "label": "Surrendered — owner",
+        "params": {
+            "owner_name": "Sam Rivera",
+            "volunteer_name": "Alex Johnson",
+            "task_title": "Write fundraising copy",
+            "project_title": "Climate Action Newsletter",
+        },
+        "compose": lambda: compose_task_surrendered_owner_email(
+            owner_name="Sam Rivera",
+            volunteer_name="Alex Johnson",
+            task_title="Write fundraising copy",
+            project_title="Climate Action Newsletter",
+            project_id=1,
+        ),
+    },
+    {
+        "key": "welcome",
+        "label": "Welcome",
+        "params": {"name": "Alex Johnson"},
+        "compose": lambda: compose_welcome_email(name="Alex Johnson"),
+    },
+    {
+        "key": "password-reset",
+        "label": "Password reset",
+        "params": {"name": "Alex Johnson", "reset_token": "example-reset-token-abc123"},
+        "compose": lambda: compose_password_reset_email(
+            reset_token="example-reset-token-abc123",
+            name="Alex Johnson",
+        ),
+    },
+    {
+        "key": "admin-invite",
+        "label": "Admin invite",
+        "params": {"invited_by": "Sam Rivera", "invite_token": "example-invite-token-xyz789"},
+        "compose": lambda: compose_admin_invite_email(
+            invite_token="example-invite-token-xyz789",
+            invited_by="Sam Rivera",
+        ),
+    },
+    {
+        "key": "digest",
+        "label": "Project digest",
+        "params": {
+            "name": "Alex Johnson",
+            "is_match": True,
+            "projects": "Climate Action Newsletter (92% match), Social Media Campaign",
+        },
+        "compose": lambda: compose_digest_email(
+            name="Alex Johnson",
+            projects=[
+                {
+                    "id": 1,
+                    "title": "Climate Action Newsletter",
+                    "description": "Help us produce a monthly newsletter covering climate action stories, volunteer spotlights, and upcoming events for the PauseAI community.",
+                    "skill_names": ["Writing", "Editing", "Communications"],
+                    "match_percent": 92,
+                },
+                {
+                    "id": 2,
+                    "title": "Social Media Campaign",
+                    "description": "Create and schedule social media content across Twitter, Instagram, and LinkedIn to grow PauseAI's online presence.",
+                    "skill_names": ["Social Media", "Graphic Design"],
+                    "match_percent": None,
+                },
+            ],
+            is_match=True,
+        ),
+    },
+    {
+        "key": "project-notification",
+        "label": "Project notification",
+        "params": {
+            "name": "Alex Johnson",
+            "project_title": "Climate Action Newsletter",
+            "subject": "You've been approved for Climate Action Newsletter",
+        },
+        "compose": lambda: compose_project_notification_email(
+            name="Alex Johnson",
+            subject="You've been approved for Climate Action Newsletter",
+            message="Great news — Sam Rivera has approved your request to join the project. You can now view the full project details and get started.",
+            project_title="Climate Action Newsletter",
+            project_id=1,
+        ),
+    },
+    {
+        "key": "relay",
+        "label": "Relay message",
+        "params": {
+            "to_name": "Alex Johnson",
+            "from_name": "Sam Rivera",
+            "from_email": "sam@example.com",
+            "project_title": "Climate Action Newsletter",
+            "subject": "Welcome to the project!",
+        },
+        "compose": lambda: compose_relay_message(
+            to_name="Alex Johnson",
+            from_name="Sam Rivera",
+            from_email="sam@example.com",
+            subject="Welcome to the project!",
+            message="Hi Alex, really glad to have you on board. Let me know if you have any questions about the fundraising copy task — happy to jump on a call.",
+            project_title="Climate Action Newsletter",
+        ),
+    },
+]
+
+
+def build_index() -> str:
+    sections = []
+    for preview in PREVIEWS:
+        subject, email_html = preview["compose"]()
+
+        params_rows = "".join(
+            f"<tr><td>{html_module.escape(k)}</td><td>{html_module.escape(str(v))}</td></tr>"
+            for k, v in preview["params"].items()
+        )
+
+        # srcdoc requires attribute-escaped HTML (double quotes → &quot;)
+        srcdoc = html_module.escape(email_html, quote=True)
+
+        sections.append(f"""
+        <section id="{preview['key']}">
+            <h2>{html_module.escape(preview['label'])}</h2>
+            <div class="row">
+                <div class="meta">
+                    <div class="subject-line">
+                        <span class="pill">Subject</span>
+                        {html_module.escape(subject)}
+                    </div>
+                    <table class="params">
+                        <thead><tr><th>Param</th><th>Value</th></tr></thead>
+                        <tbody>{params_rows}</tbody>
+                    </table>
+                </div>
+                <div class="preview-box">
+                    <iframe srcdoc="{srcdoc}" sandbox="allow-same-origin"></iframe>
+                </div>
+            </div>
+        </section>
+        """)
+
+    nav_links = " &middot; ".join(
+        f'<a href="#{p["key"]}">{html_module.escape(p["label"])}</a>'
+        for p in PREVIEWS
+    )
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Email Previews — Catalyse</title>
+  <style>
+    *, *::before, *::after {{ box-sizing: border-box; }}
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f7fafc; color: #1a202c; margin: 0; padding: 0;
+    }}
+    header {{
+      position: sticky; top: 0; z-index: 100;
+      background: #1a202c; color: #e2e8f0;
+      padding: 12px 32px; display: flex; align-items: baseline; gap: 24px;
+    }}
+    header h1 {{ margin: 0; font-size: 16px; color: #FF9416; white-space: nowrap; }}
+    nav {{ font-size: 13px; flex: 1; overflow-x: auto; white-space: nowrap; }}
+    nav a {{ color: #a0aec0; text-decoration: none; margin-right: 4px; }}
+    nav a:hover {{ color: #FF9416; }}
+    main {{ padding: 32px; max-width: 1400px; margin: 0 auto; }}
+    section {{ margin-bottom: 64px; }}
+    section h2 {{
+      font-size: 18px; margin: 0 0 16px;
+      padding-bottom: 8px; border-bottom: 2px solid #FF9416;
+      display: inline-block;
+    }}
+    .row {{
+      display: grid;
+      grid-template-columns: 300px 1fr;
+      gap: 24px;
+      align-items: start;
+    }}
+    .meta {{ display: flex; flex-direction: column; gap: 12px; }}
+    .subject-line {{
+      background: white; border: 1px solid #e2e8f0; border-radius: 8px;
+      padding: 12px 14px; font-size: 13px; line-height: 1.5; color: #2d3748;
+    }}
+    .pill {{
+      display: inline-block; background: #FF9416; color: white;
+      font-size: 10px; font-weight: bold; letter-spacing: 0.05em;
+      padding: 2px 6px; border-radius: 4px; margin-right: 6px;
+      vertical-align: middle;
+    }}
+    table.params {{
+      width: 100%; border-collapse: collapse; font-size: 12px;
+      background: white; border: 1px solid #e2e8f0; border-radius: 8px;
+      overflow: hidden;
+    }}
+    table.params th, table.params td {{
+      padding: 8px 12px; text-align: left; border-bottom: 1px solid #f0f4f8;
+    }}
+    table.params th {{ background: #f7fafc; color: #718096; font-weight: 600; }}
+    table.params td:first-child {{ color: #718096; white-space: nowrap; }}
+    table.params tr:last-child td {{ border-bottom: none; }}
+    .preview-box {{
+      border: 1px solid #e2e8f0; border-radius: 8px;
+      overflow: hidden; background: white;
+    }}
+    .preview-box iframe {{
+      width: 100%; height: 0; border: none; display: block;
+    }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Email Previews</h1>
+    <nav>{nav_links}</nav>
+  </header>
+  <main>
+    {"".join(sections)}
+  </main>
+  <script>
+    document.querySelectorAll('iframe').forEach(function(frame) {{
+      frame.addEventListener('load', function() {{
+        frame.style.height = frame.contentDocument.documentElement.scrollHeight + 'px';
+      }});
+    }});
+  </script>
+</body>
+</html>"""
+
+
+class PreviewHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        path = urlparse(self.path).path.lstrip("/")
+        if path == "" or path == "index.html":
+            self._respond(200, build_index())
+        else:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"Not found")
+
+    def _respond(self, status, html):
+        body = html.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class ReusableHTTPServer(HTTPServer):
+    allow_reuse_address = True
+
+    def server_bind(self):
+        import socket
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        super().server_bind()
+
+
+if __name__ == "__main__":
+    server = ReusableHTTPServer(("127.0.0.1", PORT), PreviewHandler)
+    print(f"Email preview server running at http://localhost:{PORT}")
+    print("Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        sys.exit(0)

--- a/preview_emails_plaintext.py
+++ b/preview_emails_plaintext.py
@@ -1,0 +1,127 @@
+"""
+Renders all email templates as plain markdown and prints them to stdout.
+Run with:
+
+    python preview_emails_plaintext.py
+
+Or pipe to a pager:
+
+    python preview_emails_plaintext.py | less
+"""
+
+import os
+import re
+from html.parser import HTMLParser
+
+os.environ.setdefault("APP_URL", "http://localhost:8000")
+
+from preview_emails import PREVIEWS
+
+
+class _HtmlToMarkdown(HTMLParser):
+    """Minimal HTML → Markdown converter sufficient for the email templates."""
+
+    _BLOCK_TAGS = {"div", "p", "ul", "ol", "blockquote"}
+    _SKIP_TAGS  = {"head", "style", "script"}
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+        self._skip_depth = 0
+        self._href: str | None = None
+        self._link_text: list[str] = []
+        self._collecting_link = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
+            return
+
+        attrs = dict(attrs)
+
+        if tag in ("h1", "h2", "h3"):
+            hashes = "#" * int(tag[1])
+            self._out.append(f"\n\n{hashes} ")
+        elif tag == "div" and "footer" in attrs.get("class", ""):
+            self._out.append("\n\n___\n\n")
+        elif tag in self._BLOCK_TAGS:
+            self._out.append("\n\n")
+        elif tag == "br":
+            self._out.append("\n")
+        elif tag == "li":
+            self._out.append("\n- ")
+        elif tag in ("strong", "b"):
+            self._out.append("**")
+        elif tag in ("em", "i"):
+            self._out.append("_")
+        elif tag == "a":
+            self._href = attrs.get("href", "")
+            self._collecting_link = True
+            self._link_text = []
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP_TAGS:
+            self._skip_depth -= 1
+            return
+        if self._skip_depth:
+            return
+
+        if tag in ("h1", "h2", "h3"):
+            self._out.append("\n")
+        elif tag in self._BLOCK_TAGS:
+            self._out.append("\n")
+        elif tag in ("strong", "b"):
+            self._out.append("**")
+        elif tag in ("em", "i"):
+            self._out.append("_")
+        elif tag == "a":
+            text = "".join(self._link_text).strip()
+            href = self._href or ""
+            # Don't duplicate when the text IS the URL
+            if text and text != href:
+                self._out.append(f"{text} ({href})")
+            else:
+                self._out.append(href)
+            self._collecting_link = False
+            self._href = None
+            self._link_text = []
+
+    def handle_data(self, data):
+        if self._skip_depth:
+            return
+        if self._collecting_link:
+            self._link_text.append(data)
+        else:
+            self._out.append(data)
+
+    def markdown(self) -> str:
+        text = "".join(self._out)
+        text = re.sub(r" +", " ", text)                        # collapse spaces
+        text = re.sub(r"[ \t]+\n", "\n", text)                 # strip trailing whitespace on lines
+        text = re.sub(r"\n[ \t]+\n", "\n\n", text)             # blank lines with only spaces → empty
+        text = re.sub(r"\n{3,}", "\n\n", text)                 # max one blank line
+        return text.strip()
+
+
+def html_to_markdown(html: str) -> str:
+    parser = _HtmlToMarkdown()
+    parser.feed(html)
+    return parser.markdown()
+
+
+def main():
+    for i, preview in enumerate(PREVIEWS):
+        subject, html = preview["compose"]()
+        body = html_to_markdown(html)
+
+        if i > 0:
+            print("\n")
+        print(f"> {preview['label']}")
+        print(f"**Subject:** {subject}\n")
+        print(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -65,7 +65,7 @@
                 </p>
                 <ul style="margin-bottom: 16px; padding-left: 20px; color: var(--text-light);">
                     <li><strong>Consent</strong> — for sharing your profile with other volunteers and allowing project owners to contact you (you can withdraw consent at any time via your profile settings)</li>
-                    <li><strong>Legitimate interest</strong> — for operating the platform, matching volunteers with projects, and platform administration</li>
+                    <li><strong>Legitimate interest</strong> — for operating the platform, matching volunteers with projects, platform administration, and sending inactivity reminders to volunteers who have claimed a task</li>
                     <li><strong>Contract performance</strong> — for providing you the service you signed up for</li>
                 </ul>
 
@@ -76,6 +76,7 @@
                     <li>To send you transactional emails (password resets, admin invites, welcome emails)</li>
                     <li>To relay messages between volunteers via email (the sender's email is included as reply-to so you can respond directly)</li>
                     <li>To send you notifications about your projects and interests</li>
+                    <li>To send you inactivity reminder emails if you have claimed a project task and there has been no update for a week or more — these are sent on the basis of legitimate interest and are a direct consequence of the commitment made when claiming a task</li>
                     <li>For platform administration and volunteer coordination</li>
                 </ul>
 

--- a/static/project.html
+++ b/static/project.html
@@ -631,7 +631,10 @@
                         </div>
                         <div style="display: flex; gap: 4px; flex-shrink: 0;">
                             ${t.status === 'open' && currentUser ? `
-                                <button class="btn btn-small btn-secondary" onclick="claimTask(${t.id})">Claim</button>
+                                <div style="text-align: right;">
+                                    <button class="btn btn-small btn-secondary" onclick="claimTask(${t.id})">Claim</button>
+                                    <p style="font-size: 0.7rem; color: var(--text-light); margin-top: 4px;">By claiming this task you may receive inactivity reminder emails.</p>
+                                </div>
                             ` : ''}
                             ${t.status === 'assigned' && t.assigned_to_id === currentUser?.id ? `
                                 <button class="btn btn-small btn-primary" onclick="completeTask(${t.id})">Done</button>

--- a/static/project.html
+++ b/static/project.html
@@ -266,6 +266,10 @@
                 renderProject();
                 document.getElementById('loadingState').style.display = 'none';
                 document.getElementById('projectContent').style.display = 'block';
+                if (location.hash) {
+                    const el = document.querySelector(location.hash);
+                    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
             } catch (error) {
                 showMessage(error.message, 'error');
                 document.getElementById('loadingState').innerHTML = `
@@ -616,7 +620,7 @@
             document.getElementById('tasksEmpty').style.display = 'none';
 
             document.getElementById('tasksList').innerHTML = project.tasks.map(t => `
-                <div class="card" style="margin-bottom: 8px; padding: 12px 16px;">
+                <div id="task-${t.id}" class="card" style="margin-bottom: 8px; padding: 12px 16px;">
                     <div style="display: flex; justify-content: space-between; align-items: start; gap: 12px;">
                         <div style="flex: 1;">
                             <div style="display: flex; align-items: center; gap: 8px;">


### PR DESCRIPTION
## Summary

- Project tasks can now only be assigned to accepted project contributors or the project owner
- Project contributors, owners, and admins can post comments on tasks to report progress
- A daily cron checks assigned tasks for inactivity (measured from assignment date or last comment): nudge at 7 days, final warning at 14 days, automatic unassignment and owner notification at 21 days
- Privacy policy and task claim UI updated to disclose inactivity reminder emails (legitimate interest basis)

## Inactivity reminder schedule

Activity is measured from the later of: the date the task was assigned, or the date of the last comment.

| Days inactive | Action |
|---|---|
| 7 | Nudge email sent to assignee |
| 14 | Final warning email sent to assignee |
| 7 days after final warning | Task unassigned; assignee and owner notified |

The surrender is triggered 7 days after the final warning was sent (not at a fixed day count from assignment), so a missed cron run cannot cause the assignee to skip the final warning or lose the guaranteed 7-day notice window.

## Email content

**Nudge (day 7)**
> Hi Sarah,
>
> It's been 7 days since you were assigned this task on **Write fundraising copy** in the project **Climate Action Newsletter** (on 22 April 2026).
>
> Could you leave a quick comment with a progress update? This helps the project owner stay informed and keeps things moving.
>
> [View Task]

**Final warning (day 14)**
> Hi Sarah,
>
> It's now been 14 days since you last updated this task on **Write fundraising copy** in **Climate Action Newsletter** (on 22 April 2026).
>
> **If there is no update within the next 7 days, you will be automatically removed from this task** so someone else can take it on.
>
> Please leave a comment with a progress update — even a brief one — to keep the task assigned to you.
>
> [View Task]

**Surrender — assignee notification**
> Hi Sarah,
>
> You have been removed from the task **Write fundraising copy** in **Climate Action Newsletter** after three weeks of inactivity despite reminders.
>
> The task is now open for another contributor to claim.

**Surrender — owner notification**
> Hi Alex,
>
> **Sarah Jones** has been removed from the task **Write fundraising copy** in your project **Climate Action Newsletter** after three weeks of inactivity despite reminders.
>
> The task is now open and can be claimed by another contributor.
>
> [View Project]

Each email links directly to the relevant task via an anchor (`#task-{id}`), which the project page scrolls to on load.

## Test plan

- [ ] Attempt to assign a task to a non-contributor — expect 400
- [ ] Assign a task to an accepted contributor — expect success
- [ ] Post a comment on a task as a contributor, owner, and admin — expect success
- [ ] Attempt to comment as a non-contributor — expect 403
- [ ] Verify `assigned_at` is set when a task is claimed, and nudge columns reset on new comment
- [ ] Run `check_task_inactivity()` manually against a task with a backdated `assigned_at` and confirm correct emails fire at each threshold
- [ ] Verify that a task at 21+ days with no `final_warning_sent_at` receives the final warning rather than being surrendered immediately
- [ ] Verify the task anchor link in emails scrolls to the correct task on the project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)