### PR TITLE
refactor: switch dashboard tab URLs from ?tab= query params to #tab- anchors

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import React, { Suspense, useEffect, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import React, { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Header from '@/components/Header'
 import Button from '@/components/Button'
@@ -50,13 +50,17 @@ interface StarterTask {
 
 type TabKey = 'owned' | 'interests' | 'proposed' | 'suggested' | 'notifications'
 
-function DashboardPageInner() {
+export default function DashboardPage() {
   const router = useRouter()
   const { user, loading } = useAuth()
   const [data, setData] = useState<DashboardData | null>(null)
   const [notifications, setNotifications] = useState<Notification[]>([])
-  const searchParams = useSearchParams()
-  const [activeTab, setActiveTab] = useState<TabKey>((searchParams.get('tab') as TabKey) || 'owned')
+  const [activeTab, setActiveTab] = useState<TabKey>(() => {
+    if (typeof window === 'undefined') return 'owned'
+    const hash = window.location.hash
+    if (hash.startsWith('#tab-')) return (hash.slice('#tab-'.length) as TabKey) || 'owned'
+    return 'owned'
+  })
   const [unreadCount, setUnreadCount] = useState(0)
   const [loadingData, setLoadingData] = useState(true)
   const [starterTasks, setStarterTasks] = useState<StarterTask[]>([])
@@ -111,8 +115,8 @@ function DashboardPageInner() {
 
   async function handleTabClick(tab: TabKey) {
     setActiveTab(tab)
-    const url = tab === 'owned' ? '/dashboard' : `/dashboard?tab=${tab}`
-    router.replace(url, { scroll: false })
+    const hash = tab === 'owned' ? '' : `#tab-${tab}`
+    history.replaceState(null, '', `/dashboard${hash}`)
     if (tab === 'notifications') {
       try {
         const notifs = await apiRequest<Notification[]>('/api/notifications')
@@ -353,10 +357,3 @@ function DashboardPageInner() {
   )
 }
 
-export default function DashboardPage() {
-  return (
-    <Suspense>
-      <DashboardPageInner />
-    </Suspense>
-  )
-}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -74,6 +74,40 @@ export default function DashboardPage() {
   }, [user, loading, router])
 
   useEffect(() => {
+    function onHashChange() {
+      const hash = window.location.hash
+      const tab: TabKey = hash.startsWith('#tab-')
+        ? ((hash.slice('#tab-'.length) as TabKey) || 'owned')
+        : 'owned'
+      setActiveTab(tab)
+      if (tab === 'notifications') {
+        apiRequest<Notification[]>('/api/notifications')
+          .then(setNotifications)
+          .catch(() => {})
+      }
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  useEffect(() => {
+    function onHashChange() {
+      const hash = window.location.hash
+      const tab: TabKey = hash.startsWith('#tab-')
+        ? ((hash.slice('#tab-'.length) as TabKey) || 'owned')
+        : 'owned'
+      setActiveTab(tab)
+      if (tab === 'notifications') {
+        apiRequest<Notification[]>('/api/notifications')
+          .then(setNotifications)
+          .catch(() => {})
+      }
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  useEffect(() => {
     if (!user) return
     apiRequest<DashboardData>('/api/dashboard')
       .then((d) => {
@@ -115,8 +149,12 @@ export default function DashboardPage() {
 
   async function handleTabClick(tab: TabKey) {
     setActiveTab(tab)
-    const hash = tab === 'owned' ? '' : `#tab-${tab}`
-    history.replaceState(null, '', `/dashboard${hash}`)
+    if (tab === 'owned') {
+      history.replaceState(null, '', '/dashboard')
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    } else {
+      window.location.hash = `tab-${tab}`
+    }
     if (tab === 'notifications') {
       try {
         const notifs = await apiRequest<Notification[]>('/api/notifications')

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -35,7 +35,7 @@ export default function SuggestPage() {
             requireTasks
             onSuccess={() => {
               toast("Project submitted for review! We'll be in touch.", 'success')
-              setTimeout(() => router.push('/dashboard?tab=proposed'), 2000)
+              setTimeout(() => router.push('/dashboard#tab-proposed'), 2000)
             }}
           />
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -54,7 +54,7 @@ function DashboardNavButtons({ unreadCount }: { unreadCount: number }) {
         My Projects
       </Button>
       <Button
-        href="/dashboard?tab=notifications"
+        href="/dashboard#tab-notifications"
         variant={dashboardTab === 'notifications' ? 'primary' : 'ghost'}
         size="sm"
       >
@@ -151,7 +151,7 @@ export default function Header() {
                     <Button href="/dashboard" variant="ghost" size="sm">
                       My Projects
                     </Button>
-                    <Button href="/dashboard?tab=notifications" variant="ghost" size="sm">
+                    <Button href="/dashboard#tab-notifications" variant="ghost" size="sm">
                       Notifications
                     </Button>
                   </>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import React, { Suspense, useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { useAuth } from '@/lib/auth-context'
 import { apiRequest } from '@/lib/api'
 import Button from '@/components/Button'
@@ -40,23 +40,60 @@ function MobileNavSection({ children, admin }: { children: React.ReactNode; admi
 
 function DashboardNavButtons({ unreadCount }: { unreadCount: number }) {
   const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const dashboardTab = pathname === '/dashboard' ? (searchParams.get('tab') ?? '') : ''
+  const [hash, setHash] = useState(() =>
+    typeof window !== 'undefined' ? window.location.hash : '',
+  )
+
+  useEffect(() => {
+    function onHashChange() {
+      setHash(window.location.hash)
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  // Sync hash when pathname changes (navigating to/from dashboard)
+  useEffect(() => {
+    setHash(typeof window !== 'undefined' ? window.location.hash : '')
+  }, [pathname])
+
+  const onDashboard = pathname === '/dashboard'
+  const activeTab = onDashboard && hash.startsWith('#tab-') ? hash.slice('#tab-'.length) : ''
+
+  function goToTab(tab: string) {
+    if (tab) {
+      window.location.hash = `tab-${tab}`
+    } else {
+      history.pushState(null, '', '/dashboard')
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    }
+  }
+
   return (
     <>
       <Button
         href="/dashboard"
-        variant={
-          pathname === '/dashboard' && dashboardTab !== 'notifications' ? 'primary' : 'ghost'
-        }
+        variant={onDashboard && activeTab !== 'notifications' ? 'primary' : 'ghost'}
         size="sm"
+        onClick={(e) => {
+          if (onDashboard) {
+            e.preventDefault()
+            goToTab('')
+          }
+        }}
       >
         My Projects
       </Button>
       <Button
         href="/dashboard#tab-notifications"
-        variant={dashboardTab === 'notifications' ? 'primary' : 'ghost'}
+        variant={activeTab === 'notifications' ? 'primary' : 'ghost'}
         size="sm"
+        onClick={(e) => {
+          if (onDashboard) {
+            e.preventDefault()
+            goToTab('notifications')
+          }
+        }}
       >
         Notifications
         {unreadCount > 0 && (
@@ -144,22 +181,7 @@ export default function Header() {
                 {label}
               </Button>
             ))}
-            {!loading && user && (
-              <Suspense
-                fallback={
-                  <>
-                    <Button href="/dashboard" variant="ghost" size="sm">
-                      My Projects
-                    </Button>
-                    <Button href="/dashboard#tab-notifications" variant="ghost" size="sm">
-                      Notifications
-                    </Button>
-                  </>
-                }
-              >
-                <DashboardNavButtons unreadCount={unreadCount} />
-              </Suspense>
-            )}
+            {!loading && user && <DashboardNavButtons unreadCount={unreadCount} />}
           </nav>
 
           <div className="hidden xl:flex gap-2 items-center">


### PR DESCRIPTION
## Summary

- Replaces `?tab=` query params on the dashboard with `#tab-{key}` URL anchors (e.g. `#tab-notifications`, `#tab-interests`)
- Removes `useSearchParams` and `Suspense` wrappers from both `DashboardPage` and `Header`'s `DashboardNavButtons`
- Fixes header button highlighting — `DashboardNavButtons` now reads `window.location.hash` via local state + `hashchange` listener
- Tab clicks use `window.location.hash =` (fires `hashchange` natively) instead of `history.replaceState` (which doesn't)
- Header nav buttons use `onClick` to set hash directly when already on the dashboard, keeping highlighting in sync
- Updates all links in `Header.tsx` and `app/suggest/page.tsx` from `?tab=` to `#tab-` format

## Test plan

- [ ] Click "My Projects" and "Notifications" in the header nav — correct tab loads and button highlights
- [ ] Click tabs on the dashboard — header buttons highlight correctly
- [ ] Navigate away and back to `/dashboard#tab-notifications` — correct tab is active on load
- [ ] Submit a project suggestion — redirects to dashboard with proposed tab active

🤖 Generated with [Claude Code](https://claude.com/claude-code)