### PR TITLE
fix: run Prisma migrations on Railway startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check .",
     "generate": "npx prisma generate && tsx scripts/post-generate.ts",
     "build:railway": "tsx scripts/build-railway.ts",
+    "migrate": "NODE_OPTIONS=--experimental-sqlite tsx scripts/migrate.ts",
     "fetch-prod-db": "NODE_OPTIONS=--experimental-sqlite tsx scripts/fetch-prod-db.ts",
     "install:browsers": "playwright install chromium",
     "test": "playwright test",

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "NIXPACKS"
 buildCommand = "npm run build:railway"
 
 [deploy]
-startCommand = "npm start"
+startCommand = "npx prisma migrate deploy && npm start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "NIXPACKS"
 buildCommand = "npm run build:railway"
 
 [deploy]
-startCommand = "npx prisma migrate deploy && npm start"
+startCommand = "npm run migrate && npm start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,26 @@
+import { execSync } from 'child_process'
+import { DatabaseSync } from 'node:sqlite'
+import { resolveDbUrl } from '../lib/db-url'
+
+function run(cmd: string) {
+  execSync(cmd, { stdio: 'inherit' })
+}
+
+const dbUrl = resolveDbUrl()
+const dbPath = dbUrl.replace(/^file:/, '')
+
+const db = new DatabaseSync(dbPath)
+
+const hasMigrationTable = db
+  .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_prisma_migrations'")
+  .all().length > 0
+
+db.close()
+
+if (!hasMigrationTable) {
+  console.log('No _prisma_migrations table found — resolving pre-Prisma migrations as applied...')
+  run('npx prisma migrate resolve --applied 20260503000000_baseline')
+  run('npx prisma migrate resolve --applied 20260504000000_seed_skills')
+}
+
+run('npx prisma migrate deploy')

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -2,11 +2,13 @@ import { execSync } from 'child_process'
 import { DatabaseSync } from 'node:sqlite'
 import { resolveDbUrl } from '../lib/db-url'
 
+const dbUrl = resolveDbUrl()
+process.env.DATABASE_URL = dbUrl
+
 function run(cmd: string) {
   execSync(cmd, { stdio: 'inherit' })
 }
 
-const dbUrl = resolveDbUrl()
 const dbPath = dbUrl.replace(/^file:/, '')
 
 const db = new DatabaseSync(dbPath)


### PR DESCRIPTION
## Summary

- Adds `scripts/migrate.ts` startup script that detects whether `_prisma_migrations` exists on the DB
- If not (prod DB uses legacy `schema_migrations` system), resolves `baseline` and `seed_skills` as already applied so Prisma doesn't try to re-create existing tables
- Then runs `prisma migrate deploy` to apply any pending migrations (e.g. `local_groups`, `local_group_suggestions`)
- Updates `railway.toml` start command to `npm run migrate && npm start`

## Test plan

- [ ] Tested locally against `anonymised_prod.db` (no `_prisma_migrations`) — baseline/seed_skills resolved, local_groups migrations applied cleanly
- [ ] Verify Railway staging redeploys without P2021 errors after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)