### PR TITLE
Edit/delete starter tasks + shareable per-task URLs

### DIFF
--- a/api.py
+++ b/api.py
@@ -465,6 +465,14 @@ class StarterTaskCreate(BaseModel):
     estimated_hours: Optional[float] = None
 
 
+class StarterTaskUpdate(BaseModel):
+    title: Optional[str] = Field(None, min_length=1, max_length=300)
+    description: Optional[str] = Field(None, min_length=1)
+    skill_id: Optional[int] = None
+    project_id: Optional[int] = None
+    estimated_hours: Optional[float] = None
+
+
 class StarterTaskAssign(BaseModel):
     volunteer_id: int
 
@@ -2991,6 +2999,107 @@ def create_starter_task(
             (data.title, data.description, data.skill_id, data.project_id, data.estimated_hours)
         )
         return {"id": cursor.lastrowid, "message": "Starter task created"}
+
+
+@app.get("/api/starter-tasks/{task_id}")
+def get_starter_task(
+    task_id: int,
+    current_volunteer: Optional[Dict] = Depends(get_current_volunteer)
+) -> Dict:
+    """Get a single starter task by ID. Open tasks are public; non-open tasks require admin or assignee."""
+    conn = get_db()
+    task = conn.execute(
+        """SELECT st.*, s.name as skill_name, sc.name as skill_category,
+                  p.title as project_title,
+                  v_assigned.name as assigned_to_name,
+                  v_reviewer.name as reviewed_by_name
+           FROM starter_tasks st
+           LEFT JOIN skills s ON st.skill_id = s.id
+           LEFT JOIN skill_categories sc ON s.category_id = sc.id
+           LEFT JOIN projects p ON st.project_id = p.id
+           LEFT JOIN volunteers v_assigned ON st.assigned_to_id = v_assigned.id
+           LEFT JOIN volunteers v_reviewer ON st.reviewed_by_id = v_reviewer.id
+           WHERE st.id = ?""",
+        (task_id,)
+    ).fetchone()
+    conn.close()
+
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    task_dict = dict(task)
+    if task_dict["status"] != "open":
+        is_admin = bool(current_volunteer and current_volunteer.get("is_admin"))
+        is_assignee = bool(
+            current_volunteer and task_dict.get("assigned_to_id") == current_volunteer["id"]
+        )
+        if not (is_admin or is_assignee):
+            raise HTTPException(status_code=404, detail="Task not found")
+
+    return task_dict
+
+
+@app.put("/api/starter-tasks/{task_id}")
+def update_starter_task(
+    task_id: int,
+    data: StarterTaskUpdate,
+    admin: Dict = Depends(require_admin)
+) -> Dict:
+    """Edit a starter task (admin only)."""
+    with db_transaction() as conn:
+        task = conn.execute("SELECT * FROM starter_tasks WHERE id = ?", (task_id,)).fetchone()
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        updates = []
+        params: List = []
+
+        if data.title is not None:
+            updates.append("title = ?")
+            params.append(data.title)
+        if data.description is not None:
+            updates.append("description = ?")
+            params.append(data.description)
+        if data.skill_id is not None:
+            updates.append("skill_id = ?")
+            params.append(data.skill_id)
+        if data.project_id is not None:
+            updates.append("project_id = ?")
+            params.append(data.project_id)
+        if data.estimated_hours is not None:
+            updates.append("estimated_hours = ?")
+            params.append(data.estimated_hours)
+
+        if updates:
+            updates.append("updated_at = ?")
+            params.append(datetime.now().isoformat())
+            params.append(task_id)
+            conn.execute(
+                f"UPDATE starter_tasks SET {', '.join(updates)} WHERE id = ?",
+                params
+            )
+
+        return {"message": "Starter task updated"}
+
+
+@app.delete("/api/starter-tasks/{task_id}")
+def delete_starter_task(
+    task_id: int,
+    admin: Dict = Depends(require_admin)
+) -> Dict:
+    """Delete a starter task (admin only)."""
+    with db_transaction() as conn:
+        task = conn.execute("SELECT * FROM starter_tasks WHERE id = ?", (task_id,)).fetchone()
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        conn.execute(
+            "DELETE FROM skill_endorsements WHERE source = 'starter_task' AND source_id = ?",
+            (task_id,)
+        )
+        conn.execute("DELETE FROM starter_tasks WHERE id = ?", (task_id,))
+
+        return {"message": "Starter task deleted"}
 
 
 @app.post("/api/starter-tasks/{task_id}/assign")

--- a/static/admin/starter-tasks.html
+++ b/static/admin/starter-tasks.html
@@ -89,6 +89,42 @@
         </div>
     </div>
 
+    <!-- Edit Task Modal -->
+    <div id="editModal" class="modal-overlay" style="display: none;">
+        <div class="modal" style="max-width: 600px;" role="dialog" aria-modal="true" aria-label="Edit Starter Task">
+            <div class="modal-header">
+                <h2>Edit Starter Task</h2>
+                <button class="modal-close" onclick="closeModal('editModal')">&times;</button>
+            </div>
+            <div class="modal-body">
+                <form id="editForm">
+                    <input type="hidden" id="editTaskId">
+                    <div class="form-group">
+                        <label for="editTaskTitle" class="required">Title</label>
+                        <input type="text" id="editTaskTitle" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="editTaskDescription" class="required">Description</label>
+                        <textarea id="editTaskDescription" required></textarea>
+                    </div>
+                    <div class="grid grid-2">
+                        <div class="form-group">
+                            <label for="editTaskSkill">Skill Being Tested</label>
+                            <select id="editTaskSkill">
+                                <option value="">None specific</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="editTaskHours">Estimated Hours</label>
+                            <input type="number" id="editTaskHours" min="0.5" max="20" step="0.5">
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Save Changes</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <!-- Assign Task Modal -->
     <div id="assignModal" class="modal-overlay" style="display: none;">
         <div class="modal" role="dialog" aria-modal="true" aria-label="Assign Task">
@@ -236,9 +272,12 @@
                         ` : ''}
                         <div class="card-footer">
                             <span style="font-size: 0.875rem; color: var(--text-light);">Created ${formatDate(t.created_at)}</span>
-                            <div style="display: flex; gap: 8px;">
+                            <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                                <button class="btn btn-small btn-secondary" onclick="event.stopPropagation(); copyTaskLink(${t.id})">Copy link</button>
                                 ${t.status === 'open' ? `<button class="btn btn-small btn-secondary" onclick="event.stopPropagation(); openAssign(${t.id})">Assign</button>` : ''}
                                 ${t.status === 'submitted' ? `<button class="btn btn-small btn-primary" onclick="event.stopPropagation(); openReview(${t.id})">Review</button>` : ''}
+                                <button class="btn btn-small btn-secondary" onclick="event.stopPropagation(); openEdit(${t.id})">Edit</button>
+                                <button class="btn btn-small btn-ghost" style="color: var(--error);" onclick="event.stopPropagation(); deleteTask(${t.id})">Delete</button>
                             </div>
                         </div>
                     </div>
@@ -260,13 +299,72 @@
 
         async function loadSkillsDropdown() {
             const skills = await apiRequest('/api/skills/flat');
-            const select = document.getElementById('taskSkill');
+            const createSelect = document.getElementById('taskSkill');
+            const editSelect = document.getElementById('editTaskSkill');
             skills.forEach(s => {
-                const option = document.createElement('option');
-                option.value = s.id;
-                option.textContent = `${s.name} (${s.category_name})`;
-                select.appendChild(option);
+                const opt1 = document.createElement('option');
+                opt1.value = s.id;
+                opt1.textContent = `${s.name} (${s.category_name})`;
+                createSelect.appendChild(opt1);
+
+                const opt2 = document.createElement('option');
+                opt2.value = s.id;
+                opt2.textContent = `${s.name} (${s.category_name})`;
+                editSelect.appendChild(opt2);
             });
+        }
+
+        function copyTaskLink(taskId) {
+            const url = `${window.location.origin}/static/starter-tasks.html?id=${taskId}`;
+            navigator.clipboard.writeText(url).then(
+                () => showMessage('Public link copied to clipboard', 'success'),
+                () => showMessage(url, 'info')
+            );
+        }
+
+        function openEdit(taskId) {
+            const task = tasks.find(t => t.id === taskId);
+            if (!task) return;
+            document.getElementById('editTaskId').value = task.id;
+            document.getElementById('editTaskTitle').value = task.title || '';
+            document.getElementById('editTaskDescription').value = task.description || '';
+            document.getElementById('editTaskSkill').value = task.skill_id || '';
+            document.getElementById('editTaskHours').value = task.estimated_hours || '';
+            openModal('editModal');
+        }
+
+        document.getElementById('editForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const taskId = document.getElementById('editTaskId').value;
+            try {
+                await apiRequest(`/api/starter-tasks/${taskId}`, {
+                    method: 'PUT',
+                    body: JSON.stringify({
+                        title: document.getElementById('editTaskTitle').value.trim(),
+                        description: document.getElementById('editTaskDescription').value.trim(),
+                        skill_id: document.getElementById('editTaskSkill').value ? parseInt(document.getElementById('editTaskSkill').value) : null,
+                        estimated_hours: document.getElementById('editTaskHours').value ? parseFloat(document.getElementById('editTaskHours').value) : null
+                    })
+                });
+                closeModal('editModal');
+                showMessage('Task updated!', 'success');
+                await loadTasks();
+            } catch (error) {
+                showMessage(error.message, 'error');
+            }
+        });
+
+        async function deleteTask(taskId) {
+            const task = tasks.find(t => t.id === taskId);
+            const label = task ? `"${task.title}"` : 'this task';
+            if (!confirm(`Delete ${label}? This cannot be undone.`)) return;
+            try {
+                await apiRequest(`/api/starter-tasks/${taskId}`, { method: 'DELETE' });
+                showMessage('Task deleted', 'success');
+                await loadTasks();
+            } catch (error) {
+                showMessage(error.message, 'error');
+            }
         }
 
         async function loadVolunteersDropdown() {

--- a/static/starter-tasks.html
+++ b/static/starter-tasks.html
@@ -55,45 +55,80 @@
             await loadTasks();
         }
 
+        function renderTaskCard(task) {
+            return `
+                <div class="card" id="task-${task.id}" style="margin-bottom: 16px;">
+                    <div class="card-header" style="cursor: pointer;" onclick="toggleTask(${task.id})">
+                        <h3 class="card-title" style="display: flex; align-items: center; gap: 8px;">
+                            <span id="st-toggle-${task.id}" style="transition: transform 0.2s; display: inline-block;">&#9654;</span>
+                            ${escapeHtml(task.title)}
+                        </h3>
+                        <div style="display: flex; align-items: center; gap: 8px;">
+                            ${task.skill_name ? `<span class="skill-tag">${escapeHtml(task.skill_name)}</span>` : ''}
+                            ${task.estimated_hours ? `<span style="color: var(--text-light); font-size: 0.875rem;">~${task.estimated_hours}h</span>` : ''}
+                        </div>
+                    </div>
+                    <div id="st-details-${task.id}" style="display: none;">
+                        <p style="white-space: pre-wrap; margin: 12px 0;">${escapeHtml(task.description)}</p>
+                        <div class="card-meta">
+                            ${task.project_title ? `<span style="color: var(--text-light);">Related project: ${escapeHtml(task.project_title)}</span>` : ''}
+                        </div>
+                        <p style="margin-top: 12px; font-size: 0.875rem; color: var(--text-light);">
+                            Interested? Reach out to the team and let them know you'd like to take this on.
+                        </p>
+                        <div style="margin-top: 12px;">
+                            <button class="btn btn-small btn-secondary" onclick="event.stopPropagation(); copyTaskLink(${task.id})">Copy link to this task</button>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
         async function loadTasks() {
+            const container = document.getElementById('tasksList');
+            const emptyState = document.getElementById('emptyState');
+            const focusedId = parseInt(new URLSearchParams(window.location.search).get('id'), 10);
+
             try {
                 const tasks = await apiRequest('/api/starter-tasks/available');
-                const container = document.getElementById('tasksList');
-                const emptyState = document.getElementById('emptyState');
 
-                if (tasks.length === 0) {
+                if (tasks.length === 0 && !focusedId) {
                     container.innerHTML = '';
                     emptyState.style.display = 'block';
                     return;
                 }
 
                 emptyState.style.display = 'none';
-                container.innerHTML = tasks.map(task => `
-                    <div class="card" style="margin-bottom: 16px;">
-                        <div class="card-header" style="cursor: pointer;" onclick="toggleTask(${task.id})">
-                            <h3 class="card-title" style="display: flex; align-items: center; gap: 8px;">
-                                <span id="st-toggle-${task.id}" style="transition: transform 0.2s; display: inline-block;">&#9654;</span>
-                                ${escapeHtml(task.title)}
-                            </h3>
-                            <div style="display: flex; align-items: center; gap: 8px;">
-                                ${task.skill_name ? `<span class="skill-tag">${escapeHtml(task.skill_name)}</span>` : ''}
-                                ${task.estimated_hours ? `<span style="color: var(--text-light); font-size: 0.875rem;">~${task.estimated_hours}h</span>` : ''}
-                            </div>
-                        </div>
-                        <div id="st-details-${task.id}" style="display: none;">
-                            <p style="white-space: pre-wrap; margin: 12px 0;">${escapeHtml(task.description)}</p>
-                            <div class="card-meta">
-                                ${task.project_title ? `<span style="color: var(--text-light);">Related project: ${escapeHtml(task.project_title)}</span>` : ''}
-                            </div>
-                            <p style="margin-top: 12px; font-size: 0.875rem; color: var(--text-light);">
-                                Interested? Reach out to the team and let them know you'd like to take this on.
-                            </p>
-                        </div>
-                    </div>
-                `).join('');
+                let renderTasks = tasks;
+
+                // If linked to a specific task that isn't in the public available list,
+                // fetch it directly so the link still resolves.
+                if (focusedId && !tasks.some(t => t.id === focusedId)) {
+                    try {
+                        const single = await apiRequest(`/api/starter-tasks/${focusedId}`);
+                        renderTasks = [single, ...tasks];
+                    } catch (e) {
+                        showMessage('That starter task is not available.', 'error');
+                    }
+                }
+
+                container.innerHTML = renderTasks.map(renderTaskCard).join('');
+
+                if (focusedId && document.getElementById(`task-${focusedId}`)) {
+                    toggleTask(focusedId);
+                    document.getElementById(`task-${focusedId}`).scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
             } catch (error) {
                 showMessage('Failed to load starter tasks', 'error');
             }
+        }
+
+        function copyTaskLink(taskId) {
+            const url = `${window.location.origin}/static/starter-tasks.html?id=${taskId}`;
+            navigator.clipboard.writeText(url).then(
+                () => showMessage('Link copied to clipboard', 'success'),
+                () => showMessage(url, 'info')
+            );
         }
 
         function toggleTask(taskId) {


### PR DESCRIPTION
## Summary

Adds endpoints to **edit** and **delete** Starter Tasks, plus the ability to **deep-link** to an individual task by URL.

## API changes (`api.py`)

| Method | Path | Auth | Purpose |
|---|---|---|---|
| `GET` | `/api/starter-tasks/{task_id}` | public for `open` tasks; admin or assignee for non-open | Fetch a single task — used to resolve shared links |
| `PUT` | `/api/starter-tasks/{task_id}` | admin | Edit `title`, `description`, `skill_id`, `project_id`, `estimated_hours` (all optional / partial update) |
| `DELETE` | `/api/starter-tasks/{task_id}` | admin | Delete a task. Also removes any auto-created skill endorsements that referenced it (`source = 'starter_task'`, `source_id = task_id`) so we don't leave dangling rows. |

A new `StarterTaskUpdate` Pydantic model holds the optional edit fields. Existing endpoints (`/available`, list, create, assign, submit, review) are unchanged.

Route ordering is safe: `/api/starter-tasks/available` and `/api/my/starter-tasks` are declared before `/api/starter-tasks/{task_id}`, so they continue to win the match.

## Per-task URLs

- **Public page** (`static/starter-tasks.html`): reading `?id=<task_id>` auto-expands and scrolls to that task. If the task isn't in the public "available" list anymore (e.g. it's been assigned), the page falls back to the new GET-by-id endpoint so the link still resolves for an admin/assignee viewing it. Each open card now has a **Copy link** button.
- **Admin page** (`static/admin/starter-tasks.html`): each task card gets **Copy link**, **Edit** (modal pre-filled with the task), and **Delete** (with a confirm prompt) buttons. The skills dropdown is now populated for both the create and edit forms.

Shareable URL format: `/static/starter-tasks.html?id={id}`

## Test plan

- [x] Manual smoke test via FastAPI `TestClient` covers: create → GET-by-id (anon) → PUT (admin & forbidden-for-volunteer) → assign → GET-by-id access rules (anon 404, assignee/admin 200) → available list excludes assigned task → DELETE (forbidden-for-volunteer & admin) → 404s for nonexistent ids
- [ ] Run the existing Playwright e2e suite locally (env here doesn't have browsers installed)
- [ ] Click through the admin page: create → edit → copy link → delete
- [ ] Open `/static/starter-tasks.html?id=<id>` while logged in as a volunteer; confirm the right task auto-expands and scrolls into view

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5AdZVwajNmRBGdaP5PTVb)_