### PR TITLE
test: strengthen GDPR export test to verify non-empty data sections

### DIFF
--- a/e2e/tests/18-gdpr-privacy.spec.ts
+++ b/e2e/tests/18-gdpr-privacy.spec.ts
@@ -1,9 +1,114 @@
 import { readFileSync } from 'fs'
 import { test, expect, getAlert, approveVolunteer } from '../fixtures'
 import { fake } from '../fake'
+import { createSkill } from '../actions/skills'
+import { adminCreateProject, transferProjectOwnership } from '../actions/projects'
 
 test.describe('GDPR & Privacy', () => {
-  test('Volunteer exports their personal data', async ({ volunteer, baseUrl }) => {
+  test('Volunteer exports their personal data', async ({
+    adminPage,
+    volunteer,
+    browser,
+    baseUrl,
+  }) => {
+    test.setTimeout(120_000)
+    // Add a skill to the volunteer's profile
+    const skill = await createSkill(baseUrl, adminPage)
+    await volunteer.page.goto(`${baseUrl}/profile`)
+    await expect(
+      volunteer.page.locator('.skill-option').filter({ hasText: skill.name }),
+    ).toBeVisible({ timeout: 10_000 })
+    await volunteer.page
+      .locator('label.skill-option')
+      .filter({ hasText: new RegExp(`^\\s*${skill.name}\\s*$`) })
+      .click()
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Profile updated!', { timeout: 10_000 })
+
+    // Admin creates a project and transfers ownership to the volunteer so they have a project in the
+    // export and a contactable owner page for the inbound message step
+    const volunteerProjectId = await adminCreateProject(
+      baseUrl,
+      adminPage,
+      fake.projectTitle(),
+      'GDPR export test project',
+    )
+    await transferProjectOwnership(baseUrl, adminPage, volunteerProjectId, volunteer.name)
+
+    // Admin creates a seeking-help project (no owner); volunteer expresses interest
+    const seekingProjectId = await adminCreateProject(
+      baseUrl,
+      adminPage,
+      fake.projectTitle(),
+      'GDPR test seeking-help project',
+    )
+    await volunteer.page.goto(`${baseUrl}/projects/${seekingProjectId}`)
+    await expect(
+      volunteer.page.getByRole('button', { name: 'Express Interest' }),
+    ).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.getByRole('button', { name: 'Express Interest' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Interest expressed!', { timeout: 10_000 })
+
+    // Sign up a second volunteer (vol2) — used as owner for the contact project and as the inbound sender
+    const vol2 = fake.person()
+    const vol2SignupResp = await fetch(`${baseUrl}/api/auth/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: vol2.name,
+        email: vol2.email,
+        password: 'testpassword1',
+        consent_make_profile_visible_in_directory: true,
+        consent_contactable_by_project_owners: true,
+      }),
+    })
+    if (!vol2SignupResp.ok) throw new Error(`vol2 signup failed: ${await vol2SignupResp.text()}`)
+    const { id: vol2Id, auth_token: vol2Token } = await vol2SignupResp.json()
+    await approveVolunteer(baseUrl, vol2Id)
+
+    // Admin creates a project and transfers ownership to vol2 so it has a contactable owner
+    const contactProjectId = await adminCreateProject(
+      baseUrl,
+      adminPage,
+      fake.projectTitle(),
+      'GDPR test contact project',
+    )
+    await transferProjectOwnership(baseUrl, adminPage, contactProjectId, vol2.name)
+
+    // Volunteer contacts vol2 on that project — creates a messagesSent record
+    await volunteer.page.goto(`${baseUrl}/projects/${contactProjectId}`)
+    await expect(
+      volunteer.page.getByRole('button', { name: 'Contact Owner' }),
+    ).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.getByRole('button', { name: 'Contact Owner' }).click()
+    const outboundDialog = volunteer.page.getByRole('dialog')
+    await expect(outboundDialog.getByLabel('Subject')).toBeVisible({ timeout: 10_000 })
+    await outboundDialog.getByLabel('Subject').fill(fake.messageSubject())
+    await outboundDialog.getByLabel('Message').fill(fake.messageBody())
+    await outboundDialog.getByRole('button', { name: 'Send Message' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Message sent', { timeout: 10_000 })
+
+    // vol2 contacts the volunteer on their approved project — creates a messagesReceived record
+    const vol2Ctx = await browser.newContext()
+    await vol2Ctx.addInitScript((token: string) => {
+      localStorage.setItem('authToken', token)
+    }, vol2Token)
+    const vol2Page = await vol2Ctx.newPage()
+    try {
+      await vol2Page.goto(`${baseUrl}/projects/${volunteerProjectId}`)
+      await expect(vol2Page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+      await vol2Page.getByRole('button', { name: 'Contact Owner' }).click()
+      const inboundDialog = vol2Page.getByRole('dialog')
+      await expect(inboundDialog.getByLabel('Subject')).toBeVisible({ timeout: 10_000 })
+      await inboundDialog.getByLabel('Subject').fill(fake.messageSubject())
+      await inboundDialog.getByLabel('Message').fill(fake.messageBody())
+      await inboundDialog.getByRole('button', { name: 'Send Message' }).click()
+      await expect(getAlert(vol2Page)).toContainText('Message sent', { timeout: 10_000 })
+    } finally {
+      await vol2Ctx.close()
+    }
+
+    // Export and verify every section has at least one record
     await volunteer.page.goto(`${baseUrl}/privacy`)
     await expect(volunteer.page.getByRole('heading', { name: 'Export Your Data' })).toBeVisible({
       timeout: 10_000,
@@ -23,10 +128,11 @@ test.describe('GDPR & Privacy', () => {
 
     const data = JSON.parse(readFileSync(filePath!, 'utf8'))
     expect(data).toHaveProperty('profile')
-    expect(data).toHaveProperty('skills')
-    expect(data).toHaveProperty('interests')
-    expect(data).toHaveProperty('messagesSent')
-    expect(data).toHaveProperty('messagesReceived')
+    expect(data.skills.length).toBeGreaterThan(0)
+    expect(data.projects.length).toBeGreaterThan(0)
+    expect(data.interests.length).toBeGreaterThan(0)
+    expect(data.messagesSent.length).toBeGreaterThan(0)
+    expect(data.messagesReceived.length).toBeGreaterThan(0)
   })
 
   test('Volunteer with contact sharing disabled does not expose contact handles', async ({


### PR DESCRIPTION
## Summary

- Previous test only used `toHaveProperty` — export fields could silently return empty arrays and the test would still pass
- Now creates real data for each section before downloading the export: adds a skill to the volunteer's profile, creates an owned project, expresses interest in another project, sends a message (outbound), and receives a message (inbound via a second volunteer)
- Assertions changed from existence checks to `length > 0` for `skills`, `projects`, `interests`, `messagesSent`, and `messagesReceived`

## Root causes discovered while fixing
- Admin-created projects have `ownerId: null` by default — "Contact Owner" never renders for them; fixed by using `transferProjectOwnership` to give the project a real owner
- Volunteer-proposed projects also default to `ownerId: null` (`wantToOwn` defaults to `false` in `ProjectForm`) — same fix applied

## Test plan
- [x] `npm test -- e2e/tests/18-gdpr-privacy.spec.ts` — both tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)