### PR TITLE
feat: Next.js skills routes (Phase 3)

### DIFF
--- a/static/admin/skills.html
+++ b/static/admin/skills.html
@@ -217,7 +217,7 @@
 
         async function loadCategories() {
             try {
-                categories = await apiRequest('/api/skills');
+                categories = await apiRequest(`${SKILLS_BASE_URL}/api/skills`);
                 renderCategories();
                 updateCategoryDropdown();
             } catch (error) {
@@ -300,13 +300,13 @@
 
             try {
                 if (catId) {
-                    await apiRequest(`/api/admin/skill-categories/${catId}`, {
+                    await apiRequest(`${SKILLS_BASE_URL}/api/admin/skill-categories/${catId}`, {
                         method: 'PUT',
                         body: JSON.stringify(data)
                     });
                     showMessage('Category updated!', 'success');
                 } else {
-                    await apiRequest('/api/admin/skill-categories', {
+                    await apiRequest(`${SKILLS_BASE_URL}/api/admin/skill-categories`, {
                         method: 'POST',
                         body: JSON.stringify(data)
                     });
@@ -335,7 +335,7 @@
 
         async function deleteCategory(catId) {
             try {
-                await apiRequest(`/api/admin/skill-categories/${catId}`, { method: 'DELETE' });
+                await apiRequest(`${SKILLS_BASE_URL}/api/admin/skill-categories/${catId}`, { method: 'DELETE' });
                 closeModal('deleteModal');
                 showMessage('Category deleted!', 'success');
                 await loadCategories();
@@ -381,13 +381,13 @@
 
             try {
                 if (skillId) {
-                    await apiRequest(`/api/admin/skills/${skillId}`, {
+                    await apiRequest(`${SKILLS_BASE_URL}/api/admin/skills/${skillId}`, {
                         method: 'PUT',
                         body: JSON.stringify(data)
                     });
                     showMessage('Skill updated!', 'success');
                 } else {
-                    await apiRequest('/api/admin/skills', {
+                    await apiRequest(`${SKILLS_BASE_URL}/api/admin/skills`, {
                         method: 'POST',
                         body: JSON.stringify(data)
                     });
@@ -410,7 +410,7 @@
 
         async function deleteSkill(skillId) {
             try {
-                await apiRequest(`/api/admin/skills/${skillId}`, { method: 'DELETE' });
+                await apiRequest(`${SKILLS_BASE_URL}/api/admin/skills/${skillId}`, { method: 'DELETE' });
                 closeModal('deleteModal');
                 showMessage('Skill deleted!', 'success');
                 await loadCategories();

--- a/static/app.js
+++ b/static/app.js
@@ -1,16 +1,17 @@
 // Catalyse - Shared JavaScript Utilities
 
-// During the strangler fig migration, auth routes live on Next.js running on a
+// During the strangler fig migration, auth and skills routes live on Next.js running on a
 // separate port. Derive that port from the current page's port:
 //   FastAPI dev  (8001) → Next.js dev  (3001)
 //   FastAPI test (8002+) → Next.js test (port - 4000, e.g. 8002 → 4002)
-// In production Next.js serves everything, so relative URLs work (AUTH_BASE_URL = '').
+// In production Next.js serves everything, so relative URLs work (BASE = '').
 const AUTH_BASE_URL = (() => {
     const p = parseInt(location.port || '0');
     if (p === 8001) return 'http://localhost:3001';
     if (p >= 8002 && p <= 8099) return `http://localhost:${p - 4000}`;
     return '';
 })();
+const SKILLS_BASE_URL = AUTH_BASE_URL;
 
 // Apply dark mode immediately to prevent flash
 (function() {
@@ -351,7 +352,7 @@ function showMessage(text, type, containerId = 'messageDiv') {
 
 // Skills rendering
 async function loadSkills() {
-    return apiRequest('/api/skills');
+    return apiRequest(`${SKILLS_BASE_URL}/api/skills`);
 }
 
 function renderSkillSelector(containerId, selectedIds = [], onChangeCallback = null) {

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -23,7 +23,7 @@ import uuid
 import requests
 import pytest
 
-from tests.e2e.helpers import BASE_URL, IS_PRODUCTION, inject_auth_token  # noqa: F401
+from tests.e2e.helpers import BASE_URL, NEXT_BASE_URL, IS_PRODUCTION, inject_auth_token  # noqa: F401
 
 ADMIN_EMAIL = "admin@test.com"
 ADMIN_PASSWORD = "adminpassword1"
@@ -45,7 +45,6 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 WEB_DIR = os.path.join(PROJECT_ROOT, "web")
 # FastAPI test port 8002 maps to Next.js test port 4002 (port - 4000)
 NEXT_PORT = 4002
-NEXT_BASE_URL = f"http://localhost:{NEXT_PORT}"
 
 
 @pytest.fixture(scope="session")
@@ -196,6 +195,16 @@ def published_project(live_server, admin_token):
         "urgency": "medium",
     }, token=admin_token)
     return data["id"]
+
+
+# ── API target fixture ────────────────────────────────────────────────────────
+
+@pytest.fixture(params=["fastapi", "nextjs"])
+def api_url(request, live_server):
+    """Base URL for API tests — parameterised to run each test against both backends."""
+    if request.param == "fastapi":
+        return BASE_URL
+    return NEXT_BASE_URL
 
 
 # ── Test label overlay ────────────────────────────────────────────────────────

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -5,6 +5,26 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:8002")
 IS_PRODUCTION = not BASE_URL.startswith("http://localhost")
 
 
+def _derive_next_base_url(base_url: str) -> str:
+    """Derive the Next.js base URL from the FastAPI base URL.
+
+    During the strangler fig migration FastAPI runs on one port and Next.js on
+    another (FastAPI port − 4000).  In production Next.js serves everything, so
+    the two URLs are the same.
+    """
+    if base_url.startswith("http://localhost:"):
+        port_str = base_url.split(":")[-1].split("/")[0]
+        try:
+            next_port = int(port_str) - 4000
+            return f"http://localhost:{next_port}"
+        except ValueError:
+            pass
+    return base_url
+
+
+NEXT_BASE_URL = _derive_next_base_url(BASE_URL)
+
+
 def inject_auth_token(context, token: str):
     """Populate localStorage before any page script runs."""
     context.add_init_script(f"localStorage.setItem('authToken', '{token}');")

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,7 +1,16 @@
 import uuid
+import requests
 import pytest
 from playwright.sync_api import Page, expect
 from tests.e2e.helpers import BASE_URL, IS_PRODUCTION, inject_auth_token
+
+
+def _api(method, path, base_url, json=None, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.request(method, f"{base_url}{path}", json=json, headers=headers, timeout=10)
+    return resp
 
 
 # ── Signup ────────────────────────────────────────────────────────────────────
@@ -105,3 +114,72 @@ class TestLogout:
         expect(page).to_have_url(f"{BASE_URL}/static/login.html", timeout=10000)
         stored = page.evaluate("localStorage.getItem('authToken')")
         assert stored is None
+
+
+# ── Direct API tests (parameterised across both backends) ─────────────────────
+
+class TestAuthApi:
+    """Direct API tests for auth endpoints — runs against both FastAPI and Next.js."""
+
+    @pytest.mark.local_only
+    def test_signup_returns_token(self, api_url):
+        email = f"api_{uuid.uuid4().hex[:8]}@test.com"
+        resp = _api("POST", "/api/auth/signup", base_url=api_url, json={
+            "name": "API Test User",
+            "email": email,
+            "password": "testpassword1",
+            "consent_profile_visible": True,
+            "consent_contact_by_owners": True,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "auth_token" in data
+        assert "id" in data
+
+    @pytest.mark.local_only
+    def test_signup_duplicate_email_rejected(self, api_url, new_user):
+        resp = _api("POST", "/api/auth/signup", base_url=api_url, json={
+            "name": "Dupe User",
+            "email": new_user["email"],
+            "password": "testpassword1",
+            "consent_profile_visible": True,
+            "consent_contact_by_owners": True,
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.local_only
+    def test_login_returns_token(self, api_url, new_user):
+        resp = _api("POST", "/api/auth/login", base_url=api_url, json={
+            "email": new_user["email"],
+            "password": new_user["password"],
+        })
+        assert resp.status_code == 200
+        assert "auth_token" in resp.json()
+
+    @pytest.mark.local_only
+    def test_login_wrong_password_rejected(self, api_url, new_user):
+        resp = _api("POST", "/api/auth/login", base_url=api_url, json={
+            "email": new_user["email"],
+            "password": "wrongpassword1",
+        })
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_login_unknown_email_rejected(self, api_url):
+        resp = _api("POST", "/api/auth/login", base_url=api_url, json={
+            "email": "nobody@nowhere.com",
+            "password": "testpassword1",
+        })
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_me_returns_user(self, api_url, new_user):
+        resp = _api("GET", "/api/auth/me", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email"] == new_user["email"]
+
+    @pytest.mark.local_only
+    def test_me_unauthenticated(self, api_url):
+        resp = _api("GET", "/api/auth/me", base_url=api_url)
+        assert resp.status_code == 401

--- a/tests/e2e/test_skills.py
+++ b/tests/e2e/test_skills.py
@@ -1,0 +1,249 @@
+"""
+E2E tests for Skills routes — parameterised to run against both FastAPI and Next.js.
+
+Scenario 03-skill-management:
+  1. Admin creates a skill category
+  2. Admin creates a skill within a category
+  3. Admin edits a skill name
+  4. Admin deletes an unused skill
+  5. Admin deletes a skill category
+"""
+
+import uuid
+import requests
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e.helpers import BASE_URL, NEXT_BASE_URL, IS_PRODUCTION, inject_auth_token
+
+
+def _api(method, path, base_url, json=None, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.request(method, f"{base_url}{path}", json=json, headers=headers, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+class TestSkillsPublicEndpoints:
+    """GET /api/skills and GET /api/skills/flat are unauthenticated."""
+
+    def test_skills_returns_nested_tree(self, api_url):
+        data = _api("GET", "/api/skills", base_url=api_url)
+        assert isinstance(data, list)
+        if data:
+            cat = data[0]
+            assert "id" in cat
+            assert "name" in cat
+            assert "skills" in cat
+            assert isinstance(cat["skills"], list)
+
+    def test_skills_flat_returns_list_with_category_name(self, api_url):
+        data = _api("GET", "/api/skills/flat", base_url=api_url)
+        assert isinstance(data, list)
+        if data:
+            skill = data[0]
+            assert "id" in skill
+            assert "category_id" in skill
+            assert "category_name" in skill
+
+
+class TestSkillManagementPage:
+    """Browser-based tests for the admin skills management UI (always targets Next.js via app.js)."""
+
+    @pytest.mark.local_only
+    def test_admin_creates_skill_category(self, page: Page, admin_token):
+        inject_auth_token(page.context, admin_token)
+        page.goto(f"{BASE_URL}/static/admin/skills.html")
+
+        cat_name = f"Test Category {uuid.uuid4().hex[:6]}"
+        page.click("button.btn-primary:has-text('+ Add Category')")
+        page.fill("#categoryName", cat_name)
+        page.click("#categoryForm button[type=submit]")
+
+        expect(page.locator("#messageDiv")).to_contain_text("created", timeout=8000)
+
+        page.reload()
+        expect(page.locator("#categoriesList")).to_contain_text(cat_name, timeout=10000)
+
+    @pytest.mark.local_only
+    def test_admin_creates_skill_in_category(self, page: Page, admin_token):
+        inject_auth_token(page.context, admin_token)
+
+        cat_name = f"UI Cat {uuid.uuid4().hex[:6]}"
+        cat = _api("POST", "/api/admin/skill-categories", base_url=NEXT_BASE_URL, json={"name": cat_name}, token=admin_token)
+        cat_id = cat["id"]
+
+        page.goto(f"{BASE_URL}/static/admin/skills.html")
+        skill_name = f"UI Skill {uuid.uuid4().hex[:6]}"
+
+        page.wait_for_selector(f"button[onclick='openAddSkill({cat_id})']", timeout=10000)
+        page.click(f"button[onclick='openAddSkill({cat_id})']")
+        page.fill("#skillName", skill_name)
+        page.click("#skillForm button[type=submit]")
+
+        expect(page.locator("#messageDiv")).to_contain_text("created", timeout=8000)
+
+        page.reload()
+        expect(page.locator("#categoriesList")).to_contain_text(skill_name, timeout=10000)
+
+    @pytest.mark.local_only
+    def test_admin_edits_skill_name(self, page: Page, admin_token):
+        inject_auth_token(page.context, admin_token)
+
+        cat_name = f"Edit Cat {uuid.uuid4().hex[:6]}"
+        cat = _api("POST", "/api/admin/skill-categories", base_url=NEXT_BASE_URL, json={"name": cat_name}, token=admin_token)
+        cat_id = cat["id"]
+
+        skill_name = f"Edit Skill {uuid.uuid4().hex[:6]}"
+        skill = _api(
+            "POST", "/api/admin/skills", base_url=NEXT_BASE_URL,
+            json={"name": skill_name, "category_id": cat_id},
+            token=admin_token,
+        )
+        skill_id = skill["id"]
+
+        page.goto(f"{BASE_URL}/static/admin/skills.html")
+        page.wait_for_selector(f"button[onclick='editSkill({skill_id}, {cat_id})']", timeout=10000)
+        page.click(f"button[onclick='editSkill({skill_id}, {cat_id})']")
+
+        updated_name = f"Updated {uuid.uuid4().hex[:6]}"
+        page.fill("#skillName", updated_name)
+        page.click("#skillForm button[type=submit]")
+
+        expect(page.locator("#messageDiv")).to_contain_text("updated", timeout=8000)
+
+        page.reload()
+        expect(page.locator("#categoriesList")).to_contain_text(updated_name, timeout=10000)
+
+    @pytest.mark.local_only
+    def test_admin_deletes_unused_skill(self, page: Page, admin_token):
+        inject_auth_token(page.context, admin_token)
+
+        cat_name = f"Del Cat {uuid.uuid4().hex[:6]}"
+        cat = _api("POST", "/api/admin/skill-categories", base_url=NEXT_BASE_URL, json={"name": cat_name}, token=admin_token)
+        cat_id = cat["id"]
+
+        skill_name = f"Del Skill {uuid.uuid4().hex[:6]}"
+        skill = _api(
+            "POST", "/api/admin/skills", base_url=NEXT_BASE_URL,
+            json={"name": skill_name, "category_id": cat_id},
+            token=admin_token,
+        )
+        skill_id = skill["id"]
+
+        page.goto(f"{BASE_URL}/static/admin/skills.html")
+        page.wait_for_selector(f"button[onclick='confirmDeleteSkill({skill_id}, \\'{skill_name}\\')']", timeout=10000)
+        page.click(f"button[onclick='confirmDeleteSkill({skill_id}, \\'{skill_name}\\')']")
+
+        page.click("#confirmDeleteBtn")
+        expect(page.locator("#messageDiv")).to_contain_text("deleted", timeout=8000)
+
+        page.reload()
+        expect(page.locator("#categoriesList")).not_to_contain_text(skill_name, timeout=10000)
+
+    @pytest.mark.local_only
+    def test_admin_deletes_skill_category(self, page: Page, admin_token):
+        inject_auth_token(page.context, admin_token)
+
+        cat_name = f"Gone Cat {uuid.uuid4().hex[:6]}"
+        cat = _api("POST", "/api/admin/skill-categories", base_url=NEXT_BASE_URL, json={"name": cat_name}, token=admin_token)
+        cat_id = cat["id"]
+
+        page.goto(f"{BASE_URL}/static/admin/skills.html")
+        page.wait_for_selector(f"button[onclick=\"confirmDeleteCategory({cat_id}, '{cat_name}', 0)\"]", timeout=10000)
+        page.click(f"button[onclick=\"confirmDeleteCategory({cat_id}, '{cat_name}', 0)\"]")
+
+        page.click("#confirmDeleteBtn")
+        expect(page.locator("#messageDiv")).to_contain_text("deleted", timeout=8000)
+
+        page.reload()
+        expect(page.locator("#categoriesList")).not_to_contain_text(cat_name, timeout=10000)
+
+
+class TestSkillsAdminApi:
+    """Direct API tests against the skills admin endpoints."""
+
+    @pytest.mark.local_only
+    def test_list_skill_categories_requires_admin(self, api_url):
+        resp = requests.get(f"{api_url}/api/admin/skill-categories", timeout=10)
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_list_skill_categories_forbidden_for_non_admin(self, api_url, new_user):
+        resp = requests.get(
+            f"{api_url}/api/admin/skill-categories",
+            headers={"Authorization": f"Bearer {new_user['token']}"},
+            timeout=10,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.local_only
+    def test_create_and_delete_category(self, api_url, admin_token):
+        cat_name = f"API Cat {uuid.uuid4().hex[:6]}"
+        created = _api(
+            "POST", "/api/admin/skill-categories", base_url=api_url,
+            json={"name": cat_name},
+            token=admin_token,
+        )
+        assert created["id"]
+        assert created["name"] == cat_name
+
+        cats = _api("GET", "/api/admin/skill-categories", base_url=api_url, token=admin_token)
+        assert any(c["id"] == created["id"] for c in cats)
+
+        deleted = _api("DELETE", f"/api/admin/skill-categories/{created['id']}", base_url=api_url, token=admin_token)
+        assert deleted["success"] is True
+
+    @pytest.mark.local_only
+    def test_cannot_delete_category_with_skills(self, api_url, admin_token):
+        cat_name = f"Blocked Cat {uuid.uuid4().hex[:6]}"
+        cat = _api(
+            "POST", "/api/admin/skill-categories", base_url=api_url,
+            json={"name": cat_name},
+            token=admin_token,
+        )
+        _api(
+            "POST", "/api/admin/skills", base_url=api_url,
+            json={"name": f"Orphan {uuid.uuid4().hex[:4]}", "category_id": cat["id"]},
+            token=admin_token,
+        )
+
+        resp = requests.delete(
+            f"{api_url}/api/admin/skill-categories/{cat['id']}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            timeout=10,
+        )
+        assert resp.status_code == 400
+        assert "skills" in resp.json()["detail"].lower()
+
+    @pytest.mark.local_only
+    def test_create_update_delete_skill(self, api_url, admin_token):
+        cat = _api(
+            "POST", "/api/admin/skill-categories", base_url=api_url,
+            json={"name": f"Skill CRUD Cat {uuid.uuid4().hex[:6]}"},
+            token=admin_token,
+        )
+        skill = _api(
+            "POST", "/api/admin/skills", base_url=api_url,
+            json={"name": "Initial Name", "category_id": cat["id"]},
+            token=admin_token,
+        )
+        assert skill["id"]
+
+        _api(
+            "PUT", f"/api/admin/skills/{skill['id']}", base_url=api_url,
+            json={"name": "Updated Name"},
+            token=admin_token,
+        )
+
+        tree = _api("GET", "/api/skills", base_url=api_url)
+        found_cat = next((c for c in tree if c["id"] == cat["id"]), None)
+        assert found_cat is not None
+        assert any(s["name"] == "Updated Name" for s in found_cat["skills"])
+
+        deleted = _api("DELETE", f"/api/admin/skills/{skill['id']}", base_url=api_url, token=admin_token)
+        assert deleted["success"] is True
+
+        _api("DELETE", f"/api/admin/skill-categories/{cat['id']}", base_url=api_url, token=admin_token)

--- a/web/app/api/admin/skill-categories/[id]/route.ts
+++ b/web/app/api/admin/skill-categories/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireAdmin } from '@/lib/auth'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  const { id } = await params
+  const categoryId = parseInt(id)
+  if (isNaN(categoryId)) return Response.json({ detail: 'Invalid id' }, { status: 400 })
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const existing = await prisma.skillCategory.findUnique({ where: { id: categoryId } })
+  if (!existing) return Response.json({ detail: 'Category not found' }, { status: 404 })
+
+  const data: { name?: string; description?: string | null; sortOrder?: number } = {}
+  if (body.name != null) data.name = String(body.name).trim()
+  if ('description' in body) data.description = body.description ? String(body.description) : null
+  if (body.sort_order != null) data.sortOrder = Number(body.sort_order)
+
+  await prisma.skillCategory.update({ where: { id: categoryId }, data })
+
+  return Response.json({ success: true })
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  const { id } = await params
+  const categoryId = parseInt(id)
+  if (isNaN(categoryId)) return Response.json({ detail: 'Invalid id' }, { status: 400 })
+
+  const skillCount = await prisma.skill.count({ where: { categoryId } })
+  if (skillCount > 0) {
+    return Response.json(
+      { detail: `Cannot delete category with ${skillCount} skills. Move or delete skills first.` },
+      { status: 400 }
+    )
+  }
+
+  const result = await prisma.skillCategory.deleteMany({ where: { id: categoryId } })
+  if (result.count === 0) return Response.json({ detail: 'Category not found' }, { status: 404 })
+
+  return Response.json({ success: true })
+}

--- a/web/app/api/admin/skill-categories/route.ts
+++ b/web/app/api/admin/skill-categories/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireAdmin } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  const categories = await prisma.skillCategory.findMany({
+    include: { _count: { select: { skills: true } } },
+    orderBy: { sortOrder: 'asc' },
+  })
+
+  return Response.json(
+    categories.map(cat => ({
+      id: cat.id,
+      name: cat.name,
+      description: cat.description,
+      sort_order: cat.sortOrder,
+      created_at: cat.createdAt,
+      skill_count: cat._count.skills,
+    }))
+  )
+}
+
+export async function POST(request: NextRequest) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const name = String(body.name || '').trim()
+  if (!name || name.length > 100) {
+    return Response.json({ detail: 'Name is required and must be at most 100 characters' }, { status: 422 })
+  }
+
+  const description = body.description ? String(body.description) : null
+
+  let sortOrder = body.sort_order != null ? Number(body.sort_order) : null
+  if (sortOrder === null) {
+    const max = await prisma.skillCategory.aggregate({ _max: { sortOrder: true } })
+    sortOrder = (max._max.sortOrder ?? 0) + 1
+  }
+
+  const category = await prisma.skillCategory.create({
+    data: { name, description, sortOrder },
+  })
+
+  return Response.json({ id: category.id, name: category.name, sort_order: category.sortOrder })
+}

--- a/web/app/api/admin/skills/[id]/route.ts
+++ b/web/app/api/admin/skills/[id]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireAdmin } from '@/lib/auth'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  const { id } = await params
+  const skillId = parseInt(id)
+  if (isNaN(skillId)) return Response.json({ detail: 'Invalid id' }, { status: 400 })
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const existing = await prisma.skill.findUnique({ where: { id: skillId } })
+  if (!existing) return Response.json({ detail: 'Skill not found' }, { status: 404 })
+
+  const data: {
+    name?: string
+    description?: string | null
+    sortOrder?: number
+    categoryId?: number
+  } = {}
+  if (body.name != null) data.name = String(body.name).trim()
+  if ('description' in body) data.description = body.description ? String(body.description) : null
+  if (body.sort_order != null) data.sortOrder = Number(body.sort_order)
+  if (body.category_id != null) {
+    const categoryId = parseInt(String(body.category_id))
+    const category = await prisma.skillCategory.findUnique({ where: { id: categoryId } })
+    if (!category) return Response.json({ detail: 'Category not found' }, { status: 400 })
+    data.categoryId = categoryId
+  }
+
+  await prisma.skill.update({ where: { id: skillId }, data })
+
+  return Response.json({ success: true })
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  const { id } = await params
+  const skillId = parseInt(id)
+  if (isNaN(skillId)) return Response.json({ detail: 'Invalid id' }, { status: 400 })
+
+  const skill = await prisma.skill.findUnique({ where: { id: skillId } })
+  if (!skill) return Response.json({ detail: 'Skill not found' }, { status: 404 })
+
+  // Null out starter tasks that reference this skill (match FastAPI cascade behaviour)
+  await prisma.starterTask.updateMany({ where: { skillId }, data: { skillId: null } })
+
+  // Delete skill — Prisma cascades VolunteerSkill, ProjectSkill, SkillEndorsement
+  await prisma.skill.delete({ where: { id: skillId } })
+
+  return Response.json({ success: true, deleted_skill: { id: skill.id, name: skill.name } })
+}

--- a/web/app/api/admin/skills/route.ts
+++ b/web/app/api/admin/skills/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireAdmin } from '@/lib/auth'
+
+export async function POST(request: NextRequest) {
+  const { error } = await requireAdmin(request.headers.get('authorization'))
+  if (error) return error
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const name = String(body.name || '').trim()
+  if (!name || name.length > 100) {
+    return Response.json({ detail: 'Name is required and must be at most 100 characters' }, { status: 422 })
+  }
+
+  const categoryId = body.category_id != null ? parseInt(String(body.category_id)) : NaN
+  if (isNaN(categoryId)) {
+    return Response.json({ detail: 'category_id is required' }, { status: 422 })
+  }
+
+  const category = await prisma.skillCategory.findUnique({ where: { id: categoryId } })
+  if (!category) return Response.json({ detail: 'Category not found' }, { status: 400 })
+
+  const description = body.description ? String(body.description) : null
+
+  let sortOrder = body.sort_order != null ? Number(body.sort_order) : null
+  if (sortOrder === null) {
+    const max = await prisma.skill.aggregate({
+      where: { categoryId },
+      _max: { sortOrder: true },
+    })
+    sortOrder = (max._max.sortOrder ?? 0) + 1
+  }
+
+  const skill = await prisma.skill.create({
+    data: { categoryId, name, description, sortOrder },
+  })
+
+  return Response.json({ id: skill.id, name: skill.name, category_id: skill.categoryId })
+}

--- a/web/app/api/skills/flat/route.ts
+++ b/web/app/api/skills/flat/route.ts
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const skills = await prisma.skill.findMany({
+    include: { category: true },
+    orderBy: [{ category: { sortOrder: 'asc' } }, { sortOrder: 'asc' }],
+  })
+
+  return Response.json(
+    skills.map(s => ({
+      id: s.id,
+      category_id: s.categoryId,
+      name: s.name,
+      description: s.description,
+      sort_order: s.sortOrder,
+      created_at: s.createdAt,
+      category_name: s.category.name,
+    }))
+  )
+}

--- a/web/app/api/skills/route.ts
+++ b/web/app/api/skills/route.ts
@@ -1,0 +1,28 @@
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const categories = await prisma.skillCategory.findMany({
+    include: {
+      skills: { orderBy: { sortOrder: 'asc' } },
+    },
+    orderBy: { sortOrder: 'asc' },
+  })
+
+  return Response.json(
+    categories.map(cat => ({
+      id: cat.id,
+      name: cat.name,
+      description: cat.description,
+      sort_order: cat.sortOrder,
+      created_at: cat.createdAt,
+      skills: cat.skills.map(s => ({
+        id: s.id,
+        category_id: s.categoryId,
+        name: s.name,
+        description: s.description,
+        sort_order: s.sortOrder,
+        created_at: s.createdAt,
+      })),
+    }))
+  )
+}

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -111,6 +111,19 @@ export function serializeEndorsement(se: {
   return { skill_id: se.skillId, rating: se.rating, skill_name: se.skill.name }
 }
 
+export async function requireAdmin(
+  authorization: string | null | undefined
+): Promise<{ volunteer: NonNullable<Awaited<ReturnType<typeof getCurrentVolunteer>>>; error: null } | { volunteer: null; error: Response }> {
+  const volunteer = await getCurrentVolunteer(authorization)
+  if (!volunteer) {
+    return { volunteer: null, error: Response.json({ detail: 'Authentication required' }, { status: 401 }) }
+  }
+  if (!volunteer.isAdmin) {
+    return { volunteer: null, error: Response.json({ detail: 'Admin access required' }, { status: 403 }) }
+  }
+  return { volunteer, error: null }
+}
+
 // Promote volunteer to admin if their email is in ADMIN_EMAILS env var
 export async function checkAdminBootstrap(email: string, volunteerId: number): Promise<boolean> {
   const adminEmails = process.env.ADMIN_EMAILS || ''


### PR DESCRIPTION
## Summary

- Add Next.js API routes for skills: `GET /api/skills`, `GET /api/skills/flat`, and full admin CRUD for skill categories and skills (`/api/admin/skill-categories`, `/api/admin/skills`)
- Wire `static/admin/skills.html` and `app.js` to route all skills API calls through `SKILLS_BASE_URL` (Next.js during migration, relative URLs in production)
- Add `requireAdmin` helper to `web/lib/auth.ts` for consistent auth/authz checks across admin routes

## Test plan

- [x] `make test` — 47 tests pass
- [x] `TestSkillsPublicEndpoints` runs against both FastAPI and Next.js (`[fastapi-chromium]` / `[nextjs-chromium]`)
- [x] `TestSkillsAdminApi` runs against both backends — CRUD, auth enforcement (401/403), constraint checks
- [x] `TestAuthApi` added — signup, login, `/me`, and error cases parameterised across both backends
- [x] `TestSkillManagementPage` browser tests pass (UI always targets Next.js via port derivation in `app.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)