### PR TITLE
fix: route approved projects with owners to needs_tasks, not in_progress

### DIFF
--- a/api.py
+++ b/api.py
@@ -2532,7 +2532,14 @@ def review_project(
         if data.status == "approved":
             # Determine lifecycle status and seeking flags
             has_owner = project["owner_id"] is not None
-            new_status = "needs_tasks" if has_owner else "in_progress"
+            if has_owner:
+                open_task_count = conn.execute(
+                    "SELECT COUNT(*) FROM project_tasks WHERE project_id = ? AND status != 'done'",
+                    (project_id,)
+                ).fetchone()[0]
+                new_status = "in_progress" if open_task_count > 0 else "needs_tasks"
+            else:
+                new_status = "in_progress"
             target = data.target_status or "seeking_owner"
 
             # Build update with seeking flags if columns exist

--- a/api.py
+++ b/api.py
@@ -3671,10 +3671,14 @@ def respond_to_interest(
             f"/static/project.html?id={project_id}"
         )
 
-        # If accepting as owner, assign them and move to needs_tasks so they can
-        # set up tasks before starting (unless the project is already in_progress)
+        # If accepting as owner, assign them. Move to in_progress if there are
+        # already open tasks, otherwise needs_tasks so the owner can add them first.
         if data.status == "accepted" and interest["interest_type"] == "want_to_own":
-            new_status = 'in_progress' if project["status"] == 'in_progress' else 'needs_tasks'
+            open_task_count = conn.execute(
+                "SELECT COUNT(*) FROM project_tasks WHERE project_id = ? AND status != 'done'",
+                (project_id,)
+            ).fetchone()[0]
+            new_status = 'in_progress' if open_task_count > 0 else 'needs_tasks'
             conn.execute(
                 "UPDATE projects SET owner_id = ?, status = ? WHERE id = ?",
                 (interest["volunteer_id"], new_status, project_id)

--- a/api.py
+++ b/api.py
@@ -2532,7 +2532,7 @@ def review_project(
         if data.status == "approved":
             # Determine lifecycle status and seeking flags
             has_owner = project["owner_id"] is not None
-            new_status = "in_progress" if has_owner else "in_progress"
+            new_status = "needs_tasks" if has_owner else "in_progress"
             target = data.target_status or "seeking_owner"
 
             # Build update with seeking flags if columns exist
@@ -2635,7 +2635,7 @@ def create_org_project(
 ) -> Dict:
     """Create an org-proposed project (skips review)."""
     with db_transaction() as conn:
-        status = "in_progress" if data.want_to_own else "in_progress"
+        status = "needs_tasks" if data.want_to_own else "in_progress"
 
         proj_columns = {row["name"] for row in conn.execute("PRAGMA table_info(projects)").fetchall()}
         proj_fields = {

--- a/static/project.html
+++ b/static/project.html
@@ -540,7 +540,11 @@
 
         function onStatusSelectChange() {
             const hint = document.getElementById('inProgressHint');
-            if (hint) hint.style.display = document.getElementById('statusSelect').value === 'in_progress' ? 'block' : 'none';
+            if (hint) {
+                const movingToInProgress = document.getElementById('statusSelect').value === 'in_progress'
+                    && project.status !== 'in_progress';
+                hint.style.display = movingToInProgress ? 'block' : 'none';
+            }
         }
 
         async function updateProjectStatus() {


### PR DESCRIPTION
## Summary

- `review_project` and `create_org_project` both had a ternary with identical branches (`"in_progress" if ... else "in_progress"`), so `new_status` was always `in_progress` — bypassing the `needs_tasks` gate added in #33
- When an admin approves a project that already has an owner, it now correctly routes to `needs_tasks` so the owner can add tasks before the project starts
- Fixes the misleading "Moving to In Progress requires at least one open task" hint on `project.html`, which was showing even when the project was *already* in `in_progress` — confusing owners of legacy projects into thinking they were blocked

## Root cause

The bug was reported for project "Help with London events" (created 28 Apr, approved 29 Apr after #33 landed). It went straight to `in_progress` with zero tasks because `review_project` never got the `needs_tasks` update that the interest-acceptance flow did.

## Test plan

- [ ] Admin approves a volunteer-proposed project that has `want_to_own: true` → project moves to `needs_tasks`, not `in_progress`
- [ ] Admin creates an org project with `want_to_own: true` → project moves to `needs_tasks`
- [ ] Owner of a `needs_tasks` project adds tasks then changes status to `in_progress` → succeeds
- [ ] Owner of a legacy `in_progress` project with no tasks sees no warning hint and can add tasks freely
- [ ] Selecting `in_progress` in the status dropdown from a non-`in_progress` project still shows the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)