### PR TITLE
feat: implement Next.js messaging and notification routes (Phase 6)

### DIFF
--- a/api.py
+++ b/api.py
@@ -3873,34 +3873,31 @@ def send_contact_message(
         if project:
             project_title = project["title"]
 
-    # TODO: The message/notification is only created if email succeeds, meaning it
-    # fails entirely in environments without RESEND_API_KEY configured (e.g. local
-    # dev and the e2e test suite). Consider saving to contact_messages and creating
-    # the notification unconditionally, then treating email as best-effort delivery.
-
-    # Send via email relay
-    email_sent = send_relay_message(
-        to=recipient["email"],
-        to_name=recipient["name"],
-        from_name=sender["name"],
-        from_email=sender["email"],
-        subject=data.subject,
-        message=data.message,
-        project_title=project_title
-    )
-
-    if not email_sent:
-        if not is_email_configured():
-            raise HTTPException(status_code=503, detail="Email service is not configured. Contact an admin for help.")
-        raise HTTPException(status_code=500, detail="Failed to send message. Please try again later.")
-
-    # Create notification for recipient
+    # Save message and create notification unconditionally; treat email as best-effort delivery.
     with db_transaction() as conn:
+        conn.execute(
+            """INSERT INTO contact_messages
+               (from_volunteer_id, to_volunteer_id, subject, message, related_project_id)
+               VALUES (?, ?, ?, ?, ?)""",
+            (sender["id"], volunteer_id, data.subject, data.message, data.related_project_id)
+        )
         create_notification(
             conn, volunteer_id, "message_received",
             f"Message from {sender['name']}",
             data.subject,
             "/static/dashboard.html"
+        )
+
+    # Send via email relay (best-effort; message already saved above)
+    if is_email_configured():
+        send_relay_message(
+            to=recipient["email"],
+            to_name=recipient["name"],
+            from_name=sender["name"],
+            from_email=sender["email"],
+            subject=data.subject,
+            message=data.message,
+            project_title=project_title
         )
 
     return {"message": "Message sent! They'll receive it by email and can reply directly to you."}

--- a/tests/e2e/test_messaging_api.py
+++ b/tests/e2e/test_messaging_api.py
@@ -1,0 +1,317 @@
+"""
+E2E tests for messaging and notification routes — parameterised to run against both FastAPI and Next.js.
+
+Scenarios covered:
+  - POST /api/contact/{volunteer_id}  (send relay message)
+  - GET  /api/messages                (list sent/received)
+  - PUT  /api/messages/{id}/read      (mark message read)
+  - GET  /api/notifications           (list notifications, unread_only filter)
+  - PUT  /api/notifications/read-all  (mark all read)
+"""
+
+import uuid
+import requests
+import pytest
+
+
+def _api(method, path, base_url, json=None, token=None, params=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return requests.request(
+        method, f"{base_url}{path}",
+        json=json, headers=headers, params=params, timeout=10,
+    )
+
+
+def _signup(base_url, consent_contact=True):
+    name = f"User_{uuid.uuid4().hex[:8]}"
+    email = f"{name.lower()}@test.com"
+    data = _api("POST", "/api/auth/signup", base_url=base_url, json={
+        "name": name,
+        "email": email,
+        "password": "testpassword1",
+        "consent_profile_visible": True,
+        "consent_contact_by_owners": consent_contact,
+    }).json()
+    return {"id": data["id"], "token": data["auth_token"], "name": name, "email": email}
+
+
+class TestSendContactMessage:
+    """POST /api/contact/{volunteer_id}"""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url, new_user):
+        resp = _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+                    json={"subject": "Hello", "message": "Hi there"})
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_cannot_message_yourself(self, api_url, new_user):
+        resp = _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+                    json={"subject": "Hello", "message": "Hi"},
+                    token=new_user["token"])
+        assert resp.status_code == 400
+        assert "yourself" in resp.json()["detail"].lower()
+
+    @pytest.mark.local_only
+    def test_unknown_volunteer_returns_404(self, api_url, new_user):
+        resp = _api("POST", "/api/contact/999999", base_url=api_url,
+                    json={"subject": "Hello", "message": "Hi"},
+                    token=new_user["token"])
+        assert resp.status_code == 404
+
+    @pytest.mark.local_only
+    def test_volunteer_without_consent_returns_404(self, api_url, new_user):
+        no_consent = _signup(api_url, consent_contact=False)
+        resp = _api("POST", f"/api/contact/{no_consent['id']}", base_url=api_url,
+                    json={"subject": "Hello", "message": "Hi"},
+                    token=new_user["token"])
+        assert resp.status_code == 404
+
+    @pytest.mark.local_only
+    def test_missing_subject_returns_422(self, api_url, new_user):
+        recipient = _signup(api_url)
+        resp = _api("POST", f"/api/contact/{recipient['id']}", base_url=api_url,
+                    json={"message": "Hi there"},
+                    token=new_user["token"])
+        assert resp.status_code == 422
+
+    @pytest.mark.local_only
+    def test_missing_message_returns_422(self, api_url, new_user):
+        recipient = _signup(api_url)
+        resp = _api("POST", f"/api/contact/{recipient['id']}", base_url=api_url,
+                    json={"subject": "Hello"},
+                    token=new_user["token"])
+        assert resp.status_code == 422
+
+    @pytest.mark.local_only
+    def test_successful_send_returns_message(self, api_url, new_user):
+        recipient = _signup(api_url)
+        resp = _api("POST", f"/api/contact/{recipient['id']}", base_url=api_url,
+                    json={"subject": "Hello", "message": "Hi there"},
+                    token=new_user["token"])
+        assert resp.status_code == 200
+        assert "message" in resp.json()
+
+    @pytest.mark.local_only
+    def test_invalid_volunteer_id_returns_400_or_404(self, api_url, new_user):
+        resp = _api("POST", "/api/contact/notanid", base_url=api_url,
+                    json={"subject": "Hello", "message": "Hi"},
+                    token=new_user["token"])
+        assert resp.status_code in (400, 404, 422)
+
+
+class TestGetMessages:
+    """GET /api/messages"""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url):
+        resp = _api("GET", "/api/messages", base_url=api_url)
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_returns_sent_and_received_structure(self, api_url, new_user):
+        resp = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "received" in data
+        assert "sent" in data
+        assert isinstance(data["received"], list)
+        assert isinstance(data["sent"], list)
+
+    @pytest.mark.local_only
+    def test_sent_message_appears_in_sent_box(self, api_url, new_user):
+        recipient = _signup(api_url)
+        subject = f"Subject_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{recipient['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Test body"},
+             token=new_user["token"])
+
+        resp = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        sent = resp.json()["sent"]
+        assert any(m["subject"] == subject for m in sent)
+
+    @pytest.mark.local_only
+    def test_received_message_appears_in_received_box(self, api_url, new_user):
+        sender = _signup(api_url)
+        subject = f"Recv_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Hello"},
+             token=sender["token"])
+
+        resp = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        received = resp.json()["received"]
+        assert any(m["subject"] == subject for m in received)
+
+    @pytest.mark.local_only
+    def test_received_message_has_from_name(self, api_url, new_user):
+        sender = _signup(api_url)
+        subject = f"FN_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Hello"},
+             token=sender["token"])
+
+        resp = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"])
+        msgs = [m for m in resp.json()["received"] if m["subject"] == subject]
+        assert msgs
+        assert msgs[0]["from_name"] == sender["name"]
+
+    @pytest.mark.local_only
+    def test_sent_message_has_to_name(self, api_url, new_user):
+        recipient = _signup(api_url)
+        subject = f"TN_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{recipient['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Test"},
+             token=new_user["token"])
+
+        resp = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"])
+        msgs = [m for m in resp.json()["sent"] if m["subject"] == subject]
+        assert msgs
+        assert msgs[0]["to_name"] == recipient["name"]
+
+
+class TestMarkMessageRead:
+    """PUT /api/messages/{id}/read"""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url, new_user):
+        resp = _api("PUT", "/api/messages/1/read", base_url=api_url)
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_marks_own_message_as_read(self, api_url, new_user):
+        sender = _signup(api_url)
+        subject = f"Read_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Hello"},
+             token=sender["token"])
+
+        messages = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"]).json()
+        msg = next(m for m in messages["received"] if m["subject"] == subject)
+        assert msg["read_at"] is None
+
+        resp = _api("PUT", f"/api/messages/{msg['id']}/read", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+
+        updated = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"]).json()
+        msg2 = next(m for m in updated["received"] if m["subject"] == subject)
+        assert msg2["read_at"] is not None
+
+    @pytest.mark.local_only
+    def test_cannot_mark_others_message_as_read(self, api_url, new_user):
+        sender = _signup(api_url)
+        bystander = _signup(api_url)
+        subject = f"Other_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Hello"},
+             token=sender["token"])
+
+        messages = _api("GET", "/api/messages", base_url=api_url, token=new_user["token"]).json()
+        msg = next(m for m in messages["received"] if m["subject"] == subject)
+
+        resp = _api("PUT", f"/api/messages/{msg['id']}/read", base_url=api_url, token=bystander["token"])
+        assert resp.status_code == 404
+
+    @pytest.mark.local_only
+    def test_nonexistent_message_returns_404(self, api_url, new_user):
+        resp = _api("PUT", "/api/messages/999999/read", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 404
+
+
+class TestGetNotifications:
+    """GET /api/notifications"""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url):
+        resp = _api("GET", "/api/notifications", base_url=api_url)
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_returns_list(self, api_url, new_user):
+        resp = _api("GET", "/api/notifications", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    @pytest.mark.local_only
+    def test_message_creates_notification_for_recipient(self, api_url, new_user):
+        sender = _signup(api_url)
+        subject = f"Notif_{uuid.uuid4().hex[:6]}"
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": subject, "message": "Hello"},
+             token=sender["token"])
+
+        resp = _api("GET", "/api/notifications", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        notifs = resp.json()
+        assert any(n["type"] == "message_received" for n in notifs)
+
+    @pytest.mark.local_only
+    def test_notification_has_expected_fields(self, api_url, new_user):
+        sender = _signup(api_url)
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": "FieldCheck", "message": "Hello"},
+             token=sender["token"])
+
+        resp = _api("GET", "/api/notifications", base_url=api_url, token=new_user["token"])
+        notifs = [n for n in resp.json() if n["type"] == "message_received"]
+        assert notifs
+        n = notifs[0]
+        assert "id" in n
+        assert "type" in n
+        assert "title" in n
+        assert "body" in n
+        assert "read_at" in n
+        assert "created_at" in n
+
+    @pytest.mark.local_only
+    def test_unread_only_filter(self, api_url, new_user):
+        sender = _signup(api_url)
+        _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+             json={"subject": "UnreadFilter", "message": "Hello"},
+             token=sender["token"])
+
+        all_notifs = _api("GET", "/api/notifications", base_url=api_url, token=new_user["token"]).json()
+        unread_notifs = _api("GET", "/api/notifications", base_url=api_url,
+                             token=new_user["token"], params={"unread_only": "true"}).json()
+
+        unread_ids = {n["id"] for n in unread_notifs}
+        assert all(n["read_at"] is None for n in unread_notifs)
+        # All unread should be a subset of all notifications
+        assert unread_ids.issubset({n["id"] for n in all_notifs})
+
+
+class TestMarkAllNotificationsRead:
+    """PUT /api/notifications/read-all"""
+
+    @pytest.mark.local_only
+    def test_requires_authentication(self, api_url):
+        resp = _api("PUT", "/api/notifications/read-all", base_url=api_url)
+        assert resp.status_code == 401
+
+    @pytest.mark.local_only
+    def test_marks_all_unread_as_read(self, api_url, new_user):
+        sender = _signup(api_url)
+        for i in range(2):
+            _api("POST", f"/api/contact/{new_user['id']}", base_url=api_url,
+                 json={"subject": f"Bulk_{i}_{uuid.uuid4().hex[:4]}", "message": "Hello"},
+                 token=sender["token"])
+
+        unread_before = _api("GET", "/api/notifications", base_url=api_url,
+                             token=new_user["token"], params={"unread_only": "true"}).json()
+        assert len(unread_before) > 0
+
+        resp = _api("PUT", "/api/notifications/read-all", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+
+        unread_after = _api("GET", "/api/notifications", base_url=api_url,
+                            token=new_user["token"], params={"unread_only": "true"}).json()
+        assert len(unread_after) == 0
+
+    @pytest.mark.local_only
+    def test_returns_confirmation_message(self, api_url, new_user):
+        resp = _api("PUT", "/api/notifications/read-all", base_url=api_url, token=new_user["token"])
+        assert resp.status_code == 200
+        assert "message" in resp.json()

--- a/web/app/api/contact/[id]/route.ts
+++ b/web/app/api/contact/[id]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+import { sendRelayMessage, isEmailConfigured } from '@/lib/email'
+import { createNotification } from '@/lib/project'
+import { fieldError, validationError } from '@/lib/errors'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const sender = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!sender) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  const { id: idParam } = await params
+  const recipientId = parseInt(idParam, 10)
+  if (isNaN(recipientId)) {
+    return Response.json({ detail: 'Invalid volunteer ID' }, { status: 400 })
+  }
+
+  if (sender.id === recipientId) {
+    return Response.json({ detail: 'Cannot message yourself' }, { status: 400 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ detail: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const errs: ReturnType<typeof fieldError>[] = []
+  if (!body.subject || typeof body.subject !== 'string' || body.subject.trim().length === 0) {
+    errs.push(fieldError('subject', 'Subject is required'))
+  } else if (body.subject.length > 200) {
+    errs.push(fieldError('subject', 'Subject must be 200 characters or fewer'))
+  }
+  if (!body.message || typeof body.message !== 'string' || body.message.trim().length === 0) {
+    errs.push(fieldError('message', 'Message is required'))
+  }
+  if (errs.length) return validationError(errs)
+
+  const subject = (body.subject as string).trim()
+  const message = body.message as string
+  const relatedProjectId = typeof body.related_project_id === 'number' ? body.related_project_id : null
+
+  const recipient = await prisma.volunteer.findFirst({
+    where: { id: recipientId, deletedAt: null, consentContactByOwners: true },
+    select: { id: true, name: true, email: true },
+  })
+
+  if (!recipient) {
+    return Response.json({ detail: "Volunteer not found or doesn't accept messages" }, { status: 404 })
+  }
+
+  if (!recipient.email) {
+    return Response.json({ detail: 'This volunteer has no email address on file' }, { status: 400 })
+  }
+
+  let projectTitle: string | null = null
+  if (relatedProjectId) {
+    const project = await prisma.project.findUnique({
+      where: { id: relatedProjectId },
+      select: { title: true },
+    })
+    if (project) projectTitle = project.title
+  }
+
+  // Save message and create notification unconditionally; treat email as best-effort delivery.
+  await prisma.$transaction(async tx => {
+    await tx.message.create({
+      data: {
+        fromVolunteerId: sender.id,
+        toVolunteerId: recipientId,
+        subject,
+        message,
+        relatedProjectId,
+      },
+    })
+    await tx.notification.create({
+      data: {
+        volunteerId: recipientId,
+        type: 'message_received',
+        title: `Message from ${sender.name}`,
+        body: subject,
+        link: '/static/dashboard.html',
+      },
+    })
+  })
+
+  if (!isEmailConfigured()) {
+    return Response.json({ message: "Message sent! They'll receive it by email and can reply directly to you." })
+  }
+
+  sendRelayMessage(
+    recipient.email, recipient.name, sender.name, sender.email ?? '',
+    subject, message, projectTitle ?? undefined
+  ).catch(e => console.error('[EMAIL ERROR]', e))
+
+  return Response.json({ message: "Message sent! They'll receive it by email and can reply directly to you." })
+}

--- a/web/app/api/messages/[id]/read/route.ts
+++ b/web/app/api/messages/[id]/read/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  const { id: idParam } = await params
+  const messageId = parseInt(idParam, 10)
+  if (isNaN(messageId)) {
+    return Response.json({ detail: 'Invalid message ID' }, { status: 400 })
+  }
+
+  const result = await prisma.message.updateMany({
+    where: { id: messageId, toVolunteerId: volunteer.id },
+    data: { readAt: new Date() },
+  })
+
+  if (result.count === 0) {
+    return Response.json({ detail: 'Message not found' }, { status: 404 })
+  }
+
+  return Response.json({ message: 'Marked as read' })
+}

--- a/web/app/api/messages/route.ts
+++ b/web/app/api/messages/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  const [received, sent] = await Promise.all([
+    prisma.message.findMany({
+      where: { toVolunteerId: volunteer.id },
+      include: { from: { select: { name: true } } },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.message.findMany({
+      where: { fromVolunteerId: volunteer.id },
+      include: { to: { select: { name: true } } },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ])
+
+  return Response.json({
+    received: received.map(m => ({
+      id: m.id,
+      from_volunteer_id: m.fromVolunteerId,
+      to_volunteer_id: m.toVolunteerId,
+      subject: m.subject,
+      message: m.message,
+      related_project_id: m.relatedProjectId,
+      read_at: m.readAt,
+      created_at: m.createdAt,
+      from_name: m.from.name,
+    })),
+    sent: sent.map(m => ({
+      id: m.id,
+      from_volunteer_id: m.fromVolunteerId,
+      to_volunteer_id: m.toVolunteerId,
+      subject: m.subject,
+      message: m.message,
+      related_project_id: m.relatedProjectId,
+      read_at: m.readAt,
+      created_at: m.createdAt,
+      to_name: m.to.name,
+    })),
+  })
+}

--- a/web/app/api/notifications/read-all/route.ts
+++ b/web/app/api/notifications/read-all/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+
+export async function PUT(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  await prisma.notification.updateMany({
+    where: { volunteerId: volunteer.id, readAt: null },
+    data: { readAt: new Date() },
+  })
+
+  return Response.json({ message: 'All marked as read' })
+}

--- a/web/app/api/notifications/route.ts
+++ b/web/app/api/notifications/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getCurrentVolunteer } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const volunteer = await getCurrentVolunteer(request.headers.get('authorization'))
+  if (!volunteer) {
+    return Response.json({ detail: 'Authentication required' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const unreadOnly = searchParams.get('unread_only') === 'true' || searchParams.get('unread_only') === '1'
+
+  const notifications = await prisma.notification.findMany({
+    where: {
+      volunteerId: volunteer.id,
+      ...(unreadOnly ? { readAt: null } : {}),
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+  })
+
+  return Response.json(notifications.map(n => ({
+    id: n.id,
+    volunteer_id: n.volunteerId,
+    type: n.type,
+    title: n.title,
+    body: n.body,
+    link: n.link,
+    read_at: n.readAt,
+    emailed_at: n.emailedAt,
+    created_at: n.createdAt,
+  })))
+}


### PR DESCRIPTION
## Summary

- Adds Next.js API routes for all 5 messaging/notification endpoints: `POST /api/contact/[id]`, `GET /api/messages`, `PUT /api/messages/[id]/read`, `GET /api/notifications`, `PUT /api/notifications/read-all`
- Fixes a bug in the Python API where `POST /api/contact/{id}` never persisted messages to `contact_messages` (the table was always empty); message and notification are now saved unconditionally and email delivery is best-effort
- Adds `tests/e2e/test_messaging_api.py` with 26 tests parameterised to run against both FastAPI and Next.js

## Test plan

- [ ] Run `pytest tests/e2e/test_messaging_api.py` — all 26 tests × 2 backends = 52 cases pass
- [ ] Send a contact message in the UI, verify it appears in the recipient's messages and notifications
- [ ] Mark a notification as read via `PUT /api/notifications/read-all`, verify unread count drops to zero
- [ ] Confirm `GET /api/messages` returns correct `from_name`/`to_name` on received/sent messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)