### PR TITLE
fix: resolve build error from non-existent isSuperAdmin DB field

### DIFF
--- a/lib/jobs/applications.ts
+++ b/lib/jobs/applications.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto'
 import { prisma } from '@/lib/prisma'
+import { isSuperAdmin } from '@/lib/auth'
 import { sendPendingApplicationsSummaryEmail } from '@/lib/email'
 import { APPLICATION_ANONYMISATION_MS } from '@/lib/applications'
 
@@ -10,10 +11,12 @@ export async function runApplicationsSummaryJob(): Promise<Record<string, unknow
 
   if (!count) return { skipped: true, reason: 'no pending applications' }
 
-  const admins = await prisma.volunteer.findMany({
-    where: { isAdmin: true, isSuperAdmin: true, deletedAt: null },
-    select: { name: true, email: true },
-  })
+  const admins = (
+    await prisma.volunteer.findMany({
+      where: { isAdmin: true, deletedAt: null },
+      select: { name: true, email: true },
+    })
+  ).filter((a) => isSuperAdmin(a.email))
 
   let sent = 0
   for (const admin of admins) {


### PR DESCRIPTION
## Summary
- `isSuperAdmin` is not a Prisma column — it's env-based (email allowlist via `ADMIN_EMAILS`)
- Removes invalid `isSuperAdmin: true` from `findMany` where clause
- Filters admins in-app via `isSuperAdmin()` from `lib/auth.ts` instead

## Test plan
- [ ] `npm run build` passes with no type errors
- [ ] Application summary emails still only send to super-admins (volunteers whose email is in `ADMIN_EMAILS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)