### PR TITLE
chore: simplify migrate script

### DIFF
--- a/scripts/fetch-prod-db.ts
+++ b/scripts/fetch-prod-db.ts
@@ -11,6 +11,7 @@ import { copyFileSync, existsSync, readFileSync, statSync, unlinkSync } from 'no
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { pbkdf2Sync, randomBytes } from 'node:crypto'
+import { execSync } from 'node:child_process'
 import { DatabaseSync } from 'node:sqlite'
 import { faker } from '@faker-js/faker'
 
@@ -306,6 +307,22 @@ async function main(): Promise<void> {
 
   console.log('Seeding dev accounts...')
   seedDevAccounts(destPath)
+
+  const db = new DatabaseSync(destPath)
+  const hasMigrationTable =
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_prisma_migrations'")
+      .all().length > 0
+  db.close()
+
+  if (!hasMigrationTable) {
+    console.log('Bootstrapping Prisma migration history...')
+    const url = `file:${destPath}`
+    const env = { ...process.env, DATABASE_URL: url }
+    const run = (cmd: string) => execSync(cmd, { stdio: 'inherit', env })
+    run('npx prisma migrate resolve --applied 20260503000000_baseline')
+    run('npx prisma migrate resolve --applied 20260504000000_seed_skills')
+  }
 
   const sizeKb = statSync(destPath).size / 1024
   console.log(`Done. anonymised_prod.db written (${sizeKb.toFixed(0)} KB)`)

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,28 +1,5 @@
 import { execSync } from 'child_process'
-import { DatabaseSync } from 'node:sqlite'
 import { resolveDbUrl } from '../lib/db-url'
 
-const dbUrl = resolveDbUrl()
-process.env.DATABASE_URL = dbUrl
-
-function run(cmd: string) {
-  execSync(cmd, { stdio: 'inherit' })
-}
-
-const dbPath = dbUrl.replace(/^file:/, '')
-
-const db = new DatabaseSync(dbPath)
-
-const hasMigrationTable = db
-  .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_prisma_migrations'")
-  .all().length > 0
-
-db.close()
-
-if (!hasMigrationTable) {
-  console.log('No _prisma_migrations table found — resolving pre-Prisma migrations as applied...')
-  run('npx prisma migrate resolve --applied 20260503000000_baseline')
-  run('npx prisma migrate resolve --applied 20260504000000_seed_skills')
-}
-
-run('npx prisma migrate deploy')
+process.env.DATABASE_URL = resolveDbUrl()
+execSync('npx prisma migrate deploy', { stdio: 'inherit' })


### PR DESCRIPTION
## Summary

- Removes legacy bootstrap logic that resolved `baseline` and `seed_skills` as applied for DBs without `_prisma_migrations`
- Now that prod/staging volumes have been migrated, this is no longer needed
- Script retains only the essential: set `DATABASE_URL` from `resolveDbUrl()` and run `prisma migrate deploy`

## Merge order

Merge after prod confirms `_prisma_migrations` exists with all prior migrations recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)