### PR TITLE
fix: send application summary emails to super-admins only

### DIFF
--- a/lib/jobs/applications.ts
+++ b/lib/jobs/applications.ts
@@ -11,7 +11,7 @@ export async function runApplicationsSummaryJob(): Promise<Record<string, unknow
   if (!count) return { skipped: true, reason: 'no pending applications' }
 
   const admins = await prisma.volunteer.findMany({
-    where: { isAdmin: true, deletedAt: null },
+    where: { isAdmin: true, isSuperAdmin: true, deletedAt: null },
     select: { name: true, email: true },
   })
 


### PR DESCRIPTION
## Summary

- Daily pending-applications summary email was going to all admins (`isAdmin = true`)
- Regular admins have no access to the application review queue, so it was noise for them
- Restrict recipient query to `isSuperAdmin = true`

## Test plan

- [ ] Trigger `runApplicationsSummaryJob` with pending applications — verify only super-admins receive the email
- [ ] Regular admins receive no email

🤖 Generated with [Claude Code](https://claude.com/claude-code)