### PR TITLE
Fix: save button blocked when only seeking checkboxes changed

### DIFF
--- a/static/edit-project.html
+++ b/static/edit-project.html
@@ -267,6 +267,8 @@
                    form.collaboration_link.value.trim() !== (project.collaboration_link || '') ||
                    (form.country.value || '') !== (project.country || '') ||
                    (form.local_group.value || '') !== (project.local_group || '') ||
+                   form.is_seeking_help.checked !== (project.is_seeking_help || false) ||
+                   form.is_seeking_owner.checked !== (project.is_seeking_owner || false) ||
                    currentSkills !== originalSkills;
         }
 


### PR DESCRIPTION
## Summary

- `hasFormChanged()` on `edit-project.html` was missing checks for the `is_seeking_help` and `is_seeking_owner` checkboxes
- Toggling either checkbox alone caused the form to report no changes, blocking the save

## Test plan

- [ ] Open an existing project in edit mode
- [ ] Toggle only the "Help / contributors" checkbox and click Save — should save successfully
- [ ] Toggle only the "An owner / lead" checkbox and click Save — should save successfully
- [ ] Confirm no changes still shows "No changes to save."

🤖 Generated with [Claude Code](https://claude.com/claude-code)