### PR TITLE
fix: hide mobile nav links when logged out

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -363,11 +363,12 @@ export default function Header() {
 
           {/* Nav links */}
           <div>
-            {navLinks.map(({ href, label }) => (
-              <MobileNavLink key={href} href={href} active={pathname === href}>
-                {label}
-              </MobileNavLink>
-            ))}
+            {user &&
+              navLinks.map(({ href, label }) => (
+                <MobileNavLink key={href} href={href} active={pathname === href}>
+                  {label}
+                </MobileNavLink>
+              ))}
 
             {!loading &&
               (user ? (


### PR DESCRIPTION
## Summary

- All four mobile nav links (Projects, Volunteers, Suggest, Starter Tasks) redirect unauthenticated users to `/login`, so showing them when logged out is misleading
- One-line fix: wrap the nav link block in `user &&`

## Test plan

- [ ] Open mobile menu when logged out — only Login / Sign Up visible
- [ ] Open mobile menu when logged in — nav links appear as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)