### PR TITLE
feat: Next.js volunteer and dashboard routes (Phase 4)

### DIFF
--- a/tests/e2e/test_volunteers.py
+++ b/tests/e2e/test_volunteers.py
@@ -1,0 +1,235 @@
+"""
+E2E tests for Volunteer and Dashboard routes — parameterised to run against both FastAPI and Next.js.
+
+Scenarios covered:
+  - GET /api/volunteers        (list, public profiles)
+  - GET /api/volunteers/{id}   (single profile, contact visibility)
+  - PUT /api/volunteers/me     (update own profile, skills)
+  - GET /api/dashboard         (owned/proposed/interests/suggested projects, unread count)
+"""
+
+import uuid
+import requests
+import pytest
+
+
+def _api(method, path, base_url, json=None, token=None, params=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.request(
+        method, f"{base_url}{path}",
+        json=json, headers=headers, params=params, timeout=10,
+    )
+    return resp
+
+
+class TestVolunteerList:
+    """GET /api/volunteers — public volunteer directory."""
+
+    @pytest.mark.local_only
+    def test_returns_paginated_structure(self, api_url, new_user):
+        resp = _api("GET", "/api/volunteers", base_url=api_url)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "volunteers" in data
+        assert "total" in data
+        assert isinstance(data["volunteers"], list)
+        assert isinstance(data["total"], int)
+
+    @pytest.mark.local_only
+    def test_new_user_appears_in_list(self, api_url, new_user):
+        # Default signup sets profile_visible=True and consent_profile_visible=True
+        resp = _api("GET", "/api/volunteers", base_url=api_url)
+        assert resp.status_code == 200
+        ids = [v["id"] for v in resp.json()["volunteers"]]
+        assert new_user["id"] in ids
+
+    @pytest.mark.local_only
+    def test_volunteer_has_expected_fields(self, api_url, new_user):
+        resp = _api("GET", "/api/volunteers", base_url=api_url)
+        assert resp.status_code == 200
+        volunteers = resp.json()["volunteers"]
+        vol = next((v for v in volunteers if v["id"] == new_user["id"]), None)
+        assert vol is not None
+        assert "id" in vol
+        assert "name" in vol
+        assert "skills" in vol
+        # Contact fields must NOT appear in the public list
+        assert "email" not in vol
+        assert "discord_handle" not in vol
+
+    @pytest.mark.local_only
+    def test_search_filter(self, api_url):
+        unique_name = f"VolSearch_{uuid.uuid4().hex[:8]}"
+        email = f"{unique_name.lower()}@test.com"
+        signup = _api("POST", "/api/auth/signup", base_url=api_url, json={
+            "name": unique_name,
+            "email": email,
+            "password": "testpassword1",
+            "consent_profile_visible": True,
+            "consent_contact_by_owners": True,
+        })
+        assert signup.status_code == 200
+
+        resp = _api("GET", "/api/volunteers", base_url=api_url, params={"search": unique_name})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        assert any(v["name"] == unique_name for v in data["volunteers"])
+
+    @pytest.mark.local_only
+    def test_limit_and_offset(self, api_url, new_user):
+        resp = _api("GET", "/api/volunteers", base_url=api_url, params={"limit": 1, "offset": 0})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["volunteers"]) <= 1
+
+
+class TestVolunteerDetail:
+    """GET /api/volunteers/{id} — single volunteer profile."""
+
+    @pytest.mark.local_only
+    def test_own_profile_shows_contact_info(self, api_url, new_user):
+        resp = _api("GET", f"/api/volunteers/{new_user['id']}", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == new_user["id"]
+        assert "email" in data
+
+    @pytest.mark.local_only
+    def test_other_profile_hides_contact_info_by_default(self, api_url, new_user):
+        # Create a second user whose shareContactDirectly is False (default)
+        other_email = f"other_{uuid.uuid4().hex[:8]}@test.com"
+        other_signup = _api("POST", "/api/auth/signup", base_url=api_url, json={
+            "name": "Other User",
+            "email": other_email,
+            "password": "testpassword1",
+            "consent_profile_visible": True,
+            "consent_contact_by_owners": True,
+        })
+        assert other_signup.status_code == 200
+        other_id = other_signup.json()["id"]
+
+        resp = _api("GET", f"/api/volunteers/{other_id}", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "email" not in data
+
+    @pytest.mark.local_only
+    def test_profile_includes_projects_and_completed_tasks(self, api_url, new_user):
+        resp = _api("GET", f"/api/volunteers/{new_user['id']}", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "projects" in data
+        assert "completed_tasks" in data
+
+    @pytest.mark.local_only
+    def test_unknown_volunteer_returns_404(self, api_url):
+        resp = _api("GET", "/api/volunteers/999999", base_url=api_url)
+        assert resp.status_code == 404
+
+
+class TestVolunteerUpdateMe:
+    """PUT /api/volunteers/me — update own profile."""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url):
+        resp = _api("PUT", "/api/volunteers/me", base_url=api_url, json={"bio": "Hello"})
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_update_bio(self, api_url, new_user):
+        new_bio = f"Updated bio {uuid.uuid4().hex[:6]}"
+        resp = _api("PUT", "/api/volunteers/me", base_url=api_url, token=new_user["token"], json={"bio": new_bio})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["bio"] == new_bio
+
+    @pytest.mark.local_only
+    def test_update_multiple_fields(self, api_url, new_user):
+        resp = _api("PUT", "/api/volunteers/me", base_url=api_url, token=new_user["token"], json={
+            "location": "London",
+            "availability_hours_per_week": 10,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["location"] == "London"
+        assert data["availability_hours_per_week"] == 10
+
+    @pytest.mark.local_only
+    def test_update_skills(self, api_url, new_user):
+        # Grab the first available skill ID
+        skills_resp = _api("GET", "/api/skills", base_url=api_url)
+        categories = skills_resp.json()
+        if not categories or not categories[0]["skills"]:
+            pytest.skip("No skills in DB")
+        skill_id = categories[0]["skills"][0]["id"]
+
+        resp = _api("PUT", "/api/volunteers/me", base_url=api_url, token=new_user["token"], json={
+            "skill_ids": [skill_id],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        skill_ids_returned = [s["id"] for s in data["skills"]]
+        assert skill_id in skill_ids_returned
+
+    @pytest.mark.local_only
+    def test_clear_skills(self, api_url, new_user):
+        resp = _api("PUT", "/api/volunteers/me", base_url=api_url, token=new_user["token"], json={
+            "skill_ids": [],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["skills"] == []
+
+    @pytest.mark.local_only
+    def test_response_includes_contact_fields(self, api_url, new_user):
+        resp = _api("PUT", "/api/volunteers/me", base_url=api_url, token=new_user["token"], json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "email" in data
+
+
+class TestDashboard:
+    """GET /api/dashboard — personalised volunteer dashboard."""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url):
+        resp = _api("GET", "/api/dashboard", base_url=api_url)
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_returns_expected_structure(self, api_url, new_user):
+        resp = _api("GET", "/api/dashboard", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "owned_projects" in data
+        assert "proposed_projects" in data
+        assert "my_interests" in data
+        assert "suggested_projects" in data
+        assert "unread_notification_count" in data
+
+    @pytest.mark.local_only
+    def test_unread_count_is_integer(self, api_url, new_user):
+        resp = _api("GET", "/api/dashboard", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        assert isinstance(resp.json()["unread_notification_count"], int)
+
+    @pytest.mark.local_only
+    def test_owned_projects_appear(self, api_url, admin_token):
+        from tests.e2e.helpers import BASE_URL
+
+        # Admin creates a project with want_to_own=True — owner_id is set to admin's id
+        proj = _api("POST", "/api/admin/projects", base_url=BASE_URL, json={
+            "title": f"Dashboard Test Project {uuid.uuid4().hex[:6]}",
+            "description": "Project for dashboard e2e test.",
+            "urgency": "medium",
+            "want_to_own": True,
+        }, token=admin_token)
+        assert proj.status_code == 200
+        project_id = proj.json()["id"]
+
+        resp = _api("GET", "/api/dashboard", base_url=api_url, token=admin_token)
+        assert resp.status_code == 200
+        owned_ids = [p["id"] for p in resp.json()["owned_projects"]]
+        assert project_id in owned_ids

--- a/web/app/api/dashboard/route.ts
+++ b/web/app/api/dashboard/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest } from 'next/server'
+import { Prisma } from '@/app/generated/prisma/client'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+import { calculateMatchScore } from '@/lib/matching'
+
+type ProjectSkillWithRelations = {
+  skillId: number
+  isRequired: boolean | null
+  skill: {
+    id: number
+    categoryId: number
+    name: string
+    description: string | null
+    sortOrder: number | null
+    createdAt: Date | null
+    category: { name: string }
+  }
+}
+
+function serializeProjectSkill(ps: ProjectSkillWithRelations) {
+  return {
+    id: ps.skill.id,
+    category_id: ps.skill.categoryId,
+    name: ps.skill.name,
+    description: ps.skill.description,
+    sort_order: ps.skill.sortOrder,
+    created_at: ps.skill.createdAt,
+    category_name: ps.skill.category.name,
+    is_required: ps.isRequired,
+  }
+}
+
+type EnrichedProject = {
+  id: number
+  title: string
+  description: string
+  status: string
+  ownerId: number | null
+  proposedById: number | null
+  isOrgProposed: boolean | null
+  projectType: string | null
+  estimatedDuration: string | null
+  timeCommitmentHoursPerWeek: number | null
+  urgency: string | null
+  reviewNotes: string | null
+  reviewedById: number | null
+  reviewedAt: Date | null
+  feedbackToProposer: string | null
+  collaborationLink: string | null
+  outcome: string | null
+  outcomeNotes: string | null
+  completedAt: Date | null
+  createdAt: Date | null
+  updatedAt: Date | null
+  country: string | null
+  isSeekingHelp: boolean | null
+  isSeekingOwner: boolean | null
+  localGroup: string | null
+  skills: ProjectSkillWithRelations[]
+  owner: { id: number; name: string } | null
+  proposedBy: { id: number; name: string } | null
+  _count: { interests: number }
+}
+
+function serializeProject(p: EnrichedProject, volunteerSkillIds?: Set<number>) {
+  const matchInput = p.skills.map(ps => ({ id: ps.skillId, isRequired: ps.isRequired }))
+  const match = volunteerSkillIds !== undefined
+    ? calculateMatchScore(volunteerSkillIds, matchInput)
+    : undefined
+
+  return {
+    id: p.id,
+    title: p.title,
+    description: p.description,
+    status: p.status,
+    owner_id: p.ownerId,
+    proposed_by_id: p.proposedById,
+    is_org_proposed: p.isOrgProposed,
+    project_type: p.projectType,
+    estimated_duration: p.estimatedDuration,
+    time_commitment_hours_per_week: p.timeCommitmentHoursPerWeek,
+    urgency: p.urgency,
+    review_notes: p.reviewNotes,
+    reviewed_by_id: p.reviewedById,
+    reviewed_at: p.reviewedAt,
+    feedback_to_proposer: p.feedbackToProposer,
+    collaboration_link: p.collaborationLink,
+    outcome: p.outcome,
+    outcome_notes: p.outcomeNotes,
+    completed_at: p.completedAt,
+    created_at: p.createdAt,
+    updated_at: p.updatedAt,
+    country: p.country,
+    is_seeking_help: p.isSeekingHelp,
+    is_seeking_owner: p.isSeekingOwner,
+    local_group: p.localGroup,
+    skills: p.skills.map(serializeProjectSkill),
+    owner: p.owner,
+    proposed_by: p.proposedBy,
+    pending_interest_count: p._count.interests,
+    ...(match !== undefined ? { match } : {}),
+  }
+}
+
+const projectInclude = {
+  skills: {
+    include: { skill: { include: { category: true } } },
+    orderBy: [
+      { isRequired: Prisma.SortOrder.desc },
+      { skill: { category: { sortOrder: Prisma.SortOrder.asc } } },
+      { skill: { sortOrder: Prisma.SortOrder.asc } },
+    ],
+  },
+  owner: { select: { id: true, name: true } },
+  proposedBy: { select: { id: true, name: true } },
+  _count: { select: { interests: { where: { status: 'pending' } } } },
+} satisfies Prisma.ProjectInclude
+
+export async function GET(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  const volunteerWithSkills = await prisma.volunteer.findUnique({
+    where: { id: volunteer.id },
+    select: { skills: { select: { skillId: true } } },
+  })
+  const volunteerSkillIds = new Set(
+    (volunteerWithSkills?.skills ?? []).map(s => s.skillId)
+  )
+
+  const alreadyInterestedProjects = await prisma.projectInterest.findMany({
+    where: { volunteerId: volunteer.id },
+    select: { projectId: true },
+  })
+  const interestedProjectIds = alreadyInterestedProjects.map(i => i.projectId)
+
+  const [ownedProjects, proposedProjects, myInterests, suggestedProjects, unreadCount] =
+    await Promise.all([
+      prisma.project.findMany({
+        where: { ownerId: volunteer.id },
+        orderBy: { updatedAt: 'desc' },
+        include: projectInclude,
+      }),
+
+      prisma.project.findMany({
+        where: {
+          proposedById: volunteer.id,
+          OR: [{ ownerId: null }, { ownerId: { not: volunteer.id } }],
+        },
+        orderBy: { createdAt: 'desc' },
+        include: projectInclude,
+      }),
+
+      prisma.projectInterest.findMany({
+        where: { volunteerId: volunteer.id },
+        orderBy: { createdAt: 'desc' },
+        include: {
+          project: { select: { title: true, status: true } },
+        },
+      }),
+
+      volunteerSkillIds.size > 0
+        ? prisma.project.findMany({
+            where: {
+              skills: { some: { skillId: { in: [...volunteerSkillIds] } } },
+              OR: [
+                { isSeekingHelp: true },
+                { isSeekingOwner: true },
+                { status: { in: ['seeking_owner', 'seeking_help'] } },
+              ],
+              ownerId: { not: volunteer.id },
+              id: { notIn: interestedProjectIds.length > 0 ? interestedProjectIds : [-1] },
+            },
+            orderBy: { createdAt: 'desc' },
+            take: 5,
+            include: projectInclude,
+          })
+        : Promise.resolve([]),
+
+      prisma.notification.count({
+        where: { volunteerId: volunteer.id, readAt: null },
+      }),
+    ])
+
+  return Response.json({
+    owned_projects: ownedProjects.map(p => serializeProject(p as EnrichedProject)),
+    proposed_projects: proposedProjects.map(p => serializeProject(p as EnrichedProject)),
+    my_interests: myInterests.map(i => ({
+      id: i.id,
+      volunteer_id: i.volunteerId,
+      project_id: i.projectId,
+      interest_type: i.interestType,
+      message: i.message,
+      status: i.status,
+      response_message: i.responseMessage,
+      created_at: i.createdAt,
+      responded_at: i.respondedAt,
+      project_title: i.project.title,
+      project_status: i.project.status,
+    })),
+    suggested_projects: suggestedProjects.map(p => serializeProject(p as EnrichedProject, volunteerSkillIds)),
+    unread_notification_count: unreadCount,
+  })
+}

--- a/web/app/api/volunteers/[id]/route.ts
+++ b/web/app/api/volunteers/[id]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer, serializeVolunteer, serializeSkill, serializeEndorsement } from '@/lib/auth'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: idParam } = await params
+  const volunteerId = parseInt(idParam, 10)
+  if (isNaN(volunteerId)) {
+    return Response.json({ detail: 'Invalid volunteer ID' }, { status: 400 })
+  }
+
+  const currentVolunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+
+  const vol = await prisma.volunteer.findFirst({
+    where: { id: volunteerId, deletedAt: null, profileVisible: true },
+    include: {
+      skills: {
+        include: { skill: { include: { category: true } } },
+        orderBy: [
+          { skill: { category: { sortOrder: 'asc' } } },
+          { skill: { sortOrder: 'asc' } },
+        ],
+      },
+      skillEndorsementsReceived: {
+        include: { skill: true },
+      },
+    },
+  })
+
+  if (!vol) {
+    return Response.json({ detail: 'Volunteer not found' }, { status: 404 })
+  }
+
+  let showContact = false
+  if (currentVolunteer) {
+    if (currentVolunteer.id === volunteerId) {
+      showContact = true
+    } else if (currentVolunteer.isAdmin) {
+      showContact = true
+    } else if (vol.shareContactDirectly && vol.consentContactByOwners) {
+      showContact = true
+    }
+  }
+
+  const skills = vol.skills.map(serializeSkill)
+  const endorsements = vol.skillEndorsementsReceived.map(serializeEndorsement)
+
+  const projects = await prisma.project.findMany({
+    where: {
+      OR: [{ ownerId: volunteerId }, { proposedById: volunteerId }],
+      status: { notIn: ['archived', 'pending_review', 'needs_discussion'] },
+    },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      status: true,
+      ownerId: true,
+      proposedById: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  })
+
+  const completedTasks = await prisma.starterTask.findMany({
+    where: {
+      assignedToId: volunteerId,
+      status: { in: ['completed', 'reviewed'] },
+      reviewRating: { in: ['excellent', 'good'] },
+    },
+    orderBy: { reviewedAt: 'desc' },
+    select: {
+      title: true,
+      reviewRating: true,
+      feedbackToVolunteer: true,
+      reviewedAt: true,
+      skill: { select: { name: true } },
+    },
+  })
+
+  return Response.json({
+    ...serializeVolunteer(vol as unknown as Record<string, unknown>, { showContact, skills, endorsements }),
+    projects: projects.map(p => ({
+      ...p,
+      owner_id: p.ownerId,
+      proposed_by_id: p.proposedById,
+      created_at: p.createdAt,
+      updated_at: p.updatedAt,
+      role: p.ownerId === volunteerId ? 'owner' : 'proposer',
+    })),
+    completed_tasks: completedTasks.map(t => ({
+      title: t.title,
+      review_rating: t.reviewRating,
+      feedback_to_volunteer: t.feedbackToVolunteer,
+      reviewed_at: t.reviewedAt,
+      skill_name: t.skill?.name ?? null,
+    })),
+  })
+}

--- a/web/app/api/volunteers/me/route.ts
+++ b/web/app/api/volunteers/me/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer, serializeVolunteer, serializeSkill, serializeEndorsement } from '@/lib/auth'
+
+export async function PUT(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const updatable = [
+    'name', 'bio', 'discord_handle', 'signal_number', 'whatsapp_number',
+    'contact_preference', 'contact_notes', 'availability_hours_per_week',
+    'location', 'country', 'local_group', 'share_contact_directly',
+    'other_skills', 'profile_visible', 'email_digest',
+  ] as const
+
+  const prismaFieldMap: Record<string, string> = {
+    discord_handle: 'discordHandle',
+    signal_number: 'signalNumber',
+    whatsapp_number: 'whatsappNumber',
+    contact_preference: 'contactPreference',
+    contact_notes: 'contactNotes',
+    availability_hours_per_week: 'availabilityHoursPerWeek',
+    local_group: 'localGroup',
+    share_contact_directly: 'shareContactDirectly',
+    other_skills: 'otherSkills',
+    profile_visible: 'profileVisible',
+    email_digest: 'emailDigest',
+  }
+
+  const data: Record<string, unknown> = { updatedAt: new Date() }
+  for (const field of updatable) {
+    if (Object.prototype.hasOwnProperty.call(body, field)) {
+      const prismaKey = prismaFieldMap[field] ?? field
+      data[prismaKey] = body[field]
+    }
+  }
+
+  const skillIds: number[] | undefined =
+    Array.isArray(body.skill_ids)
+      ? (body.skill_ids as unknown[]).map(id => Number(id)).filter(n => !isNaN(n))
+      : undefined
+
+  const [vol] = await prisma.$transaction(async tx => {
+    const updated = await tx.volunteer.update({
+      where: { id: volunteer.id },
+      data,
+      include: {
+        skills: {
+          include: { skill: { include: { category: true } } },
+          orderBy: [
+            { skill: { category: { sortOrder: 'asc' } } },
+            { skill: { sortOrder: 'asc' } },
+          ],
+        },
+        skillEndorsementsReceived: {
+          include: { skill: true },
+        },
+      },
+    })
+
+    if (skillIds !== undefined) {
+      await tx.volunteerSkill.deleteMany({ where: { volunteerId: volunteer.id } })
+      if (skillIds.length > 0) {
+        await tx.volunteerSkill.createMany({
+          data: skillIds.map(skillId => ({ volunteerId: volunteer.id, skillId })),
+        })
+      }
+      const fresh = await tx.volunteer.findUnique({
+        where: { id: volunteer.id },
+        include: {
+          skills: {
+            include: { skill: { include: { category: true } } },
+            orderBy: [
+              { skill: { category: { sortOrder: 'asc' } } },
+              { skill: { sortOrder: 'asc' } },
+            ],
+          },
+          skillEndorsementsReceived: {
+            include: { skill: true },
+          },
+        },
+      })
+      return [fresh!]
+    }
+
+    return [updated]
+  })
+
+  const skills = vol.skills.map(serializeSkill)
+  const endorsements = vol.skillEndorsementsReceived.map(serializeEndorsement)
+
+  return Response.json(
+    serializeVolunteer(vol as unknown as Record<string, unknown>, {
+      showContact: true,
+      skills,
+      endorsements,
+    })
+  )
+}

--- a/web/app/api/volunteers/route.ts
+++ b/web/app/api/volunteers/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { serializeSkill } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const skillIdsParam = searchParams.get('skill_ids')
+  const search = searchParams.get('search')
+  const country = searchParams.get('country')
+  const localGroup = searchParams.get('local_group')
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '50', 10), 100)
+  const offset = parseInt(searchParams.get('offset') ?? '0', 10)
+
+  const skillIds = skillIdsParam
+    ? skillIdsParam.split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n))
+    : null
+
+  const where: Record<string, unknown> = {
+    deletedAt: null,
+    profileVisible: true,
+    consentProfileVisible: true,
+    ...(skillIds && skillIds.length > 0
+      ? { skills: { some: { skillId: { in: skillIds } } } }
+      : {}),
+    ...(search
+      ? { OR: [{ name: { contains: search } }, { bio: { contains: search } }] }
+      : {}),
+    ...(country ? { country } : {}),
+    ...(localGroup ? { localGroup } : {}),
+  }
+
+  const [volunteers, total] = await Promise.all([
+    prisma.volunteer.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        bio: true,
+        availabilityHoursPerWeek: true,
+        location: true,
+        otherSkills: true,
+        localGroup: true,
+        createdAt: true,
+        skills: {
+          include: { skill: { include: { category: true } } },
+          orderBy: [
+            { skill: { category: { sortOrder: 'asc' } } },
+            { skill: { sortOrder: 'asc' } },
+          ],
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.volunteer.count({ where }),
+  ])
+
+  return Response.json({
+    volunteers: volunteers.map(v => ({
+      id: v.id,
+      name: v.name,
+      bio: v.bio,
+      availability_hours_per_week: v.availabilityHoursPerWeek,
+      location: v.location,
+      other_skills: v.otherSkills,
+      local_group: v.localGroup,
+      created_at: v.createdAt,
+      skills: v.skills.map(serializeSkill),
+    })),
+    total,
+  })
+}

--- a/web/lib/matching.ts
+++ b/web/lib/matching.ts
@@ -1,0 +1,40 @@
+export interface ProjectSkillRow {
+  id: number
+  isRequired: boolean | null
+}
+
+export interface MatchScore {
+  required_match_percent: number
+  matched_required_count: number
+  total_required: number
+  matched_nice_to_have_count: number
+  total_nice_to_have: number
+  overall_score: number
+}
+
+export function calculateMatchScore(
+  volunteerSkillIds: Set<number>,
+  projectSkills: ProjectSkillRow[]
+): MatchScore {
+  const required = projectSkills.filter(s => s.isRequired)
+  const niceToHave = projectSkills.filter(s => !s.isRequired)
+
+  const requiredIds = new Set(required.map(s => s.id))
+  const niceIds = new Set(niceToHave.map(s => s.id))
+
+  const matchedRequired = new Set([...volunteerSkillIds].filter(id => requiredIds.has(id)))
+  const matchedNice = new Set([...volunteerSkillIds].filter(id => niceIds.has(id)))
+
+  const requiredScore = requiredIds.size > 0
+    ? (matchedRequired.size / requiredIds.size) * 100
+    : 100
+
+  return {
+    required_match_percent: Math.round(requiredScore),
+    matched_required_count: matchedRequired.size,
+    total_required: requiredIds.size,
+    matched_nice_to_have_count: matchedNice.size,
+    total_nice_to_have: niceIds.size,
+    overall_score: Math.round(requiredScore),
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `GET /api/volunteers`, `GET /api/volunteers/{id}`, `PUT /api/volunteers/me`, and `GET /api/dashboard` in Next.js, matching FastAPI parity
- Ports match-scoring logic from Python to `web/lib/matching.ts`
- Adds `tests/e2e/test_volunteers.py` parameterised to run each test against both FastAPI and Next.js backends via the existing `api_url` fixture

## Test plan

- [ ] Run `pytest tests/e2e/test_volunteers.py` — all 14 tests pass against both FastAPI and Next.js
- [ ] `GET /api/volunteers` returns paginated list with skills, hides contact fields
- [ ] `GET /api/volunteers/{id}` shows contact info to own profile owner / admin only
- [ ] `PUT /api/volunteers/me` updates profile fields and replaces skills atomically
- [ ] `GET /api/dashboard` returns owned/proposed projects, interests, skill-matched suggestions, unread count
- [ ] Unauthenticated requests to `/me` and `/dashboard` return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)