### PR TITLE
feat: Railway PR preview environments

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,2 @@
 [phases.setup]
-nixPkgs = ["python3", "gcc", "nodejs_20"]
+nixPkgs = ["python3", "gcc", "nodejs_24"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,2 @@
 [phases.setup]
-nixPkgs = ["python3", "gcc", "nodejs_24"]
+nixPkgs = ["python3", "gcc", "nodejs_22"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "python build.py && npm install --prefix web && (cd web && npx prisma generate) && npm run build --prefix web"
+buildCommand = "python build.py && npm install --prefix web && (cd web && npx prisma generate) && npm run build --prefix web && if [ \"$RAILWAY_ENVIRONMENT_NAME\" != \"production\" ] && [ -n \"$B2_KEY_ID\" ]; then (cd web && npm run fetch-prod-db) && cp anonymised_prod.db catalyse.db; fi"
 
 [deploy]
 startCommand = "bash start.sh"

--- a/start.sh
+++ b/start.sh
@@ -5,8 +5,12 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "[start] Running pre-deploy backup..."
-python "$SCRIPT_DIR/backup_service.py"
+if [ "$RAILWAY_ENVIRONMENT_NAME" = "production" ]; then
+  echo "[start] Running pre-deploy backup..."
+  python "$SCRIPT_DIR/backup_service.py"
+else
+  echo "[start] Skipping backup (non-production environment: ${RAILWAY_ENVIRONMENT_NAME:-local})"
+fi
 
 echo "[start] Starting Next.js on port 3000..."
 (cd "$SCRIPT_DIR/web" && PORT=3000 npm start) &

--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -1,6 +1,23 @@
+import { existsSync, statSync } from 'node:fs'
+import path from 'node:path'
 import { prisma } from '@/lib/prisma'
+import { resolveDbUrl } from '@/lib/db-url'
 
 export async function GET() {
-  await prisma.$queryRaw`SELECT 1`
-  return Response.json({ ok: true })
+  const dbUrl = resolveDbUrl()
+  const filePath = dbUrl.startsWith('file:') ? dbUrl.slice(5) : dbUrl
+  const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath)
+  const exists = existsSync(absPath)
+  const sizeKb = exists ? Math.round(statSync(absPath).size / 1024) : null
+
+  let dbOk = false
+  let projectCount: number | null = null
+  try {
+    await prisma.$queryRaw`SELECT 1`
+    dbOk = true
+    const result = await prisma.$queryRaw<[{ count: bigint }]>`SELECT COUNT(*) as count FROM projects`
+    projectCount = Number(result[0].count)
+  } catch {}
+
+  return Response.json({ ok: dbOk, dbUrl, cwd: process.cwd(), fileExists: exists, sizeKb, projectCount })
 }

--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -1,26 +1,6 @@
-import { existsSync, statSync } from 'node:fs'
-import path from 'node:path'
 import { prisma } from '@/lib/prisma'
-import { resolveDbUrl } from '@/lib/db-url'
 
 export async function GET() {
-  const dbUrl = resolveDbUrl()
-  const filePath = dbUrl.startsWith('file:') ? dbUrl.slice(5) : dbUrl
-  const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath)
-  const exists = existsSync(absPath)
-  const sizeKb = exists ? Math.round(statSync(absPath).size / 1024) : null
-
-  let dbOk = false
-  let projectCount: number | null = null
-  let volunteerCount: number | null = null
-  try {
-    await prisma.$queryRaw`SELECT 1`
-    dbOk = true
-    const pr = await prisma.$queryRaw<[{ count: bigint }]>`SELECT COUNT(*) as count FROM projects`
-    projectCount = Number(pr[0].count)
-    const vr = await prisma.$queryRaw<[{ count: bigint }]>`SELECT COUNT(*) as count FROM volunteers`
-    volunteerCount = Number(vr[0].count)
-  } catch {}
-
-  return Response.json({ ok: dbOk, dbUrl, cwd: process.cwd(), fileExists: exists, sizeKb, projectCount, volunteerCount })
+  await prisma.$queryRaw`SELECT 1`
+  return Response.json({ ok: true })
 }

--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -12,12 +12,15 @@ export async function GET() {
 
   let dbOk = false
   let projectCount: number | null = null
+  let volunteerCount: number | null = null
   try {
     await prisma.$queryRaw`SELECT 1`
     dbOk = true
-    const result = await prisma.$queryRaw<[{ count: bigint }]>`SELECT COUNT(*) as count FROM projects`
-    projectCount = Number(result[0].count)
+    const pr = await prisma.$queryRaw<[{ count: bigint }]>`SELECT COUNT(*) as count FROM projects`
+    projectCount = Number(pr[0].count)
+    const vr = await prisma.$queryRaw<[{ count: bigint }]>`SELECT COUNT(*) as count FROM volunteers`
+    volunteerCount = Number(vr[0].count)
   } catch {}
 
-  return Response.json({ ok: dbOk, dbUrl, cwd: process.cwd(), fileExists: exists, sizeKb, projectCount })
+  return Response.json({ ok: dbOk, dbUrl, cwd: process.cwd(), fileExists: exists, sizeKb, projectCount, volunteerCount })
 }

--- a/web/lib/db-url.ts
+++ b/web/lib/db-url.ts
@@ -2,7 +2,8 @@ import path from "node:path";
 
 export function resolveDbUrl(fallback = "file:../catalyse.db"): string {
   const mountPath = process.env.RAILWAY_VOLUME_MOUNT_PATH;
-  if (mountPath) return `file:${path.join(/*turbopackIgnore: true*/ mountPath, "catalyse.db")}`;
+  const isProduction = process.env.RAILWAY_ENVIRONMENT_NAME === 'production';
+  if (mountPath && isProduction) return `file:${path.join(/*turbopackIgnore: true*/ mountPath, "catalyse.db")}`;
 
   const rawUrl = process.env.DATABASE_URL ?? fallback;
   if (rawUrl.startsWith("file:") && !path.isAbsolute(rawUrl.slice(5))) {

--- a/web/lib/db-url.ts
+++ b/web/lib/db-url.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-export function resolveDbUrl(fallback = "file:../anonymised_prod.db"): string {
+export function resolveDbUrl(fallback = "file:../catalyse.db"): string {
   const mountPath = process.env.RAILWAY_VOLUME_MOUNT_PATH;
   if (mountPath) return `file:${path.join(/*turbopackIgnore: true*/ mountPath, "catalyse.db")}`;
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "generate": "npx prisma generate && tsx scripts/post-generate.ts",
-    "fetch-prod-db": "tsx scripts/fetch-prod-db.ts"
+    "fetch-prod-db": "NODE_OPTIONS=--experimental-sqlite tsx scripts/fetch-prod-db.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web/scripts/fetch-prod-db.ts
+++ b/web/scripts/fetch-prod-db.ts
@@ -101,14 +101,22 @@ async function b2DownloadFile(auth: B2Auth, bucketName: string, fileName: string
 
 // ── Anonymisation ─────────────────────────────────────────────────────────────
 
-// Seed faker with the volunteer ID so names/emails are deterministic per volunteer.
-function fakeVolunteer(id: number): { name: string; email: string } {
+// Seed faker with the volunteer ID so all fake fields are deterministic per volunteer.
+function fakeVolunteerData(id: number): { name: string; email: string; bio: string; discordHandle: string; signalNumber: string; whatsappNumber: string; contactNotes: string; otherSkills: string; location: string; localGroup: string } {
   faker.seed(id)
   const firstName = faker.person.firstName()
   const lastName = faker.person.lastName()
   return {
     name: `${firstName} ${lastName}`,
     email: faker.internet.email({ firstName, lastName }).toLowerCase(),
+    bio: faker.lorem.sentence(),
+    discordHandle: faker.internet.username(),
+    signalNumber: faker.phone.number({ style: 'international' }),
+    whatsappNumber: faker.phone.number({ style: 'international' }),
+    contactNotes: faker.lorem.sentence(),
+    otherSkills: faker.lorem.words({ min: 2, max: 5 }),
+    location: `${faker.location.city()}, ${faker.location.country()}`,
+    localGroup: faker.location.city(),
   }
 }
 
@@ -128,33 +136,46 @@ function anonymise(dbPath: string): void {
 
   const anonPasswordHash = makePasswordHash('volunteerpass1')
 
-  const volunteerIds = (db.prepare('SELECT id FROM volunteers').all() as { id: number }[]).map(r => r.id)
+  const volunteerRows = db.prepare('SELECT id, bio, discord_handle, signal_number, whatsapp_number, contact_notes, other_skills, location, local_group FROM volunteers').all() as { id: number; bio: string | null; discord_handle: string | null; signal_number: string | null; whatsapp_number: string | null; contact_notes: string | null; other_skills: string | null; location: string | null; local_group: string | null }[]
   const updateVolunteer = db.prepare(`
     UPDATE volunteers SET
       name                  = ?,
       email                 = ?,
-      bio                   = '[redacted]',
-      discord_handle        = NULL,
-      signal_number         = NULL,
-      whatsapp_number       = NULL,
-      contact_notes         = NULL,
-      other_skills          = NULL,
-      location              = NULL,
-      local_group           = NULL,
+      bio                   = ?,
+      discord_handle        = ?,
+      signal_number         = ?,
+      whatsapp_number       = ?,
+      contact_notes         = ?,
+      other_skills          = ?,
+      location              = ?,
+      local_group           = ?,
       auth_token            = NULL,
       auth_token_expires_at = NULL,
       password_hash         = ?
     WHERE id = ?
   `)
-  for (const vid of volunteerIds) {
-    const { name, email } = fakeVolunteer(vid)
-    updateVolunteer.run(name, email, anonPasswordHash, vid)
+  for (const row of volunteerRows) {
+    const { name, email, bio, discordHandle, signalNumber, whatsappNumber, contactNotes, otherSkills, location, localGroup } = fakeVolunteerData(row.id)
+    updateVolunteer.run(
+      name,
+      email,
+      row.bio !== null ? bio : null,
+      row.discord_handle !== null ? discordHandle : null,
+      row.signal_number !== null ? signalNumber : null,
+      row.whatsapp_number !== null ? whatsappNumber : null,
+      row.contact_notes !== null ? contactNotes : null,
+      row.other_skills !== null ? otherSkills : null,
+      row.location !== null ? location : null,
+      row.local_group !== null ? localGroup : null,
+      anonPasswordHash,
+      row.id,
+    )
   }
 
   const adminInvites = db.prepare('SELECT id, invited_by_id FROM admin_invites').all() as { id: number; invited_by_id: number }[]
   const updateInvite = db.prepare('UPDATE admin_invites SET email = ?, invite_token = ? WHERE id = ?')
   for (const row of adminInvites) {
-    updateInvite.run(fakeVolunteer(row.invited_by_id).email, randomToken(), row.id)
+    updateInvite.run(fakeVolunteerData(row.invited_by_id).email, randomToken(), row.id)
   }
 
   db.exec("UPDATE admin_notes SET content = '[redacted]'")


### PR DESCRIPTION
## Summary

- Adds conditional `fetch-prod-db` step to Railway build command — runs for non-production environments when B2 creds are present, downloads latest backup, anonymises PII with faker, copies result to `catalyse.db`
- Expands `fetch-prod-db` anonymisation to replace contact fields (discord, phone, location, etc.) with faker data rather than NULLing them, preserving NULL where the original was NULL
- Fixes Prisma DB fallback path from `anonymised_prod.db` → `catalyse.db` so both FastAPI and Prisma use the same file in PR preview environments

## Railway dashboard setup required

- staging environment created as PR base (with `STUB_EMAIL=true`, `APP_URL=https://${{RAILWAY_PUBLIC_DOMAIN}}`)
- Project Settings → PR Environments → base set to `staging`

## Test plan

- [ ] Open a PR and verify Railway build runs `fetch-prod-db` step
- [ ] Confirm preview URL loads with anonymised prod data
- [ ] Confirm emails are stubbed (not sent) in preview
- [ ] Verify production deploys still skip the fetch-prod-db step

🤖 Generated with [Claude Code](https://claude.com/claude-code)