### PR TITLE
chore: add npm run new-migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,12 @@ npm run fetch-prod-db && npm run migrate
 Do **not** use `prisma migrate dev` — it checks for schema drift against the live DB and will fail. The correct workflow:
 
 1. Edit `prisma/schema.prisma`
-2. Generate the SQL:
+2. Generate the migration file:
    ```bash
-   npx prisma migrate diff \
-     --from-schema-datasource prisma/schema.prisma \
-     --to-schema-datamodel prisma/schema.prisma \
-     --script
+   npm run new-migration your_migration_name
    ```
-3. Create a new timestamped directory under `prisma/migrations/` and save the relevant SQL as `migration.sql`:
-   ```
-   prisma/migrations/YYYYMMDDHHMMSS_your_migration_name/migration.sql
-   ```
+   This creates `prisma/migrations/YYYYMMDDHHMMSS_your_migration_name/migration.sql` with the diff SQL.
+3. **Review the generated SQL** — the diff may include unrelated pending changes from other branches. Remove any statements not relevant to your change.
 4. Apply it:
    ```bash
    npm run migrate
@@ -118,8 +113,6 @@ Do **not** use `prisma migrate dev` — it checks for schema drift against the l
    ```bash
    npx prisma generate
    ```
-
-The `migrate diff` command compares the actual database against the schema model and outputs Prisma-authoritative SQL. Extract only the statements relevant to your change (the output may include unrelated pending changes from other branches).
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check .",
     "generate": "npx prisma generate && tsx scripts/post-generate.ts",
     "build:railway": "tsx scripts/build-railway.ts",
+    "new-migration": "tsx scripts/new-migration.ts",
     "migrate": "NODE_OPTIONS=--experimental-sqlite tsx scripts/migrate.ts",
     "fetch-prod-db": "NODE_OPTIONS=--experimental-sqlite tsx scripts/fetch-prod-db.ts",
     "install:browsers": "playwright install chromium",

--- a/scripts/new-migration.ts
+++ b/scripts/new-migration.ts
@@ -1,0 +1,35 @@
+import { execSync } from 'child_process'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+const name = process.argv[2]
+if (!name) {
+  console.error('Usage: npm run new-migration <migration_name>')
+  process.exit(1)
+}
+
+const now = new Date()
+const pad = (n: number) => String(n).padStart(2, '0')
+const ts =
+  `${now.getFullYear()}` +
+  `${pad(now.getMonth() + 1)}` +
+  `${pad(now.getDate())}` +
+  `${pad(now.getHours())}` +
+  `${pad(now.getMinutes())}` +
+  `${pad(now.getSeconds())}`
+
+const dirName = `${ts}_${name}`
+const dirPath = join(process.cwd(), 'prisma', 'migrations', dirName)
+
+mkdirSync(dirPath, { recursive: true })
+
+const sql = execSync(
+  'npx prisma migrate diff --from-schema-datasource prisma/schema.prisma --to-schema-datamodel prisma/schema.prisma --script',
+  { encoding: 'utf8' },
+)
+
+const sqlPath = join(dirPath, 'migration.sql')
+writeFileSync(sqlPath, sql)
+
+console.log(`Created: prisma/migrations/${dirName}/migration.sql`)
+console.log('Review the SQL, then run: npm run migrate && npx prisma generate')


### PR DESCRIPTION
## Summary

- Adds `scripts/new-migration.ts` — generates a timestamped migration directory and runs `prisma migrate diff` automatically
- Adds `npm run new-migration <name>` script to `package.json`
- Updates README to document the new workflow

## Test plan

- [ ] Run `npm run new-migration test_migration` and verify directory created with correct timestamp format and SQL content
- [ ] Verify generated SQL matches a manual `prisma migrate diff` run
- [ ] Delete the test migration dir before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)