### PR TITLE
Fix: collapse redundant volunteer consent flag pairs

### DIFF
--- a/api.py
+++ b/api.py
@@ -293,11 +293,11 @@ class VolunteerSignup(BaseModel):
     location: Optional[str] = None
     country: Optional[str] = None
     local_group: Optional[str] = None
-    share_contact_directly: bool = False
+    consent_make_profile_visible_in_directory: bool = True
+    consent_contactable_by_project_owners: bool = True
+    consent_share_contact_info_with_project_owner: bool = False
     other_skills: Optional[str] = None
     skill_ids: List[int] = []
-    consent_profile_visible: bool = True
-    consent_contact_by_owners: bool = True
     email_digest: Optional[str] = "none"  # 'none', 'match', 'fortnightly'
 
 
@@ -313,10 +313,11 @@ class VolunteerUpdate(BaseModel):
     location: Optional[str] = None
     country: Optional[str] = None
     local_group: Optional[str] = None
-    share_contact_directly: Optional[bool] = None
+    consent_make_profile_visible_in_directory: Optional[bool] = None
+    consent_contactable_by_project_owners: Optional[bool] = None
+    consent_share_contact_info_with_project_owner: Optional[bool] = None
     other_skills: Optional[str] = None
     skill_ids: Optional[List[int]] = None
-    profile_visible: Optional[bool] = None
     email_digest: Optional[str] = None  # 'none', 'match', 'fortnightly'
 
 
@@ -751,9 +752,11 @@ def signup(data: VolunteerSignup) -> Dict:
             "discord_handle": data.discord_handle, "signal_number": data.signal_number,
             "whatsapp_number": data.whatsapp_number, "contact_preference": data.contact_preference,
             "contact_notes": data.contact_notes, "availability_hours_per_week": data.availability_hours_per_week,
-            "location": data.location, "share_contact_directly": data.share_contact_directly,
-            "other_skills": data.other_skills, "consent_profile_visible": data.consent_profile_visible,
-            "consent_contact_by_owners": data.consent_contact_by_owners,
+            "location": data.location,
+            "other_skills": data.other_skills,
+            "consent_make_profile_visible_in_directory": data.consent_make_profile_visible_in_directory,
+            "consent_contactable_by_project_owners": data.consent_contactable_by_project_owners,
+            "consent_share_contact_info_with_project_owner": data.consent_share_contact_info_with_project_owner,
             "consent_given_at": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
             "auth_token": auth_token, "password_hash": password_hash
         }
@@ -1029,9 +1032,9 @@ def google_auth(data: GoogleAuthRequest) -> Dict:
             cursor = conn.execute(
                 """INSERT INTO volunteers (
                     name, email, auth_token,
-                    consent_profile_visible, consent_contact_by_owners, consent_given_at
-                ) VALUES (?, ?, ?, ?, ?, ?)""",
-                (name, email, auth_token, True, True, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+                    consent_make_profile_visible_in_directory, consent_contactable_by_project_owners, consent_share_contact_info_with_project_owner, consent_given_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (name, email, auth_token, True, True, False, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             )
             volunteer_id = cursor.lastrowid
 
@@ -1699,8 +1702,7 @@ def list_volunteers(
                v.location, v.other_skills, v.local_group, v.created_at
         FROM volunteers v
         WHERE v.deleted_at IS NULL
-        AND v.profile_visible = 1
-        AND v.consent_profile_visible = 1
+        AND v.consent_make_profile_visible_in_directory = 1
     """
     params = []
 
@@ -1766,7 +1768,7 @@ def get_volunteer(
     volunteer = conn.execute(
         """SELECT * FROM volunteers
            WHERE id = ? AND deleted_at IS NULL
-           AND profile_visible = 1""",
+           AND consent_make_profile_visible_in_directory = 1""",
         (volunteer_id,)
     ).fetchone()
 
@@ -1784,7 +1786,7 @@ def get_volunteer(
         elif current_volunteer.get("is_admin"):
             show_contact = True
         # Show contact if they've opted to share directly AND consent to being contacted
-        elif volunteer["share_contact_directly"] and volunteer["consent_contact_by_owners"]:
+        elif volunteer["consent_contactable_by_project_owners"] and volunteer["consent_share_contact_info_with_project_owner"]:
             show_contact = True
 
     result = enrich_volunteer(conn, dict(volunteer), show_contact=show_contact)
@@ -1833,13 +1835,22 @@ def update_me(data: VolunteerUpdate, volunteer: Dict = Depends(require_auth)) ->
         for field in ["name", "bio", "discord_handle", "signal_number",
                       "whatsapp_number", "contact_preference", "contact_notes",
                       "availability_hours_per_week", "location", "country", "local_group",
-                      "share_contact_directly", "other_skills", "profile_visible", "email_digest"]:
+                      "consent_make_profile_visible_in_directory",
+                      "consent_contactable_by_project_owners",
+                      "consent_share_contact_info_with_project_owner",
+                      "other_skills", "email_digest"]:
             if field not in existing_columns:
                 continue
             value = getattr(data, field, None)
             if value is not None or (field == "local_group" and field in data.model_fields_set):
                 updates.append(f"{field} = ?")
                 params.append(value)
+
+        # Re-affirm consent timestamp when either consent flag is being set to true
+        consent_fields = {"consent_make_profile_visible_in_directory", "consent_contactable_by_project_owners", "consent_share_contact_info_with_project_owner"}
+        if any(getattr(data, f) is True for f in consent_fields):
+            updates.append("consent_given_at = ?")
+            params.append(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
 
         if updates:
             updates.append("updated_at = ?")
@@ -3851,7 +3862,7 @@ def send_contact_message(
     recipient = conn.execute(
         """SELECT * FROM volunteers
            WHERE id = ? AND deleted_at IS NULL
-           AND consent_contact_by_owners = 1""",
+           AND consent_contactable_by_project_owners = 1""",
         (volunteer_id,)
     ).fetchone()
     conn.close()

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -45,8 +45,8 @@ export const test = base.extend<Fixtures, WorkerFixtures>({
         name: credentials.name,
         email: credentials.email,
         password: credentials.password,
-        consent_profile_visible: true,
-        consent_contact_by_owners: true,
+        consent_make_profile_visible_in_directory: true,
+        consent_contactable_by_project_owners: true,
       }),
     });
     if (!resp.ok) throw new Error(`Volunteer signup failed: ${await resp.text()}`);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -72,8 +72,8 @@ async function setupAdminAuth(parallelIndex: number): Promise<void> {
         name: 'Test Admin',
         email: ADMIN_EMAIL,
         password: ADMIN_PASSWORD,
-        consent_profile_visible: true,
-        consent_contact_by_owners: true,
+        consent_make_profile_visible_in_directory: true,
+        consent_contactable_by_project_owners: true,
       }),
     });
     if (!resp.ok) {

--- a/e2e/tests/05-volunteer-profile.spec.ts
+++ b/e2e/tests/05-volunteer-profile.spec.ts
@@ -59,7 +59,7 @@ test.describe('Volunteer Profile', () => {
     await volunteer.page.goto(`${baseUrl}/static/profile.html`);
     await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 });
     await volunteer.page.getByLabel('Your Name').fill(uniqueName);
-    await volunteer.page.locator('#profile_visible').check();
+    await volunteer.page.locator('#consent_make_profile_visible_in_directory').check();
     await volunteer.page.getByRole('button', { name: 'Save Changes' }).click();
     await expect(volunteer.page.getByRole('alert')).toBeVisible({ timeout: 10_000 });
 
@@ -73,7 +73,7 @@ test.describe('Volunteer Profile', () => {
     // Now hide the profile
     await volunteer.page.goto(`${baseUrl}/static/profile.html`);
     await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 });
-    await volunteer.page.locator('#profile_visible').uncheck();
+    await volunteer.page.locator('#consent_make_profile_visible_in_directory').uncheck();
     await volunteer.page.getByRole('button', { name: 'Save Changes' }).click();
     await expect(volunteer.page.getByRole('alert')).toBeVisible({ timeout: 10_000 });
 
@@ -92,7 +92,7 @@ test.describe('Volunteer Profile', () => {
     await volunteer.page.goto(`${baseUrl}/static/profile.html`);
     await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 });
     await volunteer.page.getByLabel('Your Name').fill(uniqueName);
-    await volunteer.page.locator('#profile_visible').uncheck();
+    await volunteer.page.locator('#consent_make_profile_visible_in_directory').uncheck();
     await volunteer.page.getByRole('button', { name: 'Save Changes' }).click();
     await expect(volunteer.page.getByRole('alert')).toBeVisible({ timeout: 10_000 });
 
@@ -106,7 +106,7 @@ test.describe('Volunteer Profile', () => {
     // Now make the profile visible
     await volunteer.page.goto(`${baseUrl}/static/profile.html`);
     await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 });
-    await volunteer.page.locator('#profile_visible').check();
+    await volunteer.page.locator('#consent_make_profile_visible_in_directory').check();
     await volunteer.page.getByRole('button', { name: 'Save Changes' }).click();
     await expect(volunteer.page.getByRole('alert')).toBeVisible({ timeout: 10_000 });
 
@@ -140,7 +140,7 @@ test.describe('Volunteer Profile', () => {
     const signupResp = await fetch(`${baseUrl}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: vol2Name, email: vol2Email, password: 'testpassword1', consent_profile_visible: true, consent_contact_by_owners: true }),
+      body: JSON.stringify({ name: vol2Name, email: vol2Email, password: 'testpassword1', consent_make_profile_visible_in_directory: true, consent_contactable_by_project_owners: true }),
     });
     if (!signupResp.ok) throw new Error(`Second volunteer signup failed: ${await signupResp.text()}`);
     const { auth_token: vol2Token } = await signupResp.json();
@@ -150,12 +150,12 @@ test.describe('Volunteer Profile', () => {
     const page2 = await ctx2.newPage();
 
     try {
-      // Set up profile with a skill and profile_visible=true
+      // Set up profile with a skill and consent_make_profile_visible_in_directory=true
       await page2.goto(`${baseUrl}/static/profile.html`);
       const skillOption = page2.locator('.skill-option').filter({ hasText: 'Fundraising' });
       await expect(skillOption).toBeVisible({ timeout: 10_000 });
       await skillOption.click();
-      await page2.locator('#profile_visible').check();
+      await page2.locator('#consent_make_profile_visible_in_directory').check();
       await page2.getByRole('button', { name: 'Save Changes' }).click();
       await expect(page2.getByRole('alert')).toBeVisible({ timeout: 10_000 });
 
@@ -169,7 +169,7 @@ test.describe('Volunteer Profile', () => {
       await expect(volunteer.page.locator('#volunteerSkills')).toContainText('Fundraising');
       // Endorsements section only appears if there are endorsements; not present for fresh volunteer
       await expect(volunteer.page.locator('#endorsementsSection')).not.toBeVisible();
-      // Contact info not shown because share_contact_directly defaults to false
+      // Contact info not shown because consent_share_contact_info_with_project_owner defaults to false
       await expect(volunteer.page.locator('#contactInfo')).not.toBeVisible();
     } finally {
       await ctx2.close();

--- a/e2e/tests/16-messaging.spec.ts
+++ b/e2e/tests/16-messaging.spec.ts
@@ -15,7 +15,7 @@ test.describe('Messaging', () => {
     const senderSignupResp = await fetch(`${baseUrl}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: `Msg Sender ${sid}`, email: `msgsender_${sid}@test.com`, password: 'testpassword1', consent_profile_visible: true, consent_contact_by_owners: true }),
+      body: JSON.stringify({ name: `Msg Sender ${sid}`, email: `msgsender_${sid}@test.com`, password: 'testpassword1', consent_make_profile_visible_in_directory: true, consent_contactable_by_project_owners: true }),
     });
     if (!senderSignupResp.ok) throw new Error(`Sender signup failed: ${await senderSignupResp.text()}`);
     const { auth_token: senderToken } = await senderSignupResp.json();
@@ -29,7 +29,7 @@ test.describe('Messaging', () => {
 
       await senderPage.getByRole('button', { name: 'Contact Owner' }).click();
 
-      // The recipient uses the default share_contact_directly = false, so the relay
+      // The recipient has consent_share_contact_info_with_project_owner = false (default), so the relay
       // form appears instead of direct contact details.
       const dialog = senderPage.getByRole('dialog');
       await expect(dialog.getByLabel('Subject')).toBeVisible({ timeout: 10_000 });
@@ -63,7 +63,7 @@ test.describe('Messaging', () => {
     const senderSignupResp = await fetch(`${baseUrl}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: `Notif Sender ${sid}`, email: `notifsender_${sid}@test.com`, password: 'testpassword1', consent_profile_visible: true, consent_contact_by_owners: true }),
+      body: JSON.stringify({ name: `Notif Sender ${sid}`, email: `notifsender_${sid}@test.com`, password: 'testpassword1', consent_make_profile_visible_in_directory: true, consent_contactable_by_project_owners: true }),
     });
     if (!senderSignupResp.ok) throw new Error(`Sender signup failed: ${await senderSignupResp.text()}`);
     const { auth_token: senderToken } = await senderSignupResp.json();

--- a/e2e/tests/18-gdpr-privacy.spec.ts
+++ b/e2e/tests/18-gdpr-privacy.spec.ts
@@ -42,7 +42,7 @@ test.describe('GDPR & Privacy', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name: vol2Name, email: `privvol_${id}@test.com`, password: 'testpassword1',
-        consent_profile_visible: true, consent_contact_by_owners: true,
+        consent_make_profile_visible_in_directory: true, consent_contactable_by_project_owners: true,
       }),
     });
     if (!signupResp.ok) throw new Error(`vol2 signup failed: ${await signupResp.text()}`);
@@ -61,7 +61,7 @@ test.describe('GDPR & Privacy', () => {
 
       // Ensure profile is publicly visible
       await page2.getByLabel(/Make my profile visible/).check();
-      // Keep share_contact_directly unchecked (contact sharing disabled — this is the default)
+      // Keep consent_share_contact_info_with_project_owner unchecked (contact sharing disabled — this is the default)
       await expect(page2.getByLabel(/Share my contact info directly/)).not.toBeChecked();
 
       await page2.getByRole('button', { name: 'Save Changes' }).click();

--- a/migration_011_collapse_consent_flags.sql
+++ b/migration_011_collapse_consent_flags.sql
@@ -1,0 +1,36 @@
+-- Migration 011: Replace redundant consent flag pairs with clearly named columns
+--
+-- The volunteers table had two pairs of overlapping columns:
+--   profile_visible (live toggle) + consent_profile_visible (GDPR audit flag)
+--   share_contact_directly (live preference) + consent_contact_by_owners (GDPR audit flag)
+--
+-- These are replaced with three clearly named consent columns:
+--   consent_make_profile_visible_in_directory  — merges profile_visible + consent_profile_visible
+--   consent_contactable_by_project_owners      — replaces consent_contact_by_owners (can contact via form)
+--   consent_share_contact_info_with_project_owner — replaces share_contact_directly (direct details)
+--
+-- Merge rule for profile visibility: 1 if either old column was 1.
+-- Contact columns are copied directly (they were always separate concepts).
+-- consent_given_at is backfilled where a row gains any true value without a timestamp.
+
+ALTER TABLE volunteers ADD COLUMN consent_make_profile_visible_in_directory BOOLEAN DEFAULT FALSE;
+ALTER TABLE volunteers ADD COLUMN consent_contactable_by_project_owners BOOLEAN DEFAULT FALSE;
+ALTER TABLE volunteers ADD COLUMN consent_share_contact_info_with_project_owner BOOLEAN DEFAULT FALSE;
+
+UPDATE volunteers
+SET
+    consent_make_profile_visible_in_directory = (profile_visible = 1 OR consent_profile_visible = 1),
+    consent_contactable_by_project_owners = (consent_contact_by_owners = 1),
+    consent_share_contact_info_with_project_owner = (share_contact_directly = 1),
+    consent_given_at = CASE
+        WHEN consent_given_at IS NOT NULL THEN consent_given_at
+        WHEN (profile_visible = 1 OR consent_profile_visible = 1
+              OR consent_contact_by_owners = 1 OR share_contact_directly = 1)
+        THEN strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        ELSE NULL
+    END;
+
+ALTER TABLE volunteers DROP COLUMN profile_visible;
+ALTER TABLE volunteers DROP COLUMN consent_profile_visible;
+ALTER TABLE volunteers DROP COLUMN share_contact_directly;
+ALTER TABLE volunteers DROP COLUMN consent_contact_by_owners;

--- a/schema.sql
+++ b/schema.sql
@@ -48,16 +48,13 @@ CREATE TABLE volunteers (
     availability_hours_per_week INTEGER,
     location TEXT,
 
-    -- Privacy settings
-    share_contact_directly BOOLEAN DEFAULT FALSE,  -- If false, use contact form only
-    profile_visible BOOLEAN DEFAULT TRUE,
-
     -- Other skills not in taxonomy
     other_skills TEXT,
 
-    -- Consent tracking (GDPR)
-    consent_profile_visible BOOLEAN DEFAULT FALSE,
-    consent_contact_by_owners BOOLEAN DEFAULT FALSE,
+    -- Consent (GDPR) — set at signup and re-affirmed when toggled on the profile page
+    consent_make_profile_visible_in_directory BOOLEAN DEFAULT FALSE,
+    consent_contactable_by_project_owners BOOLEAN DEFAULT FALSE,
+    consent_share_contact_info_with_project_owner BOOLEAN DEFAULT FALSE,
     consent_given_at TIMESTAMP,
 
     -- Auth (simple token-based for lightweight auth)

--- a/static/profile.html
+++ b/static/profile.html
@@ -109,11 +109,15 @@
 
                 <div class="checkbox-group">
                     <label class="checkbox-label">
-                        <input type="checkbox" id="profile_visible" name="profile_visible">
+                        <input type="checkbox" id="consent_make_profile_visible_in_directory" name="consent_make_profile_visible_in_directory">
                         <span>Make my profile visible in the volunteer directory</span>
                     </label>
                     <label class="checkbox-label">
-                        <input type="checkbox" id="share_directly" name="share_contact_directly">
+                        <input type="checkbox" id="consent_contactable_by_project_owners" name="consent_contactable_by_project_owners">
+                        <span>Allow project owners to contact me about opportunities</span>
+                    </label>
+                    <label class="checkbox-label" style="margin-left: 24px;">
+                        <input type="checkbox" id="consent_share_contact_info_with_project_owner" name="consent_share_contact_info_with_project_owner">
                         <span>Share my contact info directly with project owners (otherwise they use the contact form)</span>
                     </label>
                 </div>
@@ -178,14 +182,26 @@
             renderCountrySelect('country', currentUser.country || '');
             renderLocalGroupSelect('local_group', currentUser.country || '', currentUser.local_group || '');
             form.other_skills.value = currentUser.other_skills || '';
-            form.profile_visible.checked = currentUser.profile_visible !== false;
-            form.share_contact_directly.checked = currentUser.share_contact_directly || false;
+            form.consent_make_profile_visible_in_directory.checked = currentUser.consent_make_profile_visible_in_directory !== false;
+            form.consent_contactable_by_project_owners.checked = currentUser.consent_contactable_by_project_owners !== false;
+            form.consent_share_contact_info_with_project_owner.checked = currentUser.consent_share_contact_info_with_project_owner || false;
+            syncShareDirectly();
             form.email_digest.value = currentUser.email_digest || 'none';
 
             // Skills
             const selectedSkillIds = currentUser.skills?.map(s => s.id) || [];
             renderSkillSelector('skillSelector', selectedSkillIds);
         }
+
+        // Keep share-directly sub-checkbox in sync with its parent
+        const contactableCheckbox = document.getElementById('consent_contactable_by_project_owners');
+        const shareDirectlyCheckbox = document.getElementById('consent_share_contact_info_with_project_owner');
+        function syncShareDirectly() {
+            shareDirectlyCheckbox.disabled = !contactableCheckbox.checked;
+            if (!contactableCheckbox.checked) shareDirectlyCheckbox.checked = false;
+        }
+        contactableCheckbox.addEventListener('change', syncShareDirectly);
+        syncShareDirectly();
 
         document.getElementById('country').addEventListener('change', (e) => {
             renderLocalGroupSelect('local_group', e.target.value);
@@ -213,8 +229,9 @@
                     country: form.country.value || null,
                     local_group: form.local_group.value || null,
                     other_skills: form.other_skills.value.trim() || null,
-                    profile_visible: form.profile_visible.checked,
-                    share_contact_directly: form.share_contact_directly.checked,
+                    consent_make_profile_visible_in_directory: form.consent_make_profile_visible_in_directory.checked,
+                    consent_contactable_by_project_owners: form.consent_contactable_by_project_owners.checked,
+                    consent_share_contact_info_with_project_owner: form.consent_share_contact_info_with_project_owner.checked,
                     email_digest: form.email_digest.value,
                     skill_ids: getSelectedSkills('skillSelector')
                 };

--- a/static/signup.html
+++ b/static/signup.html
@@ -145,15 +145,15 @@
                     <h3>Privacy & Consent</h3>
                     <div class="checkbox-group">
                         <label class="checkbox-label">
-                            <input type="checkbox" id="consent_visible" name="consent_profile_visible" checked>
+                            <input type="checkbox" id="consent_visible" name="consent_make_profile_visible_in_directory" checked>
                             <span>Make my profile visible to other volunteers</span>
                         </label>
                         <label class="checkbox-label">
-                            <input type="checkbox" id="consent_contact" name="consent_contact_by_owners" checked>
+                            <input type="checkbox" id="consent_contact" name="consent_contactable_by_project_owners" checked>
                             <span>Allow project owners to contact me about opportunities</span>
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="share_directly" name="share_contact_directly">
+                        <label class="checkbox-label" style="margin-left: 24px;">
+                            <input type="checkbox" id="consent_share_directly" name="consent_share_contact_info_with_project_owner">
                             <span>Share my contact info directly (otherwise use contact form)</span>
                         </label>
                     </div>
@@ -250,6 +250,16 @@
             }
         }
 
+        // Keep share-directly sub-checkbox in sync with its parent
+        const contactableCheckbox = document.getElementById('consent_contact');
+        const shareDirectlyCheckbox = document.getElementById('consent_share_directly');
+        function syncShareDirectly() {
+            shareDirectlyCheckbox.disabled = !contactableCheckbox.checked;
+            if (!contactableCheckbox.checked) shareDirectlyCheckbox.checked = false;
+        }
+        contactableCheckbox.addEventListener('change', syncShareDirectly);
+        syncShareDirectly();
+
         // Prevent Enter key from submitting form (except on submit button)
         document.getElementById('signupForm').addEventListener('keydown', (e) => {
             if (e.key === 'Enter' && e.target.type !== 'submit' && e.target.tagName !== 'TEXTAREA') {
@@ -291,11 +301,11 @@
                     availability_hours_per_week: form.availability_hours_per_week.value ? parseInt(form.availability_hours_per_week.value) : null,
                     location: form.location.value.trim() || null,
                     country: form.country.value || null,
-                    share_contact_directly: form.share_contact_directly.checked,
                     other_skills: form.other_skills.value.trim() || null,
                     skill_ids: getSelectedSkills('skillSelector'),
-                    consent_profile_visible: form.consent_profile_visible.checked,
-                    consent_contact_by_owners: form.consent_contact_by_owners.checked,
+                    consent_make_profile_visible_in_directory: form.consent_make_profile_visible_in_directory.checked,
+                    consent_contactable_by_project_owners: form.consent_contactable_by_project_owners.checked,
+                    consent_share_contact_info_with_project_owner: form.consent_share_contact_info_with_project_owner.checked,
                     email_digest: form.email_digest.value
                 };
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -109,8 +109,8 @@ def admin_token(live_server, _tmp_db_dir):
         "name": "Test Admin",
         "email": ADMIN_EMAIL,
         "password": ADMIN_PASSWORD,
-        "consent_profile_visible": True,
-        "consent_contact_by_owners": True,
+        "consent_make_profile_visible_in_directory": True,
+        "consent_contactable_by_project_owners": True,
     })
     db_path = os.path.join(_tmp_db_dir, "catalyse.db")
     conn = _sqlite3.connect(db_path)
@@ -129,8 +129,8 @@ def new_user(live_server):
         "name": "Test User",
         "email": email,
         "password": password,
-        "consent_profile_visible": True,
-        "consent_contact_by_owners": True,
+        "consent_make_profile_visible_in_directory": True,
+        "consent_contactable_by_project_owners": True,
     })
     return {"email": email, "password": password, "token": data["auth_token"], "id": data["id"]}
 
@@ -241,8 +241,8 @@ def user_credentials(live_server):
             "name": "Session Test User",
             "email": email,
             "password": password,
-            "consent_profile_visible": True,
-            "consent_contact_by_owners": True,
+            "consent_make_profile_visible_in_directory": True,
+            "consent_contactable_by_project_owners": True,
         })
         return {"email": email, "password": password, "token": data["auth_token"]}
 


### PR DESCRIPTION
## Summary

- The `volunteers` table had four columns across two overlapping pairs: `profile_visible` + `consent_profile_visible`, and `share_contact_directly` + `consent_contact_by_owners`
- Code gating on both simultaneously meant volunteers imported/seeded without the GDPR flags set could never enable contact sharing, with no feedback in the UI
- Replaces all four with three clearly named consent columns that serve as both the live preference and the GDPR audit flag

## Changes

**Migration 011** merges the old data into:
- `consent_make_profile_visible_in_directory` (merges `profile_visible` OR `consent_profile_visible`)
- `consent_contactable_by_project_owners` (replaces `consent_contact_by_owners`)
- `consent_share_contact_info_with_project_owner` (replaces `share_contact_directly`)

**`api.py`** updated throughout: models, INSERT, SELECT queries, contact visibility logic, profile update allowed fields. Setting any consent flag to true now also writes `consent_given_at`.

**`static/signup.html` / `static/profile.html`** updated to use new field names. The "share contact directly" checkbox is now a sub-item that disables and unchecks itself when "allow project owners to contact me" is unchecked.

## Test plan

- [ ] Sign up as a new volunteer — three consent checkboxes appear; unchecking "allow contact" disables the share-directly sub-checkbox
- [ ] Save profile — toggling any consent field on updates `consent_given_at`
- [ ] Volunteer with only `consent_contactable_by_project_owners = true` does not have contact info shown directly
- [ ] Volunteer with both contact consent flags true has contact info shown
- [ ] Run migration against a copy of the db and verify old data maps correctly
- [ ] Existing tests pass: `pytest tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)