### PR TITLE
fix: add schema_migrations tracking to prevent migrations re-running

### DIFF
--- a/api.py
+++ b/api.py
@@ -223,7 +223,23 @@ def run_migrations():
         return
 
     conn = get_db()
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            filename TEXT PRIMARY KEY,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.commit()
+
     for migration_path in migration_files:
+        already_applied = conn.execute(
+            "SELECT 1 FROM schema_migrations WHERE filename = ?",
+            (migration_path.name,)
+        ).fetchone()
+        if already_applied:
+            continue
+
         with open(migration_path) as f:
             sql = f.read()
 
@@ -241,15 +257,17 @@ def run_migrations():
                 conn.execute(non_comment)
                 applied += 1
             except Exception as e:
-                # "already exists" / "duplicate column" are safe to skip
                 err = str(e).lower()
                 if "already exists" not in err and "duplicate column" not in err:
                     print(f"Migration {migration_path.name}: {e}")
 
-        if applied:
-            print(f"Migration applied: {migration_path.name} ({applied} statements)")
+        conn.execute(
+            "INSERT INTO schema_migrations (filename) VALUES (?)",
+            (migration_path.name,)
+        )
+        conn.commit()
+        print(f"Migration applied: {migration_path.name} ({applied} statements)")
 
-    conn.commit()
     conn.close()
 
 

--- a/migration_000_seed_schema_migrations.sql
+++ b/migration_000_seed_schema_migrations.sql
@@ -1,0 +1,21 @@
+-- Migration 000: Seed schema_migrations for pre-existing databases
+-- Marks migrations 001-009 as already applied so they are not re-run on existing installs.
+-- The WHERE EXISTS guard ensures this is a no-op on fresh databases where project_tasks
+-- does not yet exist and the real migrations still need to run.
+
+INSERT OR IGNORE INTO schema_migrations (filename)
+SELECT filename FROM (
+    VALUES
+        ('migration_001_features.sql'),
+        ('migration_002_admin_bugs.sql'),
+        ('migration_003_passwords.sql'),
+        ('migration_004_project_tasks.sql'),
+        ('migration_005_country.sql'),
+        ('migration_006_email_digest.sql'),
+        ('migration_007_seeking_flags.sql'),
+        ('migration_008_local_group.sql'),
+        ('migration_009_needs_tasks_status.sql')
+) AS t(filename)
+WHERE EXISTS (
+    SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'project_tasks'
+);


### PR DESCRIPTION
## Summary

- `run_migrations()` had no tracking and re-ran all migrations on every app restart
- `migration_009` drops and recreates the `projects` table with `PRAGMA foreign_keys=OFF` — if the PRAGMA was silently ignored due to an open transaction, the `DROP TABLE` would cascade-delete all `project_tasks` rows (likely cause of the reported task disappearances)
- Adds a `schema_migrations` table; each migration is recorded when first applied and skipped on all future restarts
- Adds `migration_000` to seed existing installs so 001–009 aren't re-run on first deploy (no-op on fresh databases)

## Test plan

- [ ] Deploy to production and confirm startup logs show migrations skipped
- [ ] Confirm `schema_migrations` table is populated with 000–009
- [ ] Create a project task and redeploy — verify task survives the restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)