### PR TITLE
feat: collapse completed projects section by default

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -214,3 +214,18 @@ textarea {
   color: #f3f4f6;
   border-color: #4b5563;
 }
+
+@keyframes fade-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-slide-in {
+  animation: fade-slide-in 0.2s ease-out both;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,6 +59,7 @@ export default function ProjectsPage() {
   const [locationFilter, setLocationFilter] = useState('')
   const [sortBy, setSortBy] = useState('')
   const [pendingCount, setPendingCount] = useState(0)
+  const [completedOpen, setCompletedOpen] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
@@ -291,15 +292,43 @@ export default function ProjectsPage() {
             ) : (
               groups
                 .filter((g) => g.projects.length > 0)
-                .map((g) => (
-                  <div key={g.key} className="mb-8">
-                    <h2 className={`text-lg mb-1 ${g.color}`}>
-                      {g.label} — {g.projects.length} project{g.projects.length !== 1 ? 's' : ''}
-                    </h2>
-                    {g.desc && <p className="text-text-light text-sm mb-3">{g.desc}</p>}
-                    <ProjectList projects={g.projects} userSkillIds={userSkillIds} />
-                  </div>
-                ))
+                .map((g) => {
+                  const isCompleted = g.key === 'completed'
+                  const isOpen = !isCompleted || completedOpen
+                  return (
+                    <div key={g.key} className="mb-8">
+                      {isCompleted ? (
+                        <h2
+                          className="text-lg mb-1 flex items-center gap-2 cursor-pointer select-none"
+                          onClick={() => setCompletedOpen((o) => !o)}
+                          role="button"
+                          aria-expanded={completedOpen}
+                          tabIndex={0}
+                          onKeyDown={(e) => e.key === 'Enter' && setCompletedOpen((o) => !o)}
+                        >
+                          {g.label} — {g.projects.length} project{g.projects.length !== 1 ? 's' : ''}
+                          <svg
+                            className="text-text-light shrink-0"
+                            width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                            style={{ transform: completedOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}
+                          >
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                        </h2>
+                      ) : (
+                        <h2 className={`text-lg mb-1 ${g.color}`}>
+                          {g.label} — {g.projects.length} project{g.projects.length !== 1 ? 's' : ''}
+                        </h2>
+                      )}
+                      {g.desc && <p className="text-text-light text-sm mb-3">{g.desc}</p>}
+                      {isOpen && (
+                        <div key={String(completedOpen)} className={isCompleted ? 'animate-fade-slide-in' : undefined}>
+                          <ProjectList projects={g.projects} userSkillIds={userSkillIds} />
+                        </div>
+                      )}
+                    </div>
+                  )
+                })
             )}
           </>
         )}


### PR DESCRIPTION
## Summary

- Completed projects group on the home page is now collapsed by default
- Click the heading (or press Enter) to toggle open/close
- Chevron icon rotates to indicate state
- Cards animate in with a fade + slide-down on open

## Test plan

- [ ] Completed section hidden on page load
- [ ] Click heading — section opens with animation
- [ ] Click again — section closes
- [ ] Keyboard: Tab to heading, Enter to toggle
- [ ] Other groups (Seeking, In Progress, On Hold) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)