### PR TITLE
feat: Next.js auth routes (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.db
+*.db-*
 backups/
 __pycache__/
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
-.PHONY: dev install build serve test test-headed test-debug test-smoke scenario scenarios scenario-clean
+.PHONY: dev dev-next install build serve test test-headed test-debug test-smoke scenario scenarios scenario-clean
 
-# Start the development server on http://localhost:8001
+# Start the FastAPI development server on http://localhost:8001
 dev:
 	. venv/bin/activate && python api.py
+
+# Start the Next.js development server on http://localhost:3001
+# Run alongside 'make dev' during the strangler fig migration (Phases 2-7).
+# Auth routes (and later, other routes) are served from Next.js.
+dev-next:
+	cd web && PORT=3001 npm run dev
 
 # Build dist/ from static/, injecting content-hash query params into HTML files
 build:

--- a/api.py
+++ b/api.py
@@ -545,7 +545,7 @@ def get_current_volunteer(authorization: Optional[str] = Header(None)) -> Option
            WHERE auth_token = ?
            AND (auth_token_expires_at IS NULL OR auth_token_expires_at > ?)
            AND deleted_at IS NULL""",
-        (token, datetime.now().isoformat())
+        (token, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
     ).fetchone()
     conn.close()
 
@@ -754,7 +754,7 @@ def signup(data: VolunteerSignup) -> Dict:
             "location": data.location, "share_contact_directly": data.share_contact_directly,
             "other_skills": data.other_skills, "consent_profile_visible": data.consent_profile_visible,
             "consent_contact_by_owners": data.consent_contact_by_owners,
-            "consent_given_at": datetime.now().isoformat(),
+            "consent_given_at": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
             "auth_token": auth_token, "password_hash": password_hash
         }
         # Add optional columns only if they exist in the DB
@@ -792,7 +792,7 @@ def signup(data: VolunteerSignup) -> Dict:
             pending_invite = conn.execute(
                 """SELECT * FROM admin_invites
                    WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
-                (data.email, datetime.now().isoformat())
+                (data.email, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             ).fetchone()
             print(f"[ADMIN_INVITE] Signup check for {data.email}: pending_invite={'found id=' + str(pending_invite['id']) if pending_invite else 'none'}")
             if pending_invite:
@@ -804,7 +804,7 @@ def signup(data: VolunteerSignup) -> Dict:
                     """UPDATE admin_invites
                        SET status = 'accepted', accepted_by_id = ?, accepted_at = ?
                        WHERE id = ?""",
-                    (volunteer_id, datetime.now().isoformat(), pending_invite["id"])
+                    (volunteer_id, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), pending_invite["id"])
                 )
                 print(f"[ADMIN_INVITE] Auto-accepted invite for {data.email} on signup")
         except AppError:
@@ -882,7 +882,7 @@ def login(data: LoginRequest) -> Dict:
         pending_invite = conn.execute(
             """SELECT * FROM admin_invites
                WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
-            (data.email, datetime.now().isoformat())
+            (data.email, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
         ).fetchone()
         print(f"[ADMIN_INVITE] Login check for {data.email}: pending_invite={'found id=' + str(pending_invite['id']) if pending_invite else 'none'}")
         if pending_invite:
@@ -894,7 +894,7 @@ def login(data: LoginRequest) -> Dict:
                 """UPDATE admin_invites
                    SET status = 'accepted', accepted_by_id = ?, accepted_at = ?
                    WHERE id = ?""",
-                (volunteer["id"], datetime.now().isoformat(), pending_invite["id"])
+                (volunteer["id"], datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), pending_invite["id"])
             )
             was_promoted = True
             print(f"[ADMIN_INVITE] Auto-accepted invite for {data.email} on login")
@@ -905,7 +905,7 @@ def login(data: LoginRequest) -> Dict:
     with db_transaction() as conn:
         conn.execute(
             "UPDATE volunteers SET auth_token = ?, updated_at = ? WHERE id = ?",
-            (auth_token, datetime.now().isoformat(), volunteer["id"])
+            (auth_token, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), volunteer["id"])
         )
 
     result = {
@@ -995,7 +995,7 @@ def google_auth(data: GoogleAuthRequest) -> Dict:
         with db_transaction() as conn:
             conn.execute(
                 "UPDATE volunteers SET auth_token = ?, updated_at = ? WHERE id = ?",
-                (auth_token, datetime.now().isoformat(), existing["id"])
+                (auth_token, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), existing["id"])
             )
 
         # Check for admin bootstrap
@@ -1006,13 +1006,13 @@ def google_auth(data: GoogleAuthRequest) -> Dict:
             pending_invite = conn.execute(
                 """SELECT * FROM admin_invites
                    WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
-                (email, datetime.now().isoformat())
+                (email, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             ).fetchone()
             if pending_invite:
                 conn.execute("UPDATE volunteers SET is_admin = 1 WHERE id = ?", (existing["id"],))
                 conn.execute(
                     """UPDATE admin_invites SET status = 'accepted', accepted_by_id = ?, accepted_at = ? WHERE id = ?""",
-                    (existing["id"], datetime.now().isoformat(), pending_invite["id"])
+                    (existing["id"], datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), pending_invite["id"])
                 )
                 was_promoted = True
 
@@ -1031,7 +1031,7 @@ def google_auth(data: GoogleAuthRequest) -> Dict:
                     name, email, auth_token,
                     consent_profile_visible, consent_contact_by_owners, consent_given_at
                 ) VALUES (?, ?, ?, ?, ?, ?)""",
-                (name, email, auth_token, True, True, datetime.now().isoformat())
+                (name, email, auth_token, True, True, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             )
             volunteer_id = cursor.lastrowid
 
@@ -1047,13 +1047,13 @@ def google_auth(data: GoogleAuthRequest) -> Dict:
                 pending_invite = conn.execute(
                     """SELECT * FROM admin_invites
                        WHERE LOWER(email) = LOWER(?) AND status = 'pending' AND expires_at > ?""",
-                    (email, datetime.now().isoformat())
+                    (email, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
                 ).fetchone()
                 if pending_invite:
                     conn.execute("UPDATE volunteers SET is_admin = 1 WHERE id = ?", (volunteer_id,))
                     conn.execute(
                         """UPDATE admin_invites SET status = 'accepted', accepted_by_id = ?, accepted_at = ? WHERE id = ?""",
-                        (volunteer_id, datetime.now().isoformat(), pending_invite["id"])
+                        (volunteer_id, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), pending_invite["id"])
                     )
             except AppError:
                 raise
@@ -1098,13 +1098,13 @@ def forgot_password(data: ForgotPasswordRequest) -> Dict:
 
     # Generate reset token
     reset_token = secrets.token_urlsafe(32)
-    expires_at = (datetime.now() + timedelta(hours=1)).isoformat()
+    expires_at = (datetime.utcnow() + timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     with db_transaction() as conn:
         # Invalidate any existing tokens
         conn.execute(
             "UPDATE password_reset_tokens SET used_at = ? WHERE volunteer_id = ? AND used_at IS NULL",
-            (datetime.now().isoformat(), volunteer["id"])
+            (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), volunteer["id"])
         )
 
         # Create new token
@@ -1144,7 +1144,7 @@ def reset_password(data: ResetPasswordRequest) -> Dict:
              AND prt.used_at IS NULL
              AND prt.expires_at > ?
              AND v.deleted_at IS NULL""",
-        (data.token, datetime.now().isoformat())
+        (data.token, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
     ).fetchone()
     conn.close()
 
@@ -1158,13 +1158,13 @@ def reset_password(data: ResetPasswordRequest) -> Dict:
         # Update password
         conn.execute(
             "UPDATE volunteers SET password_hash = ?, auth_token = NULL, updated_at = ? WHERE id = ?",
-            (password_hash, datetime.now().isoformat(), token_record["volunteer_id"])
+            (password_hash, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), token_record["volunteer_id"])
         )
 
         # Mark token as used
         conn.execute(
             "UPDATE password_reset_tokens SET used_at = ? WHERE id = ?",
-            (datetime.now().isoformat(), token_record["id"])
+            (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), token_record["id"])
         )
 
     return {"message": "Password reset successful. Please log in with your new password."}
@@ -1193,7 +1193,7 @@ def change_password(
     with db_transaction() as conn:
         conn.execute(
             "UPDATE volunteers SET password_hash = ?, updated_at = ? WHERE id = ?",
-            (new_hash, datetime.now().isoformat(), volunteer["id"])
+            (new_hash, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), volunteer["id"])
         )
 
     return {"message": "Password changed successfully"}
@@ -1229,7 +1229,7 @@ def change_email(
             raise HTTPException(status_code=400, detail="This email is already registered to another account")
         conn.execute(
             "UPDATE volunteers SET email = ?, updated_at = ? WHERE id = ?",
-            (data.new_email, datetime.now().isoformat(), volunteer["id"])
+            (data.new_email, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), volunteer["id"])
         )
 
     return {"message": "Email changed successfully"}
@@ -1392,7 +1392,7 @@ def delete_account(
                 deleted_at = ?,
                 updated_at = ?
                WHERE id = ?""",
-            (datetime.now().isoformat(), datetime.now().isoformat(), volunteer["id"])
+            (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), volunteer["id"])
         )
 
         conn.execute(
@@ -1843,7 +1843,7 @@ def update_me(data: VolunteerUpdate, volunteer: Dict = Depends(require_auth)) ->
 
         if updates:
             updates.append("updated_at = ?")
-            params.append(datetime.now().isoformat())
+            params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             params.append(volunteer["id"])
 
             conn.execute(
@@ -2243,7 +2243,7 @@ def update_project(
 
         if updates:
             updates.append("updated_at = ?")
-            params.append(datetime.now().isoformat())
+            params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             params.append(project_id)
 
             conn.execute(
@@ -2472,7 +2472,7 @@ def update_project_task(
             params.append(data.status)
             if data.status == "done":
                 updates.append("completed_at = ?")
-                params.append(datetime.now().isoformat())
+                params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             elif data.status == "open":
                 updates.append("assigned_to_id = NULL")
                 updates.append("completed_at = NULL")
@@ -2482,7 +2482,7 @@ def update_project_task(
 
         if updates:
             updates.append("updated_at = ?")
-            params.append(datetime.now().isoformat())
+            params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             params.append(task_id)
             conn.execute(
                 f"UPDATE project_tasks SET {', '.join(updates)} WHERE id = ?",
@@ -2582,7 +2582,7 @@ def review_project(
                        WHERE id = ?""",
                     (new_status, is_seeking_help, is_seeking_owner,
                      data.review_notes, admin["id"],
-                     datetime.now().isoformat(), datetime.now().isoformat(), project_id)
+                     datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), project_id)
                 )
             else:
                 conn.execute(
@@ -2590,7 +2590,7 @@ def review_project(
                        status = ?, review_notes = ?, reviewed_by_id = ?, reviewed_at = ?, updated_at = ?
                        WHERE id = ?""",
                     (target, data.review_notes, admin["id"],
-                     datetime.now().isoformat(), datetime.now().isoformat(), project_id)
+                     datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), project_id)
                 )
 
             # Notify proposer
@@ -2633,7 +2633,7 @@ def review_project(
                    reviewed_by_id = ?, reviewed_at = ?, updated_at = ?
                    WHERE id = ?""",
                 (data.review_notes, data.feedback_to_proposer, admin["id"],
-                 datetime.now().isoformat(), datetime.now().isoformat(), project_id)
+                 datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), project_id)
             )
 
             # Notify proposer
@@ -2879,7 +2879,7 @@ def update_admin_note(
 
         if updates:
             updates.append("updated_at = ?")
-            params.append(datetime.now().isoformat())
+            params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             params.append(note_id)
             conn.execute(f"UPDATE admin_notes SET {', '.join(updates)} WHERE id = ?", params)
 
@@ -3009,7 +3009,7 @@ def assign_starter_task(
             """UPDATE starter_tasks
                SET assigned_to_id = ?, assigned_by_id = ?, status = 'assigned', updated_at = ?
                WHERE id = ?""",
-            (data.volunteer_id, admin["id"], datetime.now().isoformat(), task_id)
+            (data.volunteer_id, admin["id"], datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), task_id)
         )
 
         # Notify the volunteer
@@ -3039,7 +3039,7 @@ def submit_starter_task(
 
         conn.execute(
             "UPDATE starter_tasks SET status = 'submitted', updated_at = ? WHERE id = ?",
-            (datetime.now().isoformat(), task_id)
+            (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), task_id)
         )
 
         # Notify assigning admin
@@ -3078,7 +3078,7 @@ def review_starter_task(
                WHERE id = ?""",
             (new_status, data.review_rating, data.review_notes,
              data.feedback_to_volunteer, admin["id"],
-             datetime.now().isoformat(), datetime.now().isoformat(), task_id)
+             datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), task_id)
         )
 
         # Auto-create admin note based on outcome
@@ -3180,14 +3180,14 @@ def set_project_outcome(
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
 
-        completed_at = datetime.now().isoformat() if outcome in ("successful", "partial", "not_completed") else None
+        completed_at = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ') if outcome in ("successful", "partial", "not_completed") else None
 
         conn.execute(
             """UPDATE projects SET outcome = ?, outcome_notes = ?, completed_at = ?,
                status = CASE WHEN ? IN ('successful', 'partial', 'not_completed') THEN 'completed' ELSE status END,
                updated_at = ?
                WHERE id = ?""",
-            (outcome, outcome_notes, completed_at, outcome, datetime.now().isoformat(), project_id)
+            (outcome, outcome_notes, completed_at, outcome, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), project_id)
         )
 
         # Auto-create admin notes for volunteers involved
@@ -3308,7 +3308,7 @@ def list_admins(admin: Dict = Depends(require_admin)) -> List[Dict]:
 def invite_admin(data: AdminInviteCreate, admin: Dict = Depends(require_admin)) -> Dict:
     """Send an admin invite to an email address."""
     invite_token = secrets.token_urlsafe(32)
-    expires_at = (datetime.now() + timedelta(days=7)).isoformat()
+    expires_at = (datetime.utcnow() + timedelta(days=7)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     with db_transaction() as conn:
         # Check if already admin
@@ -3322,7 +3322,7 @@ def invite_admin(data: AdminInviteCreate, admin: Dict = Depends(require_admin)) 
         # Check for pending invite
         pending = conn.execute(
             "SELECT * FROM admin_invites WHERE email = ? AND status = 'pending' AND expires_at > ?",
-            (data.email, datetime.now().isoformat())
+            (data.email, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
         ).fetchone()
         if pending:
             raise HTTPException(status_code=400, detail="An invite is already pending for this email")
@@ -3364,7 +3364,7 @@ def accept_admin_invite(
     invite = conn.execute(
         """SELECT * FROM admin_invites
            WHERE invite_token = ? AND status = 'pending' AND expires_at > ?""",
-        (invite_token, datetime.now().isoformat())
+        (invite_token, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
     ).fetchone()
     conn.close()
 
@@ -3387,7 +3387,7 @@ def accept_admin_invite(
             """UPDATE admin_invites
                SET status = 'accepted', accepted_by_id = ?, accepted_at = ?
                WHERE id = ?""",
-            (volunteer["id"], datetime.now().isoformat(), invite["id"])
+            (volunteer["id"], datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), invite["id"])
         )
 
     return {"message": "You are now an admin!"}
@@ -3533,7 +3533,7 @@ def update_bug_report(
                 updates.append("resolved_by_id = ?")
                 params.append(admin["id"])
                 updates.append("resolved_at = ?")
-                params.append(datetime.now().isoformat())
+                params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
 
         if data.resolution_notes is not None:
             updates.append("resolution_notes = ?")
@@ -3589,7 +3589,7 @@ def assign_volunteer_to_project(
                 # Auto-accept existing pending interest
                 conn.execute(
                     "UPDATE project_interests SET status = 'accepted', responded_at = ? WHERE id = ?",
-                    (datetime.now().isoformat(), existing["id"])
+                    (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), existing["id"])
                 )
             elif existing["status"] == "accepted":
                 return {"message": "This volunteer is already assigned to this project"}
@@ -3598,7 +3598,7 @@ def assign_volunteer_to_project(
             conn.execute(
                 """INSERT INTO project_interests (volunteer_id, project_id, interest_type, message, status, responded_at)
                    VALUES (?, ?, ?, 'Assigned by admin/owner', 'accepted', ?)""",
-                (data.volunteer_id, project_id, data.interest_type, datetime.now().isoformat())
+                (data.volunteer_id, project_id, data.interest_type, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             )
 
         # Notify the volunteer
@@ -3770,7 +3770,7 @@ def respond_to_interest(
             """UPDATE project_interests
                SET status = ?, response_message = ?, responded_at = ?
                WHERE id = ?""",
-            (data.status, data.response_message, datetime.now().isoformat(), interest_id)
+            (data.status, data.response_message, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), interest_id)
         )
 
         # Notify the interested volunteer
@@ -3946,7 +3946,7 @@ def mark_message_read(
         result = conn.execute(
             """UPDATE contact_messages SET read_at = ?
                WHERE id = ? AND to_volunteer_id = ?""",
-            (datetime.now().isoformat(), message_id, volunteer["id"])
+            (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), message_id, volunteer["id"])
         )
         if result.rowcount == 0:
             raise HTTPException(status_code=404, detail="Message not found")
@@ -3984,7 +3984,7 @@ def mark_all_read(volunteer: Dict = Depends(require_auth)) -> Dict:
     with db_transaction() as conn:
         conn.execute(
             "UPDATE notifications SET read_at = ? WHERE volunteer_id = ? AND read_at IS NULL",
-            (datetime.now().isoformat(), volunteer["id"])
+            (datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), volunteer["id"])
         )
         return {"message": "All marked as read"}
 
@@ -4062,7 +4062,7 @@ def export_my_data(volunteer: Dict = Depends(require_auth)) -> Dict:
     conn.close()
 
     return {
-        "exported_at": datetime.now().isoformat(),
+        "exported_at": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
         "profile": profile,
         "skills": skills,
         "projects": rows_to_list(projects),

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -8,6 +8,8 @@ export const ADMIN_EMAIL = 'admin@e2e-test.com';
 export const ADMIN_PASSWORD = 'adminpassword1';
 
 export const BASE_PORT = 8002;
+// Next.js workers run at BASE_PORT - 4000 (e.g. 8002 → 4002)
+export const NEXT_BASE_PORT = BASE_PORT - 4000;
 export const WORKER_COUNT = 4;
 
 export function workerBaseUrl(parallelIndex: number): string {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -6,12 +6,14 @@ import path from 'path';
 import {
   IS_LOCAL, WORKER_COUNT,
   ADMIN_EMAIL, ADMIN_PASSWORD,
-  BASE_PORT,
+  BASE_PORT, NEXT_BASE_PORT,
   workerBaseUrl, workerDbDir, workerAuthFile,
   SERVER_PIDS_FILE,
 } from './config';
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
+const WEB_DIR = path.join(PROJECT_ROOT, 'web');
+const NEXT_BINARY = path.join(WEB_DIR, 'node_modules', '.bin', 'next');
 const VENV_PYTHON = path.join(PROJECT_ROOT, 'venv', 'bin', 'python3');
 const PYTHON = fs.existsSync(VENV_PYTHON) ? VENV_PYTHON : 'python3';
 
@@ -47,18 +49,39 @@ function startWorkerServer(parallelIndex: number): number {
   return server.pid!;
 }
 
-async function waitForServer(baseUrl: string): Promise<void> {
-  const deadline = Date.now() + 30_000;
+function startWorkerNextJs(parallelIndex: number): number {
+  const nextPort = NEXT_BASE_PORT + parallelIndex;
+  const dbDir = workerDbDir(parallelIndex);
+
+  killServerOnPort(nextPort);
+
+  const server = spawn(NEXT_BINARY, ['dev', '-p', String(nextPort)], {
+    env: {
+      ...process.env,
+      PORT: String(nextPort),
+      RAILWAY_VOLUME_MOUNT_PATH: dbDir,
+      RESEND_API_KEY: '',
+      STUB_EMAIL: 'true',
+    },
+    cwd: WEB_DIR,
+    detached: false,
+  });
+
+  return server.pid!;
+}
+
+async function waitForServer(baseUrl: string, path = '/api/skills', timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const r = await fetch(`${baseUrl}/api/skills`);
+      const r = await fetch(`${baseUrl}${path}`);
       if (r.ok) return;
     } catch {
       // not ready yet
     }
     await new Promise(r => setTimeout(r, 500));
   }
-  throw new Error(`Server at ${baseUrl} did not become ready within 30 seconds`);
+  throw new Error(`Server at ${baseUrl}${path} did not become ready within ${timeoutMs / 1000}s`);
 }
 
 async function setupAdminAuth(parallelIndex: number): Promise<void> {
@@ -103,12 +126,17 @@ async function globalSetup(): Promise<void> {
     const pids: Record<number, number> = {};
     for (let i = 0; i < WORKER_COUNT; i++) {
       pids[i] = startWorkerServer(i);
+      pids[`next_${i}`] = startWorkerNextJs(i);
     }
     fs.writeFileSync(SERVER_PIDS_FILE, JSON.stringify(pids));
 
-    await Promise.all(
-      Array.from({ length: WORKER_COUNT }, (_, i) => waitForServer(workerBaseUrl(i)))
-    );
+    // Wait for FastAPI and Next.js workers to be ready in parallel
+    await Promise.all([
+      ...Array.from({ length: WORKER_COUNT }, (_, i) => waitForServer(workerBaseUrl(i))),
+      ...Array.from({ length: WORKER_COUNT }, (_, i) =>
+        waitForServer(`http://localhost:${NEXT_BASE_PORT + i}`, '/api/health', 60_000)
+      ),
+    ]);
 
     await Promise.all(
       Array.from({ length: WORKER_COUNT }, (_, i) => setupAdminAuth(i))

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
-import { IS_LOCAL, WORKER_COUNT, BASE_PORT, SERVER_PIDS_FILE } from './config';
+import { IS_LOCAL, WORKER_COUNT, BASE_PORT, NEXT_BASE_PORT, SERVER_PIDS_FILE } from './config';
 
 function killServerOnPort(port: number): void {
   try {
@@ -14,7 +14,7 @@ async function globalTeardown(): Promise<void> {
   if (!IS_LOCAL) return;
 
   if (fs.existsSync(SERVER_PIDS_FILE)) {
-    const pids: Record<number, number> = JSON.parse(fs.readFileSync(SERVER_PIDS_FILE, 'utf8'));
+    const pids: Record<string, number> = JSON.parse(fs.readFileSync(SERVER_PIDS_FILE, 'utf8'));
     for (const pid of Object.values(pids)) {
       try { process.kill(pid, 'SIGTERM'); } catch { /* already exited */ }
     }
@@ -23,6 +23,7 @@ async function globalTeardown(): Promise<void> {
 
   for (let i = 0; i < WORKER_COUNT; i++) {
     killServerOnPort(BASE_PORT + i);
+    killServerOnPort(NEXT_BASE_PORT + i);
   }
 }
 

--- a/migration_010_fix_datetime_format.sql
+++ b/migration_010_fix_datetime_format.sql
@@ -1,0 +1,90 @@
+-- Migration 010: Normalise datetime format for Prisma compatibility
+--
+-- FastAPI previously stored explicit datetime values using Python's
+-- datetime.now().isoformat(), which produces "YYYY-MM-DDTHH:MM:SS.ssssss"
+-- (T separator, 6-digit microseconds, no timezone suffix).
+-- Prisma 6's SQLite driver cannot parse this format (P2023).
+--
+-- This migration rewrites all affected values to "YYYY-MM-DDTHH:MM:SSZ"
+-- (T separator, no fractional seconds, UTC Z suffix) — the format both
+-- FastAPI (after api.py fix) and Prisma 6 accept.
+--
+-- CURRENT_TIMESTAMP default values ("YYYY-MM-DD HH:MM:SS", space separator)
+-- are left untouched — Prisma 6 can read those already.
+--
+-- Guard: WHERE col LIKE '%T%' AND col NOT LIKE '%Z'
+--   matches only the old Python isoformat values.
+
+-- volunteers
+UPDATE volunteers SET consent_given_at = substr(consent_given_at, 1, 19) || 'Z'
+WHERE consent_given_at IS NOT NULL AND consent_given_at LIKE '%T%' AND consent_given_at NOT LIKE '%Z';
+
+UPDATE volunteers SET updated_at = substr(updated_at, 1, 19) || 'Z'
+WHERE updated_at IS NOT NULL AND updated_at LIKE '%T%' AND updated_at NOT LIKE '%Z';
+
+UPDATE volunteers SET deleted_at = substr(deleted_at, 1, 19) || 'Z'
+WHERE deleted_at IS NOT NULL AND deleted_at LIKE '%T%' AND deleted_at NOT LIKE '%Z';
+
+UPDATE volunteers SET auth_token_expires_at = substr(auth_token_expires_at, 1, 19) || 'Z'
+WHERE auth_token_expires_at IS NOT NULL AND auth_token_expires_at LIKE '%T%' AND auth_token_expires_at NOT LIKE '%Z';
+
+-- password_reset_tokens
+UPDATE password_reset_tokens SET expires_at = substr(expires_at, 1, 19) || 'Z'
+WHERE expires_at IS NOT NULL AND expires_at LIKE '%T%' AND expires_at NOT LIKE '%Z';
+
+UPDATE password_reset_tokens SET used_at = substr(used_at, 1, 19) || 'Z'
+WHERE used_at IS NOT NULL AND used_at LIKE '%T%' AND used_at NOT LIKE '%Z';
+
+-- admin_invites
+UPDATE admin_invites SET expires_at = substr(expires_at, 1, 19) || 'Z'
+WHERE expires_at IS NOT NULL AND expires_at LIKE '%T%' AND expires_at NOT LIKE '%Z';
+
+UPDATE admin_invites SET accepted_at = substr(accepted_at, 1, 19) || 'Z'
+WHERE accepted_at IS NOT NULL AND accepted_at LIKE '%T%' AND accepted_at NOT LIKE '%Z';
+
+-- projects
+UPDATE projects SET reviewed_at = substr(reviewed_at, 1, 19) || 'Z'
+WHERE reviewed_at IS NOT NULL AND reviewed_at LIKE '%T%' AND reviewed_at NOT LIKE '%Z';
+
+UPDATE projects SET completed_at = substr(completed_at, 1, 19) || 'Z'
+WHERE completed_at IS NOT NULL AND completed_at LIKE '%T%' AND completed_at NOT LIKE '%Z';
+
+UPDATE projects SET updated_at = substr(updated_at, 1, 19) || 'Z'
+WHERE updated_at IS NOT NULL AND updated_at LIKE '%T%' AND updated_at NOT LIKE '%Z';
+
+-- project_tasks
+UPDATE project_tasks SET completed_at = substr(completed_at, 1, 19) || 'Z'
+WHERE completed_at IS NOT NULL AND completed_at LIKE '%T%' AND completed_at NOT LIKE '%Z';
+
+UPDATE project_tasks SET updated_at = substr(updated_at, 1, 19) || 'Z'
+WHERE updated_at IS NOT NULL AND updated_at LIKE '%T%' AND updated_at NOT LIKE '%Z';
+
+-- starter_tasks
+UPDATE starter_tasks SET reviewed_at = substr(reviewed_at, 1, 19) || 'Z'
+WHERE reviewed_at IS NOT NULL AND reviewed_at LIKE '%T%' AND reviewed_at NOT LIKE '%Z';
+
+UPDATE starter_tasks SET updated_at = substr(updated_at, 1, 19) || 'Z'
+WHERE updated_at IS NOT NULL AND updated_at LIKE '%T%' AND updated_at NOT LIKE '%Z';
+
+-- admin_notes
+UPDATE admin_notes SET updated_at = substr(updated_at, 1, 19) || 'Z'
+WHERE updated_at IS NOT NULL AND updated_at LIKE '%T%' AND updated_at NOT LIKE '%Z';
+
+-- bug_reports
+UPDATE bug_reports SET resolved_at = substr(resolved_at, 1, 19) || 'Z'
+WHERE resolved_at IS NOT NULL AND resolved_at LIKE '%T%' AND resolved_at NOT LIKE '%Z';
+
+-- project_interests
+UPDATE project_interests SET responded_at = substr(responded_at, 1, 19) || 'Z'
+WHERE responded_at IS NOT NULL AND responded_at LIKE '%T%' AND responded_at NOT LIKE '%Z';
+
+-- contact_messages
+UPDATE contact_messages SET read_at = substr(read_at, 1, 19) || 'Z'
+WHERE read_at IS NOT NULL AND read_at LIKE '%T%' AND read_at NOT LIKE '%Z';
+
+-- notifications
+UPDATE notifications SET read_at = substr(read_at, 1, 19) || 'Z'
+WHERE read_at IS NOT NULL AND read_at LIKE '%T%' AND read_at NOT LIKE '%Z';
+
+UPDATE notifications SET emailed_at = substr(emailed_at, 1, 19) || 'Z'
+WHERE emailed_at IS NOT NULL AND emailed_at LIKE '%T%' AND emailed_at NOT LIKE '%Z';

--- a/static/app.js
+++ b/static/app.js
@@ -1,5 +1,17 @@
 // Catalyse - Shared JavaScript Utilities
 
+// During the strangler fig migration, auth routes live on Next.js running on a
+// separate port. Derive that port from the current page's port:
+//   FastAPI dev  (8001) → Next.js dev  (3001)
+//   FastAPI test (8002+) → Next.js test (port - 4000, e.g. 8002 → 4002)
+// In production Next.js serves everything, so relative URLs work (AUTH_BASE_URL = '').
+const AUTH_BASE_URL = (() => {
+    const p = parseInt(location.port || '0');
+    if (p === 8001) return 'http://localhost:3001';
+    if (p >= 8002 && p <= 8099) return `http://localhost:${p - 4000}`;
+    return '';
+})();
+
 // Apply dark mode immediately to prevent flash
 (function() {
     const saved = localStorage.getItem('theme');
@@ -405,7 +417,7 @@ async function getCurrentUser() {
     if (!token) return null;
 
     try {
-        return await apiRequest('/api/auth/me');
+        return await apiRequest(`${AUTH_BASE_URL}/api/auth/me`);
     } catch (e) {
         localStorage.removeItem('authToken');
         return null;
@@ -592,7 +604,7 @@ async function logout() {
     const token = localStorage.getItem('authToken');
     if (token) {
         try {
-            await fetch('/api/auth/logout', {
+            await fetch(`${AUTH_BASE_URL}/api/auth/logout`, {
                 method: 'POST',
                 headers: { 'Authorization': `Bearer ${token}` }
             });

--- a/static/forgot-password.html
+++ b/static/forgot-password.html
@@ -76,7 +76,7 @@
             submitBtn.textContent = 'Sending...';
 
             try {
-                const response = await fetch('/api/auth/forgot-password', {
+                const response = await fetch(`${AUTH_BASE_URL}/api/auth/forgot-password`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({

--- a/static/login.html
+++ b/static/login.html
@@ -99,7 +99,7 @@
 
         async function initGoogleSignIn() {
             try {
-                const config = await fetch('/api/auth/google-client-id').then(r => r.json());
+                const config = await fetch(`${AUTH_BASE_URL}/api/auth/google-client-id`).then(r => r.json());
                 if (config.client_id) {
                     const onloadDiv = document.getElementById('g_id_onload');
                     onloadDiv.setAttribute('data-client_id', config.client_id);
@@ -124,7 +124,7 @@
 
         async function handleGoogleSignIn(response) {
             try {
-                const result = await fetch('/api/auth/google', {
+                const result = await fetch(`${AUTH_BASE_URL}/api/auth/google`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ credential: response.credential })
@@ -165,7 +165,7 @@
             submitBtn.textContent = 'Logging in...';
 
             try {
-                const response = await fetch('/api/auth/login', {
+                const response = await fetch(`${AUTH_BASE_URL}/api/auth/login`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({

--- a/static/reset-password.html
+++ b/static/reset-password.html
@@ -97,7 +97,7 @@
             submitBtn.textContent = 'Resetting...';
 
             try {
-                const response = await fetch('/api/auth/reset-password', {
+                const response = await fetch(`${AUTH_BASE_URL}/api/auth/reset-password`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({

--- a/static/settings.html
+++ b/static/settings.html
@@ -156,7 +156,7 @@
             btn.disabled = true;
 
             try {
-                await apiRequest('/api/auth/change-email', {
+                await apiRequest(`${AUTH_BASE_URL}/api/auth/change-email`, {
                     method: 'POST',
                     body: JSON.stringify({
                         new_email: form.new_email.value.trim(),
@@ -199,7 +199,7 @@
             btn.disabled = true;
 
             try {
-                await apiRequest('/api/auth/change-password', {
+                await apiRequest(`${AUTH_BASE_URL}/api/auth/change-password`, {
                     method: 'POST',
                     body: JSON.stringify({
                         current_password: form.current_password.value,
@@ -235,7 +235,7 @@
             btn.textContent = 'Deleting...';
 
             try {
-                await apiRequest('/api/auth/delete-account', {
+                await apiRequest(`${AUTH_BASE_URL}/api/auth/delete-account`, {
                     method: 'POST',
                     body: JSON.stringify({ password: form.password.value })
                 });

--- a/static/signup.html
+++ b/static/signup.html
@@ -210,7 +210,7 @@
 
         async function initGoogleSignIn() {
             try {
-                const config = await fetch('/api/auth/google-client-id').then(r => r.json());
+                const config = await fetch(`${AUTH_BASE_URL}/api/auth/google-client-id`).then(r => r.json());
                 if (config.client_id) {
                     document.getElementById('googleSignIn').style.display = 'block';
                     if (window.google?.accounts?.id) {
@@ -229,7 +229,7 @@
 
         async function handleGoogleSignIn(response) {
             try {
-                const result = await fetch('/api/auth/google', {
+                const result = await fetch(`${AUTH_BASE_URL}/api/auth/google`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ credential: response.credential })
@@ -299,7 +299,7 @@
                     email_digest: form.email_digest.value
                 };
 
-                const response = await fetch('/api/auth/signup', {
+                const response = await fetch(`${AUTH_BASE_URL}/api/auth/signup`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(data)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -41,6 +41,13 @@ def _api(method, path, json=None, token=None):
 
 # ── Server lifecycle ──────────────────────────────────────────────────────────
 
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WEB_DIR = os.path.join(PROJECT_ROOT, "web")
+# FastAPI test port 8002 maps to Next.js test port 4002 (port - 4000)
+NEXT_PORT = 4002
+NEXT_BASE_URL = f"http://localhost:{NEXT_PORT}"
+
+
 @pytest.fixture(scope="session")
 def _tmp_db_dir():
     tmp = tempfile.mkdtemp(prefix="catalyse_test_")
@@ -50,28 +57,32 @@ def _tmp_db_dir():
 
 @pytest.fixture(scope="session", autouse=True)
 def live_server(_tmp_db_dir):
-    """Start the API on port 8002 with an isolated test database (local only)."""
+    """Start FastAPI (port 8002) and Next.js (port 4002) with a shared isolated test database."""
     if IS_PRODUCTION:
         yield
         return
 
-    env = {
+    base_env = {
         **os.environ,
-        "PORT": "8002",
         "RAILWAY_VOLUME_MOUNT_PATH": _tmp_db_dir,
-        # Don't use ADMIN_EMAILS: it triggers a nested db_transaction inside signup
-        # which causes SQLite lock contention. Promote via direct DB write instead.
-        "ADMIN_EMAILS": "",
         "RESEND_API_KEY": "",
+        "STUB_EMAIL": "true",
     }
 
-    proc = subprocess.Popen(
+    fastapi_proc = subprocess.Popen(
         ["python", "api.py"],
-        env=env,
-        cwd=str(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+        env={**base_env, "PORT": "8002", "ADMIN_EMAILS": ""},
+        cwd=PROJECT_ROOT,
     )
 
-    # Poll until ready (skills endpoint requires a fully-initialised DB)
+    next_binary = os.path.join(WEB_DIR, "node_modules", ".bin", "next")
+    next_proc = subprocess.Popen(
+        [next_binary, "dev", "-p", str(NEXT_PORT)],
+        env={**base_env, "PORT": str(NEXT_PORT)},
+        cwd=WEB_DIR,
+    )
+
+    # Wait for FastAPI (skills endpoint requires a fully-initialised DB)
     deadline = time.time() + 30
     while time.time() < deadline:
         try:
@@ -81,16 +92,35 @@ def live_server(_tmp_db_dir):
             pass
         time.sleep(0.5)
     else:
-        proc.terminate()
-        raise RuntimeError("Test server did not become ready within 30 seconds")
+        fastapi_proc.terminate()
+        next_proc.terminate()
+        raise RuntimeError("FastAPI test server did not become ready within 30 seconds")
+
+    # Wait for Next.js (health endpoint)
+    # Use a longer per-request timeout: Turbopack compiles routes lazily, and the
+    # health route runs a Prisma query — the first request can take 10+ seconds.
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        try:
+            if requests.get(f"{NEXT_BASE_URL}/api/health", timeout=15).status_code == 200:
+                break
+        except (requests.ConnectionError, requests.ReadTimeout):
+            pass
+        time.sleep(1)
+    else:
+        fastapi_proc.terminate()
+        next_proc.terminate()
+        raise RuntimeError("Next.js test server did not become ready within 120 seconds")
 
     yield
 
-    proc.terminate()
-    try:
-        proc.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        proc.kill()
+    fastapi_proc.terminate()
+    next_proc.terminate()
+    for proc in (fastapi_proc, next_proc):
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
 
 
 # ── User fixtures ─────────────────────────────────────────────────────────────

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -100,7 +100,7 @@ class TestLogout:
         page.click("#loginForm button[type=submit]")
         expect(page).to_have_url(f"{BASE_URL}/static/dashboard.html", timeout=10000)
         page.locator(".user-button").click()
-        page.get_by_role("link", name="Logout").click()
+        page.get_by_role("link", name="Sign Out").click()
         # logout() redirects to login; wait for that to confirm the full logout flow ran
         expect(page).to_have_url(f"{BASE_URL}/static/login.html", timeout=10000)
         stored = page.evaluate("localStorage.getItem('authToken')")

--- a/web/app/api/auth/change-email/route.ts
+++ b/web/app/api/auth/change-email/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer, verifyPassword } from '@/lib/auth'
+import { fieldError, validationError } from '@/lib/errors'
+
+export async function POST(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const errs: ReturnType<typeof fieldError>[] = []
+  if (!body.new_email) errs.push(fieldError('new_email', 'New email is required'))
+  if (!body.password) errs.push(fieldError('password', 'Password is required'))
+  if (errs.length) return validationError(errs)
+
+  const vol = await prisma.volunteer.findUnique({
+    where: { id: volunteer.id },
+    select: { passwordHash: true },
+  })
+
+  if (!vol?.passwordHash) {
+    return Response.json(
+      { detail: 'Cannot change email for accounts without a password. Contact an admin.' },
+      { status: 400 }
+    )
+  }
+  if (!verifyPassword(String(body.password), vol.passwordHash)) {
+    return Response.json({ detail: 'Password is incorrect' }, { status: 400 })
+  }
+
+  const newEmail = String(body.new_email).toLowerCase().trim()
+  const existing = await prisma.volunteer.findFirst({
+    where: { email: newEmail, id: { not: volunteer.id } },
+    select: { id: true },
+  })
+  if (existing) {
+    return Response.json(
+      { detail: 'This email is already registered to another account' },
+      { status: 400 }
+    )
+  }
+
+  await prisma.volunteer.update({
+    where: { id: volunteer.id },
+    data: { email: newEmail, updatedAt: new Date() },
+  })
+
+  return Response.json({ message: 'Email changed successfully' })
+}

--- a/web/app/api/auth/change-password/route.ts
+++ b/web/app/api/auth/change-password/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer, verifyPassword, hashPassword } from '@/lib/auth'
+import { fieldError, validationError } from '@/lib/errors'
+
+export async function POST(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const errs: ReturnType<typeof fieldError>[] = []
+  if (!body.current_password) errs.push(fieldError('current_password', 'Current password is required'))
+  if (!body.new_password) errs.push(fieldError('new_password', 'New password is required'))
+  else if (String(body.new_password).length < 8)
+    errs.push(fieldError('new_password', 'New password must be at least 8 characters'))
+  else if (String(body.new_password).length > 128)
+    errs.push(fieldError('new_password', 'New password must be no more than 128 characters'))
+  if (errs.length) return validationError(errs)
+
+  const vol = await prisma.volunteer.findUnique({
+    where: { id: volunteer.id },
+    select: { passwordHash: true },
+  })
+
+  if (!vol?.passwordHash || !verifyPassword(String(body.current_password), vol.passwordHash)) {
+    return Response.json({ detail: 'Current password is incorrect' }, { status: 400 })
+  }
+
+  await prisma.volunteer.update({
+    where: { id: volunteer.id },
+    data: { passwordHash: hashPassword(String(body.new_password)), updatedAt: new Date() },
+  })
+
+  return Response.json({ message: 'Password changed successfully' })
+}

--- a/web/app/api/auth/delete-account/route.ts
+++ b/web/app/api/auth/delete-account/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer, verifyPassword } from '@/lib/auth'
+import { sendProjectNotificationEmail } from '@/lib/email'
+
+async function sendAccountDeletionNotifications(
+  deletedId: number,
+  deletedName: string
+) {
+  // Projects with unfinished tasks assigned to the deleted user, grouped by project owner
+  const taskRows = await prisma.$queryRaw<Array<{
+    owner_id: number; owner_name: string; owner_email: string | null
+    project_id: number; project_title: string; task_count: number
+  }>>`
+    SELECT p.owner_id, v.name AS owner_name, v.email AS owner_email,
+           p.id AS project_id, p.title AS project_title,
+           COUNT(st.id) AS task_count
+    FROM starter_tasks st
+    JOIN projects p ON st.project_id = p.id
+    JOIN volunteers v ON p.owner_id = v.id
+    WHERE st.assigned_to_id = ${deletedId}
+      AND st.status NOT IN ('completed', 'reviewed')
+      AND p.owner_id != ${deletedId}
+      AND v.deleted_at IS NULL
+    GROUP BY p.id
+  `
+
+  const ownedProjects = await prisma.project.findMany({
+    where: { ownerId: deletedId, status: { notIn: ['completed', 'archived'] } },
+    select: { id: true, title: true },
+  })
+
+  if (!taskRows.length && !ownedProjects.length) return
+
+  type Recipient = {
+    name: string; email: string | null
+    taskProjects: { projectId: number; projectTitle: string; taskCount: number }[]
+    ownerlessProjects: { projectId: number; projectTitle: string }[]
+  }
+  const recipients: Record<number, Recipient> = {}
+
+  for (const row of taskRows) {
+    if (!recipients[row.owner_id]) {
+      recipients[row.owner_id] = {
+        name: row.owner_name, email: row.owner_email,
+        taskProjects: [], ownerlessProjects: [],
+      }
+    }
+    recipients[row.owner_id].taskProjects.push({
+      projectId: row.project_id, projectTitle: row.project_title, taskCount: Number(row.task_count),
+    })
+  }
+
+  const ownerless = ownedProjects.map(p => ({ projectId: p.id, projectTitle: p.title }))
+
+  if (ownerless.length) {
+    const admins = await prisma.volunteer.findMany({
+      where: { isAdmin: true, deletedAt: null, id: { not: deletedId } },
+      select: { id: true, name: true, email: true },
+    })
+    for (const admin of admins) {
+      if (!recipients[admin.id]) {
+        recipients[admin.id] = { name: admin.name, email: admin.email, taskProjects: [], ownerlessProjects: [] }
+      }
+      recipients[admin.id].ownerlessProjects = ownerless
+    }
+  }
+
+  for (const [recipientId, r] of Object.entries(recipients)) {
+    const rid = Number(recipientId)
+    for (const p of r.taskProjects) {
+      const word = p.taskCount === 1 ? 'task' : 'tasks'
+      try {
+        await prisma.notification.create({
+          data: {
+            volunteerId: rid, type: 'account_deleted_impact',
+            title: `${deletedName} has deleted their account`,
+            body: `${p.taskCount} ${word} in '${p.projectTitle}' assigned to ${deletedName} need a new assignee.`,
+            link: `/static/project.html?id=${p.projectId}`,
+          },
+        })
+      } catch (e) {
+        console.error('[NOTIFY ERROR] Account deletion notification failed:', e)
+      }
+    }
+    for (const p of r.ownerlessProjects) {
+      try {
+        await prisma.notification.create({
+          data: {
+            volunteerId: rid, type: 'account_deleted_impact',
+            title: `${deletedName} has deleted their account`,
+            body: `'${p.projectTitle}' needs a new owner.`,
+            link: `/static/project.html?id=${p.projectId}`,
+          },
+        })
+      } catch (e) {
+        console.error('[NOTIFY ERROR] Account deletion notification failed:', e)
+      }
+    }
+
+    if (r.email) {
+      const allProjects = [...r.taskProjects, ...r.ownerlessProjects]
+      const msgParts: string[] = [
+        `<p><strong>${deletedName}</strong> has deleted their account.</p>`,
+      ]
+      if (r.taskProjects.length) {
+        const rows = r.taskProjects
+          .map(p => `<li>${p.taskCount} ${p.taskCount === 1 ? 'task' : 'tasks'} in <strong>${p.projectTitle}</strong></li>`)
+          .join('')
+        msgParts.push(`<p>The following tasks need a new assignee:</p><ul>${rows}</ul>`)
+      }
+      if (r.ownerlessProjects.length) {
+        const rows = r.ownerlessProjects
+          .map(p => `<li><strong>${p.projectTitle}</strong></li>`)
+          .join('')
+        msgParts.push(`<p>The following projects need a new owner:</p><ul>${rows}</ul>`)
+      }
+      try {
+        await sendProjectNotificationEmail(
+          r.email, r.name,
+          `${deletedName} has deleted their account`,
+          msgParts.join(''),
+          allProjects[0].projectTitle,
+          allProjects[0].projectId,
+        )
+      } catch (e) {
+        console.error('[NOTIFY ERROR] Account deletion email failed:', e)
+      }
+    }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const vol = await prisma.volunteer.findUnique({
+    where: { id: volunteer.id },
+    select: { passwordHash: true },
+  })
+
+  if (!vol?.passwordHash || !verifyPassword(String(body.password || ''), vol.passwordHash)) {
+    return Response.json({ detail: 'Password is incorrect' }, { status: 400 })
+  }
+
+  await prisma.deletionRequest.create({
+    data: {
+      volunteerId: volunteer.id,
+      volunteerEmail: volunteer.email,
+      status: 'completed',
+    },
+  })
+
+  await sendAccountDeletionNotifications(volunteer.id, volunteer.name)
+
+  await prisma.volunteer.update({
+    where: { id: volunteer.id },
+    data: {
+      name: '[Deleted User]',
+      email: null,
+      bio: null,
+      discordHandle: null,
+      signalNumber: null,
+      whatsappNumber: null,
+      contactNotes: null,
+      location: null,
+      otherSkills: null,
+      authToken: null,
+      passwordHash: null,
+      deletedAt: new Date(),
+      updatedAt: new Date(),
+    },
+  })
+
+  await prisma.volunteerSkill.deleteMany({ where: { volunteerId: volunteer.id } })
+
+  return Response.json({ message: "Your account has been deleted. We're sorry to see you go." })
+}

--- a/web/app/api/auth/forgot-password/route.ts
+++ b/web/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { generateAuthToken } from '@/lib/auth'
+import { sendPasswordResetEmail, isEmailConfigured } from '@/lib/email'
+
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const email = String(body.email || '').toLowerCase().trim()
+  const volunteer = await prisma.volunteer.findFirst({
+    where: { email, deletedAt: null },
+    select: { id: true, name: true, email: true },
+  })
+
+  // Always return success to prevent email enumeration
+  const successMsg = "If an account exists with this email, you'll receive a reset link."
+
+  if (!volunteer || !volunteer.email) {
+    return Response.json({ message: successMsg })
+  }
+
+  const resetToken = generateAuthToken()
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
+
+  // Invalidate existing tokens
+  await prisma.passwordResetToken.updateMany({
+    where: { volunteerId: volunteer.id, usedAt: null },
+    data: { usedAt: new Date() },
+  })
+
+  await prisma.passwordResetToken.create({
+    data: { volunteerId: volunteer.id, token: resetToken, expiresAt },
+  })
+
+  await sendPasswordResetEmail(volunteer.email, resetToken, volunteer.name)
+
+  const result: Record<string, unknown> = { message: successMsg }
+
+  if (!isEmailConfigured()) {
+    result._dev_reset_token = resetToken
+    result._dev_reset_url = `/static/reset-password.html?token=${resetToken}`
+    result._dev_note = 'Email not configured. Set RESEND_API_KEY to enable.'
+  }
+
+  return Response.json(result)
+}

--- a/web/app/api/auth/google-client-id/route.ts
+++ b/web/app/api/auth/google-client-id/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ client_id: process.env.GOOGLE_CLIENT_ID || '' })
+}

--- a/web/app/api/auth/google/route.ts
+++ b/web/app/api/auth/google/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import {
+  generateAuthToken, checkAdminBootstrap, acceptPendingInvite,
+} from '@/lib/auth'
+import { sendWelcomeEmail } from '@/lib/email'
+
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID
+
+async function verifyGoogleToken(credential: string) {
+  if (!GOOGLE_CLIENT_ID) return null
+  try {
+    const resp = await fetch(
+      `https://oauth2.googleapis.com/tokeninfo?id_token=${credential}`
+    )
+    if (!resp.ok) return null
+    const data = await resp.json() as Record<string, string>
+    if (data.aud !== GOOGLE_CLIENT_ID) {
+      console.log(`[GOOGLE_AUTH] Token audience mismatch: ${data.aud}`)
+      return null
+    }
+    if (data.email_verified !== 'true') {
+      console.log(`[GOOGLE_AUTH] Email not verified: ${data.email}`)
+      return null
+    }
+    return {
+      email: data.email,
+      name: data.name || data.email.split('@')[0],
+      googleId: data.sub,
+      picture: data.picture,
+    }
+  } catch (e) {
+    console.error('[GOOGLE_AUTH] Token verification failed:', e)
+    return null
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!GOOGLE_CLIENT_ID) {
+    return Response.json({ detail: 'Google Sign-In is not configured' }, { status: 503 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const googleUser = await verifyGoogleToken(String(body.credential || ''))
+  if (!googleUser) {
+    return Response.json({ detail: 'Invalid Google token' }, { status: 401 })
+  }
+
+  const { email, name } = googleUser
+  const existing = await prisma.volunteer.findFirst({
+    where: { email, deletedAt: null },
+  })
+
+  if (existing) {
+    const authToken = generateAuthToken()
+    await prisma.volunteer.update({
+      where: { id: existing.id },
+      data: { authToken, updatedAt: new Date() },
+    })
+
+    let wasPromoted = await checkAdminBootstrap(email, existing.id)
+    const inviteAccepted = await acceptPendingInvite(email, existing.id)
+    if (inviteAccepted) wasPromoted = true
+
+    const message = wasPromoted
+      ? "Login successful - you've been granted admin access!"
+      : 'Login successful'
+    return Response.json({ message, auth_token: authToken })
+  }
+
+  // New user
+  const authToken = generateAuthToken()
+  const volunteer = await prisma.volunteer.create({
+    data: {
+      name, email, authToken,
+      consentProfileVisible: true,
+      consentContactByOwners: true,
+      consentGivenAt: new Date(),
+    },
+  })
+
+  try {
+    await checkAdminBootstrap(email, volunteer.id)
+  } catch (e) {
+    console.error('[GOOGLE_SIGNUP ERROR] admin bootstrap failed:', e)
+    return Response.json(
+      { detail: 'Something went wrong creating your account. Please try again or contact us. Error Code: C' },
+      { status: 500 }
+    )
+  }
+  try {
+    await acceptPendingInvite(email, volunteer.id)
+  } catch (e) {
+    console.error('[GOOGLE_SIGNUP ERROR] admin invite check failed:', e)
+    return Response.json(
+      { detail: 'Something went wrong creating your account. Please try again or contact us. Error Code: D' },
+      { status: 500 }
+    )
+  }
+
+  sendWelcomeEmail(email, name).catch(e => console.error('[GOOGLE_SIGNUP] Welcome email failed:', e))
+
+  return Response.json({ auth_token: authToken, message: 'Welcome to Catalyse!', is_new_user: true })
+}

--- a/web/app/api/auth/login/route.ts
+++ b/web/app/api/auth/login/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import {
+  verifyPassword, generateAuthToken,
+  checkAdminBootstrap, acceptPendingInvite,
+} from '@/lib/auth'
+
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const email = String(body.email || '').toLowerCase().trim()
+  const password = String(body.password || '')
+  if (!email || !password) {
+    return Response.json({ detail: 'Invalid email or password' }, { status: 401 })
+  }
+
+  const volunteer = await prisma.volunteer.findFirst({
+    where: { email, deletedAt: null },
+  })
+
+  if (!volunteer || !volunteer.passwordHash || !verifyPassword(password, volunteer.passwordHash)) {
+    return Response.json({ detail: 'Invalid email or password' }, { status: 401 })
+  }
+
+  let wasPromoted = await checkAdminBootstrap(email, volunteer.id)
+  const inviteAccepted = await acceptPendingInvite(email, volunteer.id)
+  if (inviteAccepted) wasPromoted = true
+
+  const authToken = generateAuthToken()
+  await prisma.volunteer.update({
+    where: { id: volunteer.id },
+    data: { authToken, updatedAt: new Date() },
+  })
+
+  const message = wasPromoted
+    ? "Login successful - you've been granted admin access!"
+    : 'Login successful'
+
+  return Response.json({ message, auth_token: authToken })
+}

--- a/web/app/api/auth/logout/route.ts
+++ b/web/app/api/auth/logout/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+
+export async function POST(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+  await prisma.volunteer.update({
+    where: { id: volunteer.id },
+    data: { authToken: null },
+  })
+  return Response.json({ message: 'Logged out' })
+}

--- a/web/app/api/auth/me/route.ts
+++ b/web/app/api/auth/me/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer, serializeVolunteer, serializeSkill, serializeEndorsement } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  const vol = await prisma.volunteer.findUnique({
+    where: { id: volunteer.id },
+    include: {
+      skills: {
+        include: { skill: { include: { category: true } } },
+        orderBy: [
+          { skill: { category: { sortOrder: 'asc' } } },
+          { skill: { sortOrder: 'asc' } },
+        ],
+      },
+      skillEndorsementsReceived: {
+        include: { skill: true },
+      },
+    },
+  })
+
+  if (!vol) return Response.json({ detail: 'Not found' }, { status: 404 })
+
+  const skills = vol.skills.map(serializeSkill)
+  const endorsements = vol.skillEndorsementsReceived.map(serializeEndorsement)
+
+  return Response.json(
+    serializeVolunteer(vol as unknown as Record<string, unknown>, {
+      showContact: true,
+      skills,
+      endorsements,
+    })
+  )
+}

--- a/web/app/api/auth/reset-password/route.ts
+++ b/web/app/api/auth/reset-password/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { hashPassword } from '@/lib/auth'
+import { fieldError, validationError } from '@/lib/errors'
+
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const errs: ReturnType<typeof fieldError>[] = []
+  if (!body.token) errs.push(fieldError('token', 'Token is required'))
+  if (!body.new_password) errs.push(fieldError('new_password', 'New password is required'))
+  else if (String(body.new_password).length < 8)
+    errs.push(fieldError('new_password', 'New password must be at least 8 characters'))
+  else if (String(body.new_password).length > 128)
+    errs.push(fieldError('new_password', 'New password must be no more than 128 characters'))
+  if (errs.length) return validationError(errs)
+
+  const tokenRecord = await prisma.passwordResetToken.findFirst({
+    where: {
+      token: String(body.token),
+      usedAt: null,
+      expiresAt: { gt: new Date() },
+      volunteer: { deletedAt: null },
+    },
+    select: { id: true, volunteerId: true },
+  })
+
+  if (!tokenRecord) {
+    return Response.json({ detail: 'Invalid or expired reset token' }, { status: 400 })
+  }
+
+  const passwordHash = hashPassword(String(body.new_password))
+
+  await prisma.volunteer.update({
+    where: { id: tokenRecord.volunteerId },
+    data: { passwordHash, authToken: null, updatedAt: new Date() },
+  })
+  await prisma.passwordResetToken.update({
+    where: { id: tokenRecord.id },
+    data: { usedAt: new Date() },
+  })
+
+  return Response.json({ message: 'Password reset successful. Please log in with your new password.' })
+}

--- a/web/app/api/auth/signup/route.ts
+++ b/web/app/api/auth/signup/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import {
+  hashPassword, generateAuthToken,
+  checkAdminBootstrap, acceptPendingInvite,
+} from '@/lib/auth'
+import { sendWelcomeEmail } from '@/lib/email'
+import { validationError, fieldError } from '@/lib/errors'
+
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  // Validate required fields
+  const errs: ReturnType<typeof fieldError>[] = []
+  if (!body.name) errs.push(fieldError('name', 'Name is required'))
+  if (!body.email) errs.push(fieldError('email', 'Email is required'))
+  if (!body.password) errs.push(fieldError('password', 'Password is required'))
+  else if (String(body.password).length < 8)
+    errs.push(fieldError('password', 'Password must be at least 8 characters'))
+  else if (String(body.password).length > 128)
+    errs.push(fieldError('password', 'Password must be no more than 128 characters'))
+  if (errs.length) return validationError(errs)
+
+  const email = String(body.email).toLowerCase().trim()
+  const name = String(body.name)
+  const password = String(body.password)
+
+  const existing = await prisma.volunteer.findFirst({
+    where: { email },
+    select: { id: true, deletedAt: true },
+  })
+
+  if (existing) {
+    if (existing.deletedAt) {
+      return Response.json(
+        { detail: 'This email was previously registered. Contact us to restore your account.' },
+        { status: 400 }
+      )
+    }
+    return Response.json({ detail: 'Email already registered' }, { status: 400 })
+  }
+
+  const authToken = generateAuthToken()
+  const passwordHash = hashPassword(password)
+
+  const volunteer = await prisma.volunteer.create({
+    data: {
+      name,
+      email,
+      passwordHash,
+      authToken,
+      bio: body.bio ? String(body.bio) : null,
+      discordHandle: body.discord_handle ? String(body.discord_handle) : null,
+      signalNumber: body.signal_number ? String(body.signal_number) : null,
+      whatsappNumber: body.whatsapp_number ? String(body.whatsapp_number) : null,
+      contactPreference: body.contact_preference ? String(body.contact_preference) : null,
+      contactNotes: body.contact_notes ? String(body.contact_notes) : null,
+      availabilityHoursPerWeek:
+        body.availability_hours_per_week != null
+          ? Number(body.availability_hours_per_week)
+          : null,
+      location: body.location ? String(body.location) : null,
+      country: body.country ? String(body.country) : null,
+      localGroup: body.local_group ? String(body.local_group) : null,
+      shareContactDirectly: Boolean(body.share_contact_directly ?? false),
+      otherSkills: body.other_skills ? String(body.other_skills) : null,
+      consentProfileVisible: Boolean(body.consent_profile_visible ?? true),
+      consentContactByOwners: Boolean(body.consent_contact_by_owners ?? true),
+      consentGivenAt: new Date(),
+      emailDigest: body.email_digest ? String(body.email_digest) : 'none',
+    },
+  })
+
+  // Add skills
+  const skillIds: number[] = Array.isArray(body.skill_ids)
+    ? body.skill_ids.map(Number).filter(Boolean)
+    : []
+  for (const skillId of skillIds) {
+    await prisma.volunteerSkill.upsert({
+      where: { volunteerId_skillId: { volunteerId: volunteer.id, skillId } },
+      create: { volunteerId: volunteer.id, skillId },
+      update: {},
+    })
+  }
+
+  // Admin bootstrap and invite acceptance
+  try {
+    await checkAdminBootstrap(email, volunteer.id)
+  } catch (e) {
+    console.error('[SIGNUP ERROR] admin bootstrap failed:', e)
+    return Response.json(
+      { detail: 'Something went wrong creating your account. Please try again or contact us. Error Code: A' },
+      { status: 500 }
+    )
+  }
+  try {
+    await acceptPendingInvite(email, volunteer.id)
+  } catch (e) {
+    console.error('[SIGNUP ERROR] admin invite check failed:', e)
+    return Response.json(
+      { detail: 'Something went wrong creating your account. Please try again or contact us. Error Code: B' },
+      { status: 500 }
+    )
+  }
+
+  // Non-blocking welcome email
+  sendWelcomeEmail(email, name).catch(e => console.error('[SIGNUP] Welcome email failed:', e))
+
+  return Response.json({ id: volunteer.id, auth_token: authToken, message: 'Welcome to Catalyse!' })
+}

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,0 +1,151 @@
+import { randomBytes, pbkdf2Sync, timingSafeEqual } from 'crypto'
+import { prisma } from './prisma'
+
+// PBKDF2-SHA256 password hashing — matches the Python implementation exactly:
+// salt = secrets.token_bytes(32); key = hashlib.pbkdf2_hmac('sha256', pw, salt, 100000)
+// stored as base64(salt + key)
+export function hashPassword(password: string): string {
+  const salt = randomBytes(32)
+  const key = pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+  return Buffer.concat([salt, key]).toString('base64')
+}
+
+export function verifyPassword(password: string, hash: string): boolean {
+  try {
+    const decoded = Buffer.from(hash, 'base64')
+    const salt = decoded.subarray(0, 32)
+    const storedKey = decoded.subarray(32)
+    const key = pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+    return timingSafeEqual(key, storedKey)
+  } catch {
+    return false
+  }
+}
+
+// secrets.token_urlsafe(32) in Python = 32 random bytes as base64url
+export function generateAuthToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export async function getCurrentVolunteer(authorization: string | null | undefined) {
+  if (!authorization) return null
+  const token = authorization.startsWith('Bearer ') ? authorization.slice(7) : authorization
+  return prisma.volunteer.findFirst({
+    where: {
+      authToken: token,
+      deletedAt: null,
+      OR: [{ authTokenExpiresAt: null }, { authTokenExpiresAt: { gt: new Date() } }],
+    },
+  })
+}
+
+// Convert a Prisma Volunteer to the snake_case response format the frontend expects.
+// showContact controls whether email and direct contact fields are included.
+export function serializeVolunteer(
+  vol: Record<string, unknown>,
+  opts: { showContact?: boolean; skills?: unknown[]; endorsements?: unknown[] } = {}
+) {
+  const { showContact = false, skills, endorsements } = opts
+  const result: Record<string, unknown> = {
+    id: vol.id,
+    name: vol.name,
+    bio: vol.bio,
+    location: vol.location,
+    country: vol.country,
+    local_group: vol.localGroup,
+    availability_hours_per_week: vol.availabilityHoursPerWeek,
+    share_contact_directly: vol.shareContactDirectly,
+    profile_visible: vol.profileVisible,
+    other_skills: vol.otherSkills,
+    consent_profile_visible: vol.consentProfileVisible,
+    consent_contact_by_owners: vol.consentContactByOwners,
+    consent_given_at: vol.consentGivenAt,
+    is_admin: vol.isAdmin,
+    email_digest: vol.emailDigest,
+    created_at: vol.createdAt,
+    updated_at: vol.updatedAt,
+    deleted_at: vol.deletedAt,
+  }
+  if (showContact) {
+    result.email = vol.email
+    result.discord_handle = vol.discordHandle
+    result.signal_number = vol.signalNumber
+    result.whatsapp_number = vol.whatsappNumber
+    result.contact_preference = vol.contactPreference
+    result.contact_notes = vol.contactNotes
+  }
+  if (skills !== undefined) result.skills = skills
+  if (endorsements !== undefined) result.endorsements = endorsements
+  return result
+}
+
+export function serializeSkill(vs: {
+  proficiencyLevel: string | null
+  skill: {
+    id: number
+    categoryId: number
+    name: string
+    description: string | null
+    sortOrder: number | null
+    createdAt: Date | null
+    category: { name: string }
+  }
+}) {
+  return {
+    id: vs.skill.id,
+    category_id: vs.skill.categoryId,
+    name: vs.skill.name,
+    description: vs.skill.description,
+    sort_order: vs.skill.sortOrder,
+    created_at: vs.skill.createdAt,
+    category_name: vs.skill.category.name,
+    proficiency_level: vs.proficiencyLevel,
+  }
+}
+
+export function serializeEndorsement(se: {
+  skillId: number
+  rating: string | null
+  skill: { name: string }
+}) {
+  return { skill_id: se.skillId, rating: se.rating, skill_name: se.skill.name }
+}
+
+// Promote volunteer to admin if their email is in ADMIN_EMAILS env var
+export async function checkAdminBootstrap(email: string, volunteerId: number): Promise<boolean> {
+  const adminEmails = process.env.ADMIN_EMAILS || ''
+  if (!adminEmails) return false
+  const allowed = adminEmails.split(',').map(e => e.trim().toLowerCase()).filter(Boolean)
+  if (!allowed.includes(email.toLowerCase())) return false
+  await prisma.volunteer.updateMany({
+    where: { id: volunteerId, isAdmin: false },
+    data: { isAdmin: true },
+  })
+  return true
+}
+
+// Accept any pending admin invite for this email (case-insensitive).
+// expires_at may be an ISO string (FastAPI-created) or ms timestamp (Prisma-created);
+// compare against both formats to be safe during the migration.
+export async function acceptPendingInvite(email: string, volunteerId: number): Promise<boolean> {
+  const nowIso = new Date().toISOString()
+  const nowMs = Date.now()
+  const result = await prisma.$queryRaw<Array<{ id: number }>>`
+    SELECT id FROM admin_invites
+    WHERE LOWER(email) = ${email.toLowerCase()}
+      AND status = 'pending'
+      AND (
+        (typeof(expires_at) = 'text' AND expires_at > ${nowIso})
+        OR (typeof(expires_at) = 'integer' AND expires_at > ${nowMs})
+      )
+    LIMIT 1
+  `
+  const invite = result[0]
+  if (!invite) return false
+  await prisma.volunteer.update({ where: { id: volunteerId }, data: { isAdmin: true } })
+  await prisma.adminInvite.update({
+    where: { id: invite.id },
+    data: { status: 'accepted', acceptedById: volunteerId, acceptedAt: new Date() },
+  })
+  return true
+}

--- a/web/lib/email.ts
+++ b/web/lib/email.ts
@@ -1,0 +1,201 @@
+import { Resend } from 'resend'
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY
+const FROM_EMAIL = process.env.FROM_EMAIL || 'Catalyse <noreply@catalyse.pauseai.uk>'
+const APP_URL = process.env.APP_URL || 'http://localhost:8001'
+const STUB_EMAIL = ['1', 'true', 'yes'].includes((process.env.STUB_EMAIL || '').toLowerCase())
+
+const resend = RESEND_API_KEY ? new Resend(RESEND_API_KEY) : null
+
+export function isEmailConfigured(): boolean {
+  return STUB_EMAIL || Boolean(RESEND_API_KEY)
+}
+
+export function isRealEmailSending(): boolean {
+  return Boolean(RESEND_API_KEY) && !STUB_EMAIL
+}
+
+async function sendEmail(to: string, subject: string, html: string, replyTo?: string): Promise<boolean> {
+  if (STUB_EMAIL) {
+    console.log(`[EMAIL STUB] Would send to ${to}: ${subject}`)
+    return true
+  }
+  if (!resend) {
+    console.log(`[EMAIL NOT CONFIGURED] Would send to ${to}: ${subject}`)
+    return false
+  }
+  try {
+    const payload: Parameters<typeof resend.emails.send>[0] = {
+      from: FROM_EMAIL,
+      to: [to],
+      subject,
+      html,
+    }
+    if (replyTo) payload.replyTo = replyTo
+    const { error } = await resend.emails.send(payload)
+    if (error) {
+      console.error(`[EMAIL ERROR] ${error.message}`)
+      return false
+    }
+    return true
+  } catch (err) {
+    console.error('[EMAIL ERROR]', err)
+    return false
+  }
+}
+
+const baseStyle = `
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }
+  .container { max-width: 500px; margin: 0 auto; padding: 20px; }
+  .button { display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }
+  .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }
+`
+
+export async function sendPasswordResetEmail(to: string, resetToken: string, name = 'there'): Promise<boolean> {
+  const resetUrl = `${APP_URL}/static/reset-password.html?token=${resetToken}`
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
+<body><div class="container">
+  <h2>Reset Your Password</h2>
+  <p>Hi ${name},</p>
+  <p>We received a request to reset your password for your Catalyse account. Click the button below to choose a new password:</p>
+  <p style="text-align: center; margin: 32px 0;"><a href="${resetUrl}" class="button">Reset Password</a></p>
+  <p>This link will expire in <strong>1 hour</strong>.</p>
+  <p>If you didn't request this, you can safely ignore this email. Your password won't be changed.</p>
+  <div class="footer">
+    <p>Catalyse - PauseAI UK Volunteer Platform</p>
+    <p style="font-size: 12px;">If the button doesn't work, copy this link:<br>${resetUrl}</p>
+  </div>
+</div></body></html>`
+  return sendEmail(to, 'Reset your Catalyse password', html)
+}
+
+export async function sendAdminInviteEmail(to: string, inviteToken: string, invitedBy: string): Promise<boolean> {
+  const inviteUrl = `${APP_URL}/static/accept-invite.html?token=${inviteToken}`
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
+<body><div class="container">
+  <h2>You're Invited to be a Catalyse Admin</h2>
+  <p>Hi!</p>
+  <p><strong>${invitedBy}</strong> has invited you to become an admin on Catalyse, the PauseAI UK volunteer coordination platform.</p>
+  <ul>
+    <li>Review and approve volunteer-proposed projects</li>
+    <li>Manage skills and starter tasks</li>
+    <li>View volunteer profiles and add notes</li>
+    <li>Invite other admins</li>
+  </ul>
+  <p style="text-align: center; margin: 32px 0;"><a href="${inviteUrl}" class="button">Accept Invitation</a></p>
+  <p>This invitation expires in <strong>7 days</strong>.</p>
+  <p>You'll need to sign up or log in with this email address to accept.</p>
+  <div class="footer">
+    <p>Catalyse - PauseAI UK Volunteer Platform</p>
+    <p style="font-size: 12px;">If the button doesn't work, copy this link:<br>${inviteUrl}</p>
+  </div>
+</div></body></html>`
+  return sendEmail(to, `${invitedBy} invited you to be a Catalyse admin`, html)
+}
+
+export async function sendWelcomeEmail(to: string, name: string): Promise<boolean> {
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
+<body><div class="container">
+  <h2>Welcome to Catalyse!</h2>
+  <p>Hi ${name},</p>
+  <p>Thanks for joining the PauseAI UK volunteer community! We're excited to have you.</p>
+  <ul>
+    <li><strong>Browse projects</strong> - Find opportunities that match your skills</li>
+    <li><strong>Complete your profile</strong> - Help project owners find you</li>
+    <li><strong>Express interest</strong> - Let project owners know you want to help</li>
+  </ul>
+  <p style="text-align: center; margin: 32px 0;"><a href="${APP_URL}" class="button">Explore Projects</a></p>
+  <div class="footer"><p>Catalyse - PauseAI UK Volunteer Platform</p></div>
+</div></body></html>`
+  return sendEmail(to, 'Welcome to Catalyse!', html)
+}
+
+export async function sendProjectNotificationEmail(
+  to: string, name: string, subject: string,
+  message: string, projectTitle: string,
+  projectId: number, extraHtml = ''
+): Promise<boolean> {
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
+<body><div class="container">
+  <h2>${subject}</h2>
+  <p>Hi ${name},</p>
+  <p>${message}</p>
+  ${extraHtml}
+  <p style="text-align: center; margin: 32px 0;">
+    <a href="${APP_URL}/static/project.html?id=${projectId}" class="button">View Project</a>
+  </p>
+  <div class="footer">
+    <p>Catalyse - PauseAI Volunteer Platform</p>
+    <p style="font-size: 12px;"><a href="${APP_URL}/static/profile.html">Manage notification preferences</a></p>
+  </div>
+</div></body></html>`
+  return sendEmail(to, subject, html)
+}
+
+export async function sendRelayMessage(
+  to: string, toName: string, fromName: string, fromEmail: string,
+  subject: string, message: string, projectTitle?: string
+): Promise<boolean> {
+  const projectContext = projectTitle ? ` about the project <strong>${projectTitle}</strong>` : ''
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+  ${baseStyle}
+  .message-box { background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin: 16px 0; white-space: pre-wrap; }
+  </style></head>
+<body><div class="container">
+  <h2>Message from ${fromName}</h2>
+  <p>Hi ${toName},</p>
+  <p><strong>${fromName}</strong> has sent you a message via Catalyse${projectContext}:</p>
+  <div class="message-box">
+    <p style="font-weight: 500; margin-bottom: 8px;">${subject}</p>
+    <p>${message}</p>
+  </div>
+  <p>You can reply directly to this email to respond to ${fromName}.</p>
+  <div class="footer">
+    <p>Catalyse - PauseAI UK Volunteer Platform</p>
+    <p style="font-size: 12px;">This message was sent via the Catalyse platform. If you no longer wish to receive messages,
+    update your contact preferences in your <a href="${APP_URL}/static/profile.html">profile settings</a>.</p>
+  </div>
+</div></body></html>`
+  return sendEmail(to, `[Catalyse] ${subject}`, html, fromEmail)
+}
+
+export async function sendDigestEmail(
+  to: string, name: string,
+  projects: Array<{ id: number; title: string; description?: string; skill_names?: string[]; match_percent?: number }>,
+  isMatch = false
+): Promise<boolean> {
+  if (!projects.length) return false
+  const matchIntro = isMatch ? 'Here are new projects that match your skills:' : "Here's what's new on Catalyse:"
+  const projectHtml = projects.map(p => {
+    const skillsHtml = (p.skill_names || []).slice(0, 5).join(', ')
+    const matchBadge = p.match_percent
+      ? ` <span style="background: #D1FAE5; color: #065F46; padding: 2px 8px; border-radius: 10px; font-size: 12px;">${p.match_percent}% match</span>`
+      : ''
+    const desc = p.description || ''
+    return `<div style="padding: 16px; margin-bottom: 12px; background: #f7fafc; border-radius: 8px; border-left: 4px solid #FF9416;">
+      <a href="${APP_URL}/static/project.html?id=${p.id}" style="font-weight: bold; color: #1A202C; text-decoration: none; font-size: 16px;">${p.title}</a>${matchBadge}
+      <p style="color: #4A5568; margin: 8px 0 4px 0; font-size: 14px;">${desc.slice(0, 150)}${desc.length > 150 ? '...' : ''}</p>
+      ${skillsHtml ? `<p style="font-size: 12px; color: #718096;">Skills: ${skillsHtml}</p>` : ''}
+    </div>`
+  }).join('')
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a202c; }
+  .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+  .button { display: inline-block; background: #FF9416; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; }
+  .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #e2e8f0; font-size: 14px; color: #718096; }
+  </style></head>
+<body><div class="container">
+  <h2 style="color: #FF9416;">Catalyse Project Update</h2>
+  <p>Hi ${name},</p>
+  <p>${matchIntro}</p>
+  ${projectHtml}
+  <p style="text-align: center; margin: 32px 0;"><a href="${APP_URL}" class="button">Browse All Projects</a></p>
+  <div class="footer">
+    <p>Catalyse - PauseAI Volunteer Platform</p>
+    <p style="font-size: 12px;">You're receiving this because you opted in to project notifications.
+    <a href="${APP_URL}/static/profile.html">Change your preferences</a> at any time.</p>
+  </div>
+</div></body></html>`
+  const subject = isMatch ? 'New projects matching your skills' : "What's new on Catalyse"
+  return sendEmail(to, subject, html)
+}

--- a/web/lib/errors.ts
+++ b/web/lib/errors.ts
@@ -1,0 +1,7 @@
+export function fieldError(field: string, msg: string) {
+  return { loc: ['body', field], msg, type: 'value_error' }
+}
+
+export function validationError(errors: ReturnType<typeof fieldError>[]) {
+  return Response.json({ detail: errors }, { status: 422 })
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Add CORS headers to all /api/ routes to allow cross-origin requests during
+// the strangler fig migration (HTML is served by FastAPI on a different port).
+// In production Next.js serves everything, so this is a no-op.
+export function middleware(request: NextRequest) {
+  if (request.method === 'OPTIONS') {
+    return new NextResponse(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    })
+  }
+
+  const response = NextResponse.next()
+  response.headers.set('Access-Control-Allow-Origin', '*')
+  response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
+  response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  return response
+}
+
+export const config = { matcher: '/api/:path*' }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,8 @@
         "next": "16.2.4",
         "prisma": "^6.19.3",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "resend": "^6.12.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1326,6 +1327,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -3754,6 +3761,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5648,6 +5661,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -5864,6 +5883,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -6238,6 +6278,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6435,6 +6485,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -6802,6 +6862,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "next": "16.2.4",
     "prisma": "^6.19.3",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "resend": "^6.12.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary

- Implements all auth API routes in Next.js (`/api/auth/signup`, `login`, `logout`, `me`, `forgot-password`, `reset-password`, `change-email`, `change-password`, `delete-account`, Google OAuth)
- Adds shared auth/email/error utility libs and middleware for token-based auth on protected routes
- Updates static pages and `app.js` to proxy auth API calls to the Next.js server (port-offset routing: FastAPI 8002 → Next.js 4002)
- Fixes FastAPI datetime storage format (`datetime.now().isoformat()` → `datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')`) so Prisma 6's SQLite driver can read FastAPI-written rows (P2023 fix)
- Adds `migration_010_fix_datetime_format.sql` to rewrite existing production datetimes into the compatible format
- Updates e2e conftest to start and health-check the Next.js dev server alongside FastAPI; fixes `ReadTimeout` not being caught during Turbopack lazy compilation

## Test plan

- [ ] Run `make test` — all 9 auth e2e tests should pass
- [ ] Manually test signup → login → logout flow via the static pages
- [ ] Manually test forgot/reset password flow
- [ ] Verify `migration_010` runs cleanly on a copy of the production DB
- [ ] Check that users created via FastAPI can log in through the Next.js route (cross-backend compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)