### PR TITLE
feat: B — Foundation refactors (#82, #89, #111, #148)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ Do **not** run `prisma migrate dev` — it checks for schema drift and will fail
 2. `npm run new-migration your_migration_name` — generates the SQL diff file
 3. Review the generated SQL and remove any unrelated statements
 4. `npm run migrate` — applies it
-5. `npx prisma generate` — regenerates the client
+5. `npm run generate` — regenerates the client and zod schema
 
 ## Verifying changes
 
-Run `npm run check-all` before committing to verify typecheck, lint, formatting, and tests all pass. This takes several minutes — lint is ~3s cached (~70s cold), tests are ~2.5–3 min. Do not abort early.
+Run `npm run check-all` when work is complete and before raising a PR, to verify typecheck, lint, formatting, and tests all pass. This takes several minutes — lint is ~3s cached (~70s cold), tests are ~2.5–3 min. Do not abort early.
 
 If `format:check` fails, run `npm run format` to fix all files at once — do not run `prettier --write` on individual files.

--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -1,17 +1,17 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRequireSuperAdmin } from '@/lib/hooks/auth'
 import { useParams, useRouter } from 'next/navigation'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
 export default function ApplicationReviewPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireSuperAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
 
@@ -19,11 +19,6 @@ export default function ApplicationReviewPage() {
   const [applicantNotes, setApplicantNotes] = useState('')
   const [initialized, setInitialized] = useState(false)
   const [confirmAction, setConfirmAction] = useState<'approve' | 'reject' | null>(null)
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isSuperAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: app, isPending: loadingData } = useQuery({
     ...orpc.admin.applications.getById.queryOptions({ input: { id: Number(id) } }),

--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 export default function ApplicationReviewPage() {
   const { id } = useParams<{ id: string }>()
@@ -107,7 +108,9 @@ export default function ApplicationReviewPage() {
     app.reviewer ? `Reviewer: ${app.reviewer.name}` : null,
   ].filter(Boolean)
 
-  const canAction = app.approvalStatus === 'PENDING' || app.approvalStatus === 'UNDER_REVIEW'
+  const canAction =
+    app.approvalStatus === ApprovalStatus.pending ||
+    app.approvalStatus === ApprovalStatus.under_review
 
   return (
     <main className="w-full max-w-2xl mx-auto px-6 py-5 pb-15">
@@ -120,7 +123,7 @@ export default function ApplicationReviewPage() {
       <h1 className="mb-1">{app.name}</h1>
       <p className="text-sm text-text-light mb-6">{meta.join(' · ')}</p>
 
-      {app.approvalStatus === 'REJECTED' && anonymiseDate && (
+      {app.approvalStatus === ApprovalStatus.rejected && anonymiseDate && (
         <p
           className={`text-sm mb-4 ${daysUntilAnonymise !== null && daysUntilAnonymise <= 1 ? 'text-red-500' : 'text-amber-500'}`}
         >

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useRequireSuperAdmin } from '@/lib/hooks/auth'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { InferRouterOutputs } from '@orpc/server'
@@ -13,7 +13,7 @@ import { AppRouter } from '@/server/router'
 
 export default function ApplicationsPage() {
   const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireSuperAdmin()
   const showToast = useToast()
   const {
     value: filter,
@@ -30,11 +30,6 @@ export default function ApplicationsPage() {
     'mine',
   )
   const [startingReview, setStartingReview] = useState<number | null>(null)
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isSuperAdmin) router.push('/')
-  }, [user, loading, router])
 
   const isAnonymised = filter === 'rejected_anonymised'
   const applicationFilter = filter === 'rejected_anonymised' ? 'mine' : filter

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -10,6 +10,7 @@ import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { InferRouterOutputs } from '@orpc/server'
 import { AppRouter } from '@/server/router'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 export default function ApplicationsPage() {
   const router = useRouter()
@@ -148,7 +149,7 @@ function ApplicationCard({
       <h3 className="m-0 mb-1">{app.name}</h3>
       <p className="text-sm text-text-light mb-4">{meta.join(' · ')}</p>
 
-      {app.approvalStatus === 'REJECTED' && anonymiseDate && (
+      {app.approvalStatus === ApprovalStatus.rejected && anonymiseDate && (
         <p
           className={`text-sm mb-3 ${daysUntilAnonymise !== null && daysUntilAnonymise <= 1 ? 'text-red-500' : 'text-amber-500'}`}
         >
@@ -277,11 +278,11 @@ function ApplicationCard({
       )}
 
       <div className="flex gap-2 justify-end border-t border-brand-border pt-4 mt-2">
-        {app.approvalStatus === 'PENDING' ? (
+        {app.approvalStatus === ApprovalStatus.pending ? (
           <Button onClick={() => onStartReview(app.id)} disabled={startingReview === app.id}>
             Start Review
           </Button>
-        ) : app.approvalStatus === 'UNDER_REVIEW' ? (
+        ) : app.approvalStatus === ApprovalStatus.under_review ? (
           <Button onClick={() => onNavigate(app.id)}>Continue Review</Button>
         ) : (
           <Button variant="secondary" onClick={() => onNavigate(app.id)}>

--- a/app/admin/bugs/page.tsx
+++ b/app/admin/bugs/page.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -35,8 +34,7 @@ function bugStatusClasses(status: string) {
 }
 
 export default function AdminBugsPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
   const { value: statusFilter, onChange: setStatusFilter } = useFilterOptions(
@@ -61,11 +59,6 @@ export default function AdminBugsPage() {
   const [editModal, setEditModal] = useState<(typeof reports)[number] | null>(null)
   const [editStatus, setEditStatus] = useState('')
   const [editNotes, setEditNotes] = useState('')
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const updateMutation = useMutation({
     ...orpc.admin.bugReports.update.mutationOptions(),

--- a/app/admin/email-preview/page.tsx
+++ b/app/admin/email-preview/page.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRef, useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useQueries } from '@tanstack/react-query'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 
 type Param = string | number | boolean
@@ -276,13 +275,7 @@ function EmailRow({
 }
 
 export default function EmailPreviewPage() {
-  const { user, loading } = useAuth()
-  const router = useRouter()
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
+  const { user, loading } = useRequireAdmin()
 
   const results = useQueries({
     queries: EMAIL_TYPES.map((t) => ({

--- a/app/admin/local-groups/page.tsx
+++ b/app/admin/local-groups/page.tsx
@@ -10,6 +10,7 @@ import FilterDropdown, { FilterOption, useFilterOptions } from '@/components/Fil
 import { orpc } from '@/lib/orpc'
 import { COUNTRY_OPTIONS } from '@/lib/filter-options'
 import { useToast } from '@/lib/toast'
+import { LocalGroupSuggestionStatus } from '@/generated/prisma/enums'
 
 type StatusFilter = 'all' | 'active' | 'pending' | 'on_hold' | 'declined'
 type ReviewAction = 'accept' | 'merge' | 'on_hold' | 'decline'
@@ -95,8 +96,8 @@ export default function AdminLocalGroupsPage() {
   const [reviewSubmitting, setReviewSubmitting] = useState(false)
 
   const fetchGroups = statusFilter === 'all' || statusFilter === 'active'
-  const fetchPending = statusFilter === 'all' || statusFilter === 'pending'
-  const fetchOnHold = statusFilter === 'all' || statusFilter === 'on_hold'
+  const fetchPending = statusFilter === 'all' || statusFilter === LocalGroupSuggestionStatus.pending
+  const fetchOnHold = statusFilter === 'all' || statusFilter === LocalGroupSuggestionStatus.on_hold
   const fetchDeclined = statusFilter === 'all' || statusFilter === 'declined'
 
   const { data: allGroupsData } = useQuery({
@@ -112,11 +113,15 @@ export default function AdminLocalGroupsPage() {
         enabled: !!user?.isAdmin && fetchGroups,
       },
       {
-        ...orpc.admin.localGroups.listSuggestions.queryOptions({ input: { status: 'pending' } }),
+        ...orpc.admin.localGroups.listSuggestions.queryOptions({
+          input: { status: LocalGroupSuggestionStatus.pending },
+        }),
         enabled: !!user?.isAdmin && fetchPending,
       },
       {
-        ...orpc.admin.localGroups.listSuggestions.queryOptions({ input: { status: 'on_hold' } }),
+        ...orpc.admin.localGroups.listSuggestions.queryOptions({
+          input: { status: LocalGroupSuggestionStatus.on_hold },
+        }),
         enabled: !!user?.isAdmin && fetchOnHold,
       },
       {
@@ -412,7 +417,8 @@ export default function AdminLocalGroupsPage() {
                     )}
                     {item.kind === 'suggestion' && (
                       <Button size="sm" onClick={() => openReview(item)}>
-                        {item.status === 'declined' || item.status === 'on_hold'
+                        {item.status === LocalGroupSuggestionStatus.declined ||
+                        item.status === LocalGroupSuggestionStatus.on_hold
                           ? 'Re-review'
                           : 'Review'}
                       </Button>

--- a/app/admin/local-groups/page.tsx
+++ b/app/admin/local-groups/page.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient, useQueries } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Radio from '@/components/Radio'
 import FilterDropdown, { FilterOption, useFilterOptions } from '@/components/FilterDropdown'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { COUNTRY_OPTIONS } from '@/lib/filter-options'
 import { useToast } from '@/lib/toast'
@@ -63,8 +62,7 @@ const STATUS_LABEL: Record<string, string> = {
 }
 
 export default function AdminLocalGroupsPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
 
@@ -95,11 +93,6 @@ export default function AdminLocalGroupsPage() {
   const [mergeTargetId, setMergeTargetId] = useState<number | ''>('')
   const [adminNotes, setAdminNotes] = useState('')
   const [reviewSubmitting, setReviewSubmitting] = useState(false)
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const fetchGroups = statusFilter === 'all' || statusFilter === 'active'
   const fetchPending = statusFilter === 'all' || statusFilter === 'pending'

--- a/app/admin/platform-settings/page.tsx
+++ b/app/admin/platform-settings/page.tsx
@@ -1,23 +1,15 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useRequireSuperAdmin } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import Toggle from '@/components/Toggle'
 
 export default function PlatformSettingsPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireSuperAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isSuperAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: settings, isLoading: loadingData } = useQuery({
     ...orpc.admin.platformSettings.get.queryOptions(),

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -1,21 +1,15 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
 import ProjectForm from '@/components/ProjectForm'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 
 export default function AdminCreateProjectPage() {
   const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const createMutation = useMutation({ ...orpc.admin.projects.create.mutationOptions() })
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   if (loading || !user) return null
 

--- a/app/admin/skills/page.tsx
+++ b/app/admin/skills/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   DndContext,
@@ -19,7 +19,6 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -235,8 +234,7 @@ function SortableCategory({
 }
 
 export default function AdminSkillsPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
   const [categories, setCategories] = useState<Category[]>([])
@@ -247,11 +245,6 @@ export default function AdminSkillsPage() {
   const [submitting, setSubmitting] = useState(false)
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: skillsListData } = useQuery({
     ...orpc.skills.list.queryOptions({ input: {} }),

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import React, { useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -67,8 +66,7 @@ function formatDate(iso: string) {
 }
 
 export default function AdminStarterTasksPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const queryClient = useQueryClient()
   const {
     value: statusFilter,
@@ -117,11 +115,6 @@ export default function AdminStarterTasksPage() {
   const [reviewNotes, setReviewNotes] = useState('')
 
   const [unassignModal, setUnassignModal] = useState<StarterTask | null>(null)
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: tasksRaw = [], isPending: loadingData } = useQuery({
     ...orpc.starterTasks.list.queryOptions({

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { StarterTaskStatus } from '@/generated/prisma/enums'
 
 interface Skill {
   id: number
@@ -510,7 +511,7 @@ export default function AdminStarterTasksPage() {
                         >
                           Delete
                         </Button>
-                        {task.status === 'open' && (
+                        {task.status === StarterTaskStatus.open && (
                           <Button
                             variant="secondary"
                             size="sm"
@@ -535,7 +536,7 @@ export default function AdminStarterTasksPage() {
                             Unassign
                           </Button>
                         )}
-                        {task.status === 'submitted' && (
+                        {task.status === StarterTaskStatus.submitted && (
                           <Button
                             size="sm"
                             onClick={(e) => {

--- a/app/admin/stats/page.tsx
+++ b/app/admin/stats/page.tsx
@@ -1,20 +1,12 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useQuery } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 
 export default function AdminStatsPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
+  const { user, loading } = useRequireAdmin()
 
   const { data: stats, isLoading: loadingData } = useQuery({
     ...orpc.admin.stats.get.queryOptions(),

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button'
 import Tabs from '@/components/Tabs'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { InviteStatus } from '@/generated/prisma/enums'
 
 export default function AdminTeamPage() {
   const { user, loading } = useRequireAdmin()
@@ -28,7 +29,7 @@ export default function AdminTeamPage() {
     enabled: !!user?.isAdmin,
   })
 
-  const invites = allInvites.filter((i) => i.status === 'pending')
+  const invites = allInvites.filter((i) => i.status === InviteStatus.pending)
   const loadingData = loadingAdmins || loadingInvites
 
   const inviteMutation = useMutation({

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -1,17 +1,15 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Button from '@/components/Button'
 import Tabs from '@/components/Tabs'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
 export default function AdminTeamPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
   const [activeTab, setActiveTab] = useState<'admins' | 'invites'>('admins')
@@ -19,11 +17,6 @@ export default function AdminTeamPage() {
   const [inviteEmail, setInviteEmail] = useState('')
   const [inviteSuccess, setInviteSuccess] = useState('')
   const dialogRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: admins = [], isLoading: loadingAdmins } = useQuery({
     ...orpc.admin.admins.list.queryOptions(),

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
@@ -14,7 +14,6 @@ import {
   CARD_GRID_CLASSES,
 } from '@/components/ProjectCard'
 import Tabs from '@/components/Tabs'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -28,8 +27,7 @@ interface ReviewModal {
 }
 
 export default function TriagePage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
   const [tab, setTab] = useState<'pending_review' | 'needs_discussion' | 'interests'>(
@@ -54,11 +52,6 @@ export default function TriagePage() {
     ],
     'pending',
   )
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: projects = [], isLoading: loadingProjects } = useQuery({
     ...orpc.admin.triage.list.queryOptions(),

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -16,6 +16,7 @@ import {
 import Tabs from '@/components/Tabs'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
 interface Project extends CardProject {
   ownerId: number | null
@@ -115,11 +116,13 @@ export default function TriagePage() {
 
   if (loading || !user) return null
 
-  const pending = (projects as unknown as Project[]).filter((p) => p.status === 'pending_review')
-  const discussion = (projects as unknown as Project[]).filter(
-    (p) => p.status === 'needs_discussion',
+  const pending = (projects as unknown as Project[]).filter(
+    (p) => p.status === ProjectStatus.pending_review,
   )
-  const pendingInterests = interests.filter((i) => i.status === 'pending')
+  const discussion = (projects as unknown as Project[]).filter(
+    (p) => p.status === ProjectStatus.needs_discussion,
+  )
+  const pendingInterests = interests.filter((i) => i.status === InterestStatus.pending)
   const visible = tab === 'pending_review' ? pending : discussion
 
   return (
@@ -235,9 +238,9 @@ export default function TriagePage() {
                       </div>
                       <span
                         className={statusBadgeClasses(
-                          i.status === 'pending'
+                          i.status === InterestStatus.pending
                             ? 'seeking_help'
-                            : i.status === 'accepted'
+                            : i.status === InterestStatus.accepted
                               ? 'completed'
                               : 'on_hold',
                         )}
@@ -265,7 +268,7 @@ export default function TriagePage() {
                       </div>
                     )}
 
-                    {i.status === 'pending' && (
+                    {i.status === InterestStatus.pending && (
                       <div className="flex gap-2 mt-3">
                         <Button
                           size="sm"
@@ -273,7 +276,7 @@ export default function TriagePage() {
                             respondInterestMutation.mutate({
                               projectId: i.projectId,
                               interestId: i.id,
-                              status: 'accepted',
+                              status: InterestStatus.accepted,
                             })
                           }
                           disabled={respondInterestMutation.isPending}

--- a/app/admin/volunteers/[id]/page.tsx
+++ b/app/admin/volunteers/[id]/page.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import { use, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { use, useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import Tabs from '@/components/Tabs'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -92,8 +91,7 @@ type Tab = 'admin_notes' | 'starter_tasks' | 'project_history' | 'endorse_skill'
 
 export default function AdminVolunteerDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
   const [submitting, setSubmitting] = useState(false)
@@ -120,11 +118,6 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
     BASED_ON_OPTIONS,
     'direct_observation',
   )
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login')
-    if (!loading && user && !user.isAdmin) router.push('/')
-  }, [user, loading, router])
 
   const { data: vol, isPending: loadingData } = useQuery({
     ...orpc.admin.volunteers.getById.queryOptions({ input: { id: Number(id) } }),

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
 import Tabs from '@/components/Tabs'
 import type { InferRouterOutputs } from '@orpc/server'
 import type { AppRouter } from '@/server/router'
+import { ApprovalStatus, StarterTaskStatus } from '@/generated/prisma/enums'
 
 type Interest = InferRouterOutputs<AppRouter>['dashboard']['get']['myInterests'][number]
 
@@ -66,7 +67,7 @@ export default function DashboardPage() {
     enabled: !!user,
   })
   const starterTasks = starterTasksRaw.filter(
-    (t) => t.status === 'assigned' || t.status === 'submitted',
+    (t) => t.status === StarterTaskStatus.assigned || t.status === StarterTaskStatus.submitted,
   )
 
   const { data: notifications = [] } = useQuery({
@@ -154,7 +155,7 @@ export default function DashboardPage() {
         <h1 role="heading">Welcome back, {user.name}!</h1>
 
         {/* Pending approval banner */}
-        {user.approvalStatus === 'PENDING' && (
+        {user.approvalStatus === ApprovalStatus.pending && (
           <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-[#FEF9C3] text-[#854D0E] border border-[#FDE047] dark:bg-[#422006] dark:text-[#FDE047] dark:border-[#854D0E]">
             <span>
               Your account is pending approval. You can browse the platform, but some actions are
@@ -216,7 +217,7 @@ export default function DashboardPage() {
                         <strong>Feedback:</strong> {task.feedbackToVolunteer}
                       </p>
                     )}
-                    {task.status === 'assigned' && (
+                    {task.status === StarterTaskStatus.assigned && (
                       <Button
                         size="sm"
                         disabled={submitTaskMutation.isPending}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
@@ -26,8 +25,7 @@ const TAB_LABELS: Record<TabKey, string> = {
 }
 
 export default function DashboardPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const showToast = useToast()
   const queryClient = useQueryClient()
   const [activeTab, setActiveTab] = useState<TabKey>(() => {
@@ -38,10 +36,6 @@ export default function DashboardPage() {
   })
   const [expandedTasks, setExpandedTasks] = useState<Set<number>>(new Set())
   const [emailBannerDismissed, setEmailBannerDismissed] = useState(false)
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   useEffect(() => {
     function onHashChange() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
 import { InferRouterInputs } from '@orpc/server'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { AppRouter } from '@/server/router'
 import { type Project, ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
@@ -44,8 +43,7 @@ const SORT_OPTIONS = [
 ] as const
 
 export default function ProjectsPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const userSkillIds = new Set(user?.skills?.map((s) => s.id) ?? [])
   const [search, setSearch] = useState('')
   const { value: statusFilter, onChange: setStatusFilter } = useFilterOptions(STATUS_OPTIONS, '')
@@ -56,10 +54,6 @@ export default function ProjectsPage() {
   const [completedOpen, setCompletedOpen] = useState(false)
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [debouncedLocationFilter, setDebouncedLocationFilter] = useState('')
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   useEffect(() => {
     const t = setTimeout(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { InferRouterInputs } from '@orpc/server'
 import { orpc } from '@/lib/orpc'
 import { AppRouter } from '@/server/router'
 import { type Project, ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
+import { ProjectStatus } from '@/generated/prisma/enums'
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All Active' },
@@ -127,12 +128,16 @@ export default function ProjectsPage() {
 
   const seeking = sortGroup(projects.filter((p) => p.isSeekingHelp || p.isSeekingOwner))
   const inProgress = sortGroup(
-    projects.filter((p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === 'in_progress'),
+    projects.filter(
+      (p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === ProjectStatus.in_progress,
+    ),
   )
   const onHold = sortGroup(
-    projects.filter((p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === 'on_hold'),
+    projects.filter(
+      (p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === ProjectStatus.on_hold,
+    ),
   )
-  const completed = sortGroup(projects.filter((p) => p.status === 'completed'))
+  const completed = sortGroup(projects.filter((p) => p.status === ProjectStatus.completed))
   const other = sortGroup(
     projects.filter(
       (p) =>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,13 +1,12 @@
 'use client'
 
 import { useEffect, useState, FormEvent } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Checkbox from '@/components/Checkbox'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -17,8 +16,7 @@ interface SelectedSkill {
 }
 
 export default function ProfilePage() {
-  const router = useRouter()
-  const { user, loading, refreshUser } = useAuth()
+  const { user, loading, refreshUser } = useRequireAuth()
   const showToast = useToast()
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
@@ -62,10 +60,6 @@ export default function ProfilePage() {
   const [skills, setSkills] = useState<SelectedSkill[]>([])
   const [otherSkills, setOtherSkills] = useState('')
   const [initialized, setInitialized] = useState(false)
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   const { data: me, isPending: loadingProfile } = useQuery({
     ...orpc.auth.me.queryOptions(),

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import React, { use, useEffect, useState } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Checkbox from '@/components/Checkbox'
 import FilterDropdown from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { buildLocationOptions } from '@/lib/filter-options'
@@ -34,7 +34,7 @@ const PROJECT_TYPES = [
 export default function EditProjectPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = use(params)
   const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const showToast = useToast()
 
   const [canEdit, setCanEdit] = useState(false)
@@ -52,10 +52,6 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [estimatedDuration, setEstimatedDuration] = useState('')
   const [seekingHelp, setSeekingHelp] = useState(true)
   const [seekingOwner, setSeekingOwner] = useState(true)
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   const { data: localGroupsData } = useQuery({
     ...orpc.localGroups.list.queryOptions({ input: {} }),

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import React, { use, useEffect, useState } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -62,7 +62,7 @@ function statusBadge(status: string) {
 export default function ProjectDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = use(params)
   const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const queryClient = useQueryClient()
 
   const showToast = useToast()
@@ -113,10 +113,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   const [showContactModal, setShowContactModal] = useState(false)
   const [contactSubject, setContactSubject] = useState('')
   const [contactBody, setContactBody] = useState('')
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   // ── Queries ──────────────────────────────────────────────────────────────
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -170,9 +171,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   const updateTaskMutation = useMutation({
     ...orpc.projects.updateTask.mutationOptions(),
     onSuccess: (_data, variables) => {
-      if (variables.data.status === 'assigned') {
+      if (variables.data.status === TaskStatus.assigned) {
         showToast('Task claimed!', 'success')
-      } else if (variables.data.status === 'done') {
+      } else if (variables.data.status === TaskStatus.done) {
         showToast('Task completed!', 'success')
       }
       void invalidateProject()
@@ -229,7 +230,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     ...orpc.projects.respondToInterest.mutationOptions(),
     onSuccess: (_data, variables) => {
       showToast(
-        variables.status === 'accepted' ? 'Interest accepted' : 'Interest declined',
+        variables.status === InterestStatus.accepted ? 'Interest accepted' : 'Interest declined',
         'success',
       )
       void invalidateProject()
@@ -348,7 +349,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     updateTaskMutation.mutate({
       projectId: parseInt(idParam, 10),
       taskId,
-      data: { status: 'assigned', assignedToId: user!.id },
+      data: { status: TaskStatus.assigned, assignedToId: user!.id },
     })
   }
 
@@ -356,7 +357,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     updateTaskMutation.mutate({
       projectId: parseInt(idParam, 10),
       taskId,
-      data: { status: 'done' },
+      data: { status: TaskStatus.done },
     })
   }
 
@@ -367,7 +368,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
   function handleUpdateStatus(e: React.FormEvent) {
     e.preventDefault()
-    updateProjectMutation.mutate({ id: parseInt(idParam, 10), status: newStatus })
+    const validStatuses = Object.values(ProjectStatus)
+    const status = validStatuses.find((s) => s === newStatus)
+    if (!status) return
+    updateProjectMutation.mutate({ id: parseInt(idParam, 10), status })
   }
 
   function handleExpressInterest(e: React.FormEvent) {
@@ -388,7 +392,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     respondToInterestMutation.mutate({
       projectId: parseInt(idParam, 10),
       interestId,
-      status: 'accepted',
+      status: InterestStatus.accepted,
     })
   }
 
@@ -628,7 +632,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                 {project.myInterest.responseMessage && (
                   <p className="text-text-light text-sm">{project.myInterest.responseMessage}</p>
                 )}
-                {project.myInterest.status === 'pending' && (
+                {project.myInterest.status === InterestStatus.pending && (
                   <Button variant="secondary" className="mt-2" onClick={handleWithdrawInterest}>
                     Withdraw Interest
                   </Button>
@@ -686,18 +690,18 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                   className="flex items-center gap-2 py-2 border-b border-brand-border last:border-0 flex-wrap"
                 >
                   <span className="flex-1">{task.title}</span>
-                  {task.status === 'done' && (
+                  {task.status === TaskStatus.done && (
                     <span className="text-success text-sm font-semibold">done</span>
                   )}
-                  {task.assignedToName && task.status !== 'done' && (
+                  {task.assignedToName && task.status !== TaskStatus.done && (
                     <span className="text-text-light text-sm">→ {task.assignedToName}</span>
                   )}
-                  {task.status === 'open' && (
+                  {task.status === TaskStatus.open && (
                     <Button variant="secondary" size="sm" onClick={() => handleClaimTask(task.id)}>
                       Claim
                     </Button>
                   )}
-                  {task.status === 'assigned' && task.assignedToId === user.id && (
+                  {task.status === TaskStatus.assigned && task.assignedToId === user.id && (
                     <Button variant="secondary" size="sm" onClick={() => handleDoneTask(task.id)}>
                       Done
                     </Button>
@@ -765,7 +769,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                           <p className="text-sm mt-1 mb-0">{interest.message}</p>
                         )}
                       </div>
-                      {interest.status === 'pending' && (
+                      {interest.status === InterestStatus.pending && (
                         <div className="flex gap-2">
                           <Button size="sm" onClick={() => handleAcceptInterest(interest.id)}>
                             Accept
@@ -836,7 +840,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
         )}
 
         {/* Record Outcome */}
-        {isAdmin && project.status === 'completed' && !project.outcome && (
+        {isAdmin && project.status === ProjectStatus.completed && !project.outcome && (
           <div className={card}>
             <h2>Record Project Outcome</h2>
             <form onSubmit={handleRecordOutcome}>
@@ -869,7 +873,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
         )}
 
         {/* Admin triage */}
-        {isAdmin && project.status === 'pending_review' && !reviewDone && (
+        {isAdmin && project.status === ProjectStatus.pending_review && !reviewDone && (
           <div className={card}>
             <h2>Review Project</h2>
             <form onSubmit={handleSubmitReview}>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import { useEffect, useState, FormEvent } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, FormEvent } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useMutation } from '@tanstack/react-query'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
 export default function SettingsPage() {
-  const router = useRouter()
-  const { user, loading, logout } = useAuth()
+  const { user, loading, logout } = useRequireAuth()
   const showToast = useToast()
 
   const [newEmail, setNewEmail] = useState('')
@@ -23,10 +21,6 @@ export default function SettingsPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [deletePassword, setDeletePassword] = useState('')
   const [deleteConfirmPassword, setDeleteConfirmPassword] = useState('')
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   const changeEmailMutation = useMutation({
     ...orpc.auth.changeEmail.mutationOptions(),

--- a/app/starter-tasks/page.tsx
+++ b/app/starter-tasks/page.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -17,14 +15,9 @@ const STATUS_LABELS: Record<string, string> = {
 }
 
 export default function StarterTasksPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const showToast = useToast()
   const queryClient = useQueryClient()
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   const { data: tasks = [], isLoading: loadingTasks } = useQuery({
     ...orpc.my.starterTasks.queryOptions(),

--- a/app/starter-tasks/page.tsx
+++ b/app/starter-tasks/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import Button from '@/components/Button'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { StarterTaskStatus } from '@/generated/prisma/enums'
 
 const STATUS_LABELS: Record<string, string> = {
   assigned: 'Assigned',
@@ -65,7 +66,7 @@ export default function StarterTasksPage() {
               <div className="flex justify-between items-start mb-2">
                 <h3 className="m-0">{task.title}</h3>
                 <span
-                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === 'completed' || task.status === 'reviewed' ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
+                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === StarterTaskStatus.completed || task.status === StarterTaskStatus.reviewed ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
                 >
                   {STATUS_LABELS[task.status] ?? task.status}
                 </span>
@@ -96,7 +97,7 @@ export default function StarterTasksPage() {
                 </div>
               )}
 
-              {task.status === 'assigned' && (
+              {task.status === StarterTaskStatus.assigned && (
                 <Button
                   onClick={() => submitMutation.mutate({ id: task.id })}
                   disabled={submitMutation.isPending && submitMutation.variables?.id === task.id}

--- a/app/suggest-local-group/page.tsx
+++ b/app/suggest-local-group/page.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Button from '@/components/Button'
 import FilterDropdown from '@/components/FilterDropdown'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { COUNTRY_OPTIONS } from '@/lib/filter-options'
 import { useToast } from '@/lib/toast'
@@ -29,17 +28,12 @@ const STATUS_CLASSES: Record<string, string> = {
 }
 
 export default function SuggestLocalGroupPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const showToast = useToast()
   const queryClient = useQueryClient()
 
   const [country, setCountry] = useState('')
   const [name, setName] = useState('')
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   const { data, isLoading: loadingSuggestions } = useQuery({
     ...orpc.localGroupSuggestions.list.queryOptions(),

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -1,22 +1,17 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
 import ProjectForm from '@/components/ProjectForm'
-import { useAuth } from '@/lib/auth-context'
 import { useToast } from '@/lib/toast'
 import { orpc } from '@/lib/orpc'
 
 export default function SuggestPage() {
   const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const toast = useToast()
   const createMutation = useMutation({ ...orpc.projects.create.mutationOptions() })
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   if (loading || !user) return null
 

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -195,7 +195,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                       {p.title}
                     </Link>
                     <span
-                      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${p.status === 'in_progress' || p.status === 'completed' ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : p.status === 'on_hold' ? 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]' : p.status === 'open' ? 'bg-[#E0E7FF] text-[#3730A3] dark:bg-[#312E81] dark:text-[#A5B4FC]' : p.status === 'assigned' || p.status === 'seeking_help' ? 'bg-[#DBEAFE] text-[#1E40AF] dark:bg-[#1E3A5F] dark:text-[#93C5FD]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
+                      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${p.status === 'in_progress' || p.status === 'completed' ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : p.status === 'on_hold' ? 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]' : p.status === 'seeking_help' ? 'bg-[#DBEAFE] text-[#1E40AF] dark:bg-[#1E3A5F] dark:text-[#93C5FD]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
                     >
                       {p.status.replace(/_/g, ' ')}
                     </span>

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -1,21 +1,15 @@
 'use client'
 
-import { use, useEffect } from 'react'
+import { use } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import { useQuery } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Button from '@/components/Button'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 
 export default function VolunteerDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
-  const router = useRouter()
-  const { user, loading } = useAuth()
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
+  const { user, loading } = useRequireAuth()
 
   const {
     data: volunteer,

--- a/app/volunteers/page.tsx
+++ b/app/volunteers/page.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRequireAuth } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import FilterDropdown from '@/components/FilterDropdown'
 import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
 import { InferRouterOutputs } from '@orpc/server'
-import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
 import { AppRouter } from '@/server/router'
 import { CARD_GRID_CLASSES } from '@/components/ProjectCard'
@@ -19,17 +18,12 @@ type FlatSkill = SkillCategory['skills'][number] & { categoryName: string }
 type Volunteer = InferRouterOutputs<AppRouter>['volunteers']['list']['volunteers'][number]
 
 export default function VolunteersPage() {
-  const router = useRouter()
-  const { user, loading } = useAuth()
+  const { user, loading } = useRequireAuth()
   const [search, setSearch] = useState('')
   const [skillFilter, setSkillFilter] = useState('')
   const [locationFilter, setLocationFilter] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [debouncedLocationFilter, setDebouncedLocationFilter] = useState('')
-
-  useEffect(() => {
-    if (!loading && !user) router.replace('/login')
-  }, [user, loading, router])
 
   useEffect(() => {
     const t = setTimeout(

--- a/jobs/applications.ts
+++ b/jobs/applications.ts
@@ -3,10 +3,14 @@ import { prisma } from '@/lib/prisma'
 import { isSuperAdmin } from '@/lib/auth'
 import { sendPendingApplicationsSummaryEmail } from '@/lib/email'
 import { APPLICATION_ANONYMISATION_MS } from '@/lib/applications'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 export async function runApplicationsSummaryJob(): Promise<Record<string, unknown>> {
   const count = await prisma.volunteer.count({
-    where: { approvalStatus: { in: ['PENDING', 'UNDER_REVIEW'] }, deletedAt: null },
+    where: {
+      approvalStatus: { in: [ApprovalStatus.pending, ApprovalStatus.under_review] },
+      deletedAt: null,
+    },
   })
 
   if (!count) return { skipped: true, reason: 'no pending applications' }
@@ -45,7 +49,7 @@ export async function runApplicationsAnonymisationJob(): Promise<Record<string, 
   >`
     SELECT id, email, rejected_at, application_admin_notes, application_applicant_notes
     FROM volunteers
-    WHERE approval_status = 'REJECTED'
+    WHERE approval_status = 'rejected'
       AND rejected_at <= ${cutoff.toISOString()}
       AND deleted_at IS NULL
   `

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,6 +2,7 @@ import { randomBytes, pbkdf2Sync, timingSafeEqual } from 'crypto'
 import type { Volunteer } from '@/generated/prisma/client'
 import { prisma } from './prisma'
 import { env } from './env'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 // PBKDF2-SHA256 password hashing — matches the Python implementation exactly:
 // salt = secrets.token_bytes(32); key = hashlib.pbkdf2_hmac('sha256', pw, salt, 100000)
@@ -154,7 +155,7 @@ export async function checkAdminBootstrap(email: string, volunteerId: number): P
   if (!allowed.includes(email.toLowerCase())) return false
   await prisma.volunteer.updateMany({
     where: { id: volunteerId, isAdmin: false },
-    data: { isAdmin: true, approvalStatus: 'APPROVED', emailConfirmed: true },
+    data: { isAdmin: true, approvalStatus: ApprovalStatus.approved, emailConfirmed: true },
   })
   return true
 }
@@ -179,7 +180,7 @@ export async function acceptPendingInvite(email: string, volunteerId: number): P
   if (!invite) return false
   await prisma.volunteer.update({
     where: { id: volunteerId },
-    data: { isAdmin: true, approvalStatus: 'APPROVED', emailConfirmed: true },
+    data: { isAdmin: true, approvalStatus: ApprovalStatus.approved, emailConfirmed: true },
   })
   await prisma.adminInvite.update({
     where: { id: invite.id },

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,7 @@ import { randomBytes, pbkdf2Sync, timingSafeEqual } from 'crypto'
 import type { Volunteer } from '@/generated/prisma/client'
 import { prisma } from './prisma'
 import { env } from './env'
-import { ApprovalStatus } from '@/generated/prisma/enums'
+import { ApprovalStatus, InviteStatus } from '@/generated/prisma/enums'
 
 // PBKDF2-SHA256 password hashing — matches the Python implementation exactly:
 // salt = secrets.token_bytes(32); key = hashlib.pbkdf2_hmac('sha256', pw, salt, 100000)
@@ -184,7 +184,7 @@ export async function acceptPendingInvite(email: string, volunteerId: number): P
   })
   await prisma.adminInvite.update({
     where: { id: invite.id },
-    data: { status: 'accepted', acceptedById: volunteerId, acceptedAt: new Date() },
+    data: { status: InviteStatus.accepted, acceptedById: volunteerId, acceptedAt: new Date() },
   })
   return true
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,7 @@
 import { randomBytes, pbkdf2Sync, timingSafeEqual } from 'crypto'
 import type { Volunteer } from '@/generated/prisma/client'
 import { prisma } from './prisma'
+import { env } from './env'
 
 // PBKDF2-SHA256 password hashing — matches the Python implementation exactly:
 // salt = secrets.token_bytes(32); key = hashlib.pbkdf2_hmac('sha256', pw, salt, 100000)
@@ -117,7 +118,7 @@ export async function requireAdmin(
 
 export function isSuperAdmin(email: string | null | undefined): boolean {
   if (!email) return false
-  const adminEmails = process.env.ADMIN_EMAILS || ''
+  const adminEmails = env.ADMIN_EMAILS
   return adminEmails
     .split(',')
     .map((e) => e.trim().toLowerCase())
@@ -144,7 +145,7 @@ export async function requireSuperAdmin(
 
 // Promote volunteer to admin if their email is in ADMIN_EMAILS env var
 export async function checkAdminBootstrap(email: string, volunteerId: number): Promise<boolean> {
-  const adminEmails = process.env.ADMIN_EMAILS || ''
+  const adminEmails = env.ADMIN_EMAILS
   if (!adminEmails) return false
   const allowed = adminEmails
     .split(',')

--- a/lib/cron-auth.ts
+++ b/lib/cron-auth.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { env } from './env'
 
 export function checkCronAuth(request: NextRequest): NextResponse | null {
-  const secret = process.env.CRON_SECRET
+  const secret = env.CRON_SECRET
   if (!secret) {
     console.error('[CRON] CRON_SECRET env var not set')
     return NextResponse.json({ error: 'Cron not configured' }, { status: 500 })

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,4 +1,5 @@
 import { Resend } from 'resend'
+import { env } from './env'
 
 function escapeHtml(s: string): string {
   return s
@@ -9,19 +10,10 @@ function escapeHtml(s: string): string {
     .replace(/'/g, '&#39;')
 }
 
-const RESEND_API_KEY = process.env.RESEND_API_KEY
-const FROM_EMAIL = process.env.FROM_EMAIL || 'Catalyse <noreply@pauseai.uk>'
-const REPLY_TO_EMAIL = process.env.REPLY_TO_EMAIL
-const APP_URL = process.env.APP_URL!
-const STUB_EMAIL_DEFAULT = process.env.NODE_ENV === 'production' ? '' : 'true'
-const STUB_EMAIL = ['1', 'true', 'yes'].includes(
-  (process.env.STUB_EMAIL || STUB_EMAIL_DEFAULT).toLowerCase(),
-)
-
-const resend = RESEND_API_KEY ? new Resend(RESEND_API_KEY) : null
+const resend = env.RESEND_API_KEY ? new Resend(env.RESEND_API_KEY) : null
 
 export function isEmailConfigured(): boolean {
-  return STUB_EMAIL || Boolean(RESEND_API_KEY)
+  return env.STUB_EMAIL || Boolean(env.RESEND_API_KEY)
 }
 
 const STUB_EMAIL_DIR = '/tmp/catalyse-emails'
@@ -32,7 +24,7 @@ async function sendEmail(
   html: string,
   replyTo?: string,
 ): Promise<boolean> {
-  if (STUB_EMAIL) {
+  if (env.STUB_EMAIL) {
     const fs = await import('fs/promises')
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
     const slug = subject
@@ -52,12 +44,12 @@ async function sendEmail(
   }
   try {
     const payload: Parameters<typeof resend.emails.send>[0] = {
-      from: FROM_EMAIL,
+      from: env.FROM_EMAIL,
       to: [to],
       subject,
       html,
     }
-    const effectiveReplyTo = replyTo || REPLY_TO_EMAIL
+    const effectiveReplyTo = replyTo || env.REPLY_TO_EMAIL
     if (effectiveReplyTo) payload.replyTo = effectiveReplyTo
     const { error } = await resend.emails.send(payload)
     if (error) {
@@ -88,7 +80,7 @@ function footer(buttons: Array<[string, string]> = []): string {
   return `<div class="footer">
     <p>Catalyse - PauseAI Volunteer Platform - This is an automated email</p>
     ${fallbacks}
-    <p style="font-size: 12px;"><a href="${APP_URL}/profile">Manage notification preferences</a></p>
+    <p style="font-size: 12px;"><a href="${env.APP_URL}/profile">Manage notification preferences</a></p>
   </div>`
 }
 
@@ -121,7 +113,7 @@ export async function sendWelcomeAndConfirmEmail({
   token: string
   name: string
 }): Promise<boolean> {
-  const confirmUrl = `${APP_URL}/verify-email?token=${token}`
+  const confirmUrl = `${env.APP_URL}/verify-email?token=${token}`
   return sendEmail(
     to,
     'Welcome to Catalyse — please confirm your email',
@@ -178,7 +170,7 @@ export async function sendApplicationApprovedEmail({
   return sendEmail(
     to,
     'Your Catalyse application has been approved',
-    buildApplicationApprovedHtml(name, APP_URL),
+    buildApplicationApprovedHtml(name, env.APP_URL),
   )
 }
 
@@ -238,7 +230,7 @@ export async function sendPendingApplicationsSummaryEmail({
   return sendEmail(
     to,
     `${count} pending ${plural} on Catalyse`,
-    buildPendingApplicationsSummaryHtml(count, APP_URL),
+    buildPendingApplicationsSummaryHtml(count, env.APP_URL),
   )
 }
 
@@ -265,7 +257,7 @@ export async function sendPasswordResetEmail({
   resetToken: string
   name?: string
 }): Promise<boolean> {
-  const resetUrl = `${APP_URL}/reset-password?token=${resetToken}`
+  const resetUrl = `${env.APP_URL}/reset-password?token=${resetToken}`
   return sendEmail(to, 'Reset your Catalyse password', buildPasswordResetHtml(resetUrl, name))
 }
 
@@ -298,7 +290,7 @@ export async function sendAdminInviteEmail({
   inviteToken: string
   invitedBy: string
 }): Promise<boolean> {
-  const inviteUrl = `${APP_URL}/accept-invite?token=${inviteToken}`
+  const inviteUrl = `${env.APP_URL}/accept-invite?token=${inviteToken}`
   return sendEmail(
     to,
     `${invitedBy} invited you to be a Catalyse admin`,
@@ -330,7 +322,7 @@ export async function sendWelcomeEmail({
   to: string
   name: string
 }): Promise<boolean> {
-  return sendEmail(to, 'Welcome to Catalyse!', buildWelcomeHtml(name, APP_URL))
+  return sendEmail(to, 'Welcome to Catalyse!', buildWelcomeHtml(name, env.APP_URL))
 }
 
 export function buildProjectNotificationHtml(
@@ -374,7 +366,7 @@ export async function sendProjectNotificationEmail({
   return sendEmail(
     to,
     subject,
-    buildProjectNotificationHtml(name, subject, message, projectId, APP_URL, extraHtml),
+    buildProjectNotificationHtml(name, subject, message, projectId, env.APP_URL, extraHtml),
   )
 }
 
@@ -408,7 +400,7 @@ export function buildLocalGroupSuggestionHtml(
   <p>Hi ${n},</p>
   <p>${message}</p>
   ${notesHtml}
-  <p style="text-align: center; margin: 32px 0;"><a href="${APP_URL}" class="button">Visit Catalyse</a></p>
+  <p style="text-align: center; margin: 32px 0;"><a href="${env.APP_URL}" class="button">Visit Catalyse</a></p>
   ${footer()}
 </div></body></html>`
 }
@@ -555,7 +547,7 @@ export async function sendDigestEmail({
   isMatch?: boolean
 }): Promise<boolean> {
   if (!projects.length) return false
-  const html = buildDigestHtml(name, APP_URL, projects, isMatch)
+  const html = buildDigestHtml(name, env.APP_URL, projects, isMatch)
   const subject = isMatch ? 'New projects matching your skills' : "What's new on Catalyse"
   return sendEmail(to, subject, html)
 }
@@ -573,7 +565,7 @@ export function buildTaskNudgeHtml(
   const n = escapeHtml(name)
   const tt = escapeHtml(taskTitle)
   const pt = escapeHtml(projectTitle)
-  const taskUrl = `${APP_URL}/projects/${projectId}#task-${taskId}`
+  const taskUrl = `${env.APP_URL}/projects/${projectId}#task-${taskId}`
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
 <body><div class="container">
   <h2>How's it going?</h2>
@@ -641,7 +633,7 @@ export function buildTaskFinalWarningHtml(
   const n = escapeHtml(name)
   const tt = escapeHtml(taskTitle)
   const pt = escapeHtml(projectTitle)
-  const taskUrl = `${APP_URL}/projects/${projectId}#task-${taskId}`
+  const taskUrl = `${env.APP_URL}/projects/${projectId}#task-${taskId}`
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
   ${baseStyle}
   .warning { background: #FFF3CD; border-left: 4px solid #FF9416; padding: 12px 16px; border-radius: 4px; margin: 16px 0; }
@@ -712,7 +704,7 @@ export function buildTaskSurrenderedOwnerHtml(
   const vn = escapeHtml(volunteerName)
   const tt = escapeHtml(taskTitle)
   const pt = escapeHtml(projectTitle)
-  const projectUrl = `${APP_URL}/projects/${projectId}`
+  const projectUrl = `${env.APP_URL}/projects/${projectId}`
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
 <body><div class="container">
   <h2>Task unassigned due to inactivity</h2>
@@ -757,7 +749,7 @@ export function buildTaskSurrenderedAssigneeHtml(
   const n = escapeHtml(name)
   const tt = escapeHtml(taskTitle)
   const pt = escapeHtml(projectTitle)
-  const projectUrl = `${APP_URL}/projects/${projectId}`
+  const projectUrl = `${env.APP_URL}/projects/${projectId}`
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
 <body><div class="container">
   <h2>Task now open to other contributors</h2>

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,5 +1,26 @@
 type EnvError = { var: string; reason: string }
 
+const stubEmailDefault = process.env.NODE_ENV === 'production' ? '' : 'true'
+
+export const env = {
+  NODE_ENV: process.env.NODE_ENV ?? 'development',
+  APP_URL: process.env.APP_URL ?? '',
+  RESEND_API_KEY: process.env.RESEND_API_KEY,
+  FROM_EMAIL: process.env.FROM_EMAIL ?? 'Catalyse <noreply@pauseai.uk>',
+  REPLY_TO_EMAIL: process.env.REPLY_TO_EMAIL,
+  STUB_EMAIL: ['1', 'true', 'yes'].includes(
+    (process.env.STUB_EMAIL || stubEmailDefault).toLowerCase(),
+  ),
+  CRON_SECRET: process.env.CRON_SECRET,
+  ADMIN_EMAILS: process.env.ADMIN_EMAILS ?? '',
+  DISABLE_RATE_LIMIT: ['1', 'true', 'yes'].includes(
+    (process.env.DISABLE_RATE_LIMIT ?? '').toLowerCase(),
+  ),
+  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  RAILWAY_GIT_COMMIT_SHA: process.env.RAILWAY_GIT_COMMIT_SHA,
+  RAILWAY_ENVIRONMENT_NAME: process.env.RAILWAY_ENVIRONMENT_NAME,
+} as const
+
 export function validateEnv(): void {
   if (process.env.NODE_ENV !== 'production') return
   // Railway PR deployments run as NODE_ENV=production but aren't the live environment
@@ -8,16 +29,15 @@ export function validateEnv(): void {
 
   const errors: EnvError[] = []
 
-  if (!process.env.APP_URL) {
+  if (!env.APP_URL) {
     errors.push({ var: 'APP_URL', reason: 'required for correct links in emails' })
   }
 
-  if (!process.env.CRON_SECRET) {
+  if (!env.CRON_SECRET) {
     errors.push({ var: 'CRON_SECRET', reason: 'required to authenticate cron endpoints' })
   }
 
-  const stubEmail = ['1', 'true', 'yes'].includes((process.env.STUB_EMAIL ?? '').toLowerCase())
-  if (!stubEmail && !process.env.RESEND_API_KEY) {
+  if (!env.STUB_EMAIL && !env.RESEND_API_KEY) {
     errors.push({
       var: 'RESEND_API_KEY',
       reason: 'required to send emails (or set STUB_EMAIL=true)',

--- a/lib/hooks/auth.ts
+++ b/lib/hooks/auth.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/lib/auth-context'
+
+export function useRequireAuth() {
+  const router = useRouter()
+  const auth = useAuth()
+  useEffect(() => {
+    if (!auth.loading && !auth.user) router.replace('/login')
+  }, [auth.user, auth.loading, router])
+  return auth
+}
+
+export function useRequireAdmin() {
+  const router = useRouter()
+  const auth = useAuth()
+  useEffect(() => {
+    if (!auth.loading && !auth.user) router.replace('/login')
+    if (!auth.loading && auth.user && !auth.user.isAdmin) router.replace('/')
+  }, [auth.user, auth.loading, router])
+  return auth
+}
+
+export function useRequireSuperAdmin() {
+  const router = useRouter()
+  const auth = useAuth()
+  useEffect(() => {
+    if (!auth.loading && !auth.user) router.replace('/login')
+    if (!auth.loading && auth.user && !auth.user.isSuperAdmin) router.replace('/')
+  }, [auth.user, auth.loading, router])
+  return auth
+}

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,0 +1,39 @@
+import { prisma } from './prisma'
+import { createNotification } from './project'
+import { sendProjectNotificationEmail } from './email'
+
+export async function notifyVolunteer(
+  volunteerId: number,
+  type: string,
+  title: string,
+  body: string | null | undefined,
+  link: string | null | undefined,
+  email?: {
+    subject?: string
+    message: string
+    projectId: number
+    projectTitle: string
+    extraHtml?: string
+  },
+): Promise<void> {
+  createNotification(volunteerId, type, title, body, link).catch((e) =>
+    console.error('[NOTIFY ERROR]', e),
+  )
+  if (!email) return
+
+  const vol = await prisma.volunteer.findFirst({
+    where: { id: volunteerId, deletedAt: null },
+    select: { name: true, email: true },
+  })
+  if (!vol?.email) return
+
+  sendProjectNotificationEmail({
+    to: vol.email,
+    name: vol.name,
+    subject: email.subject ?? title,
+    message: email.message,
+    projectTitle: email.projectTitle,
+    projectId: email.projectId,
+    extraHtml: email.extraHtml,
+  }).catch((e) => console.error('[EMAIL ERROR]', e))
+}

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -2,7 +2,7 @@ import { prisma } from './prisma'
 import { createNotification } from './project'
 import { sendProjectNotificationEmail } from './email'
 
-export async function notifyVolunteer(
+export async function notifyUser(
   volunteerId: number,
   type: string,
   title: string,

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@/generated/prisma/client'
 import { calculateMatchScore } from './matching'
 import { prisma } from './prisma'
+import { InterestStatus } from '@/generated/prisma/enums'
 
 export type ProjectSkillWithRelations = {
   skillId: number
@@ -107,7 +108,7 @@ export const projectInclude = {
   },
   owner: { select: { id: true, name: true } },
   proposedBy: { select: { id: true, name: true } },
-  _count: { select: { interests: { where: { status: 'pending' } } } },
+  _count: { select: { interests: { where: { status: InterestStatus.pending } } } },
 } satisfies Prisma.ProjectInclude
 
 export async function createNotification(

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,5 +1,7 @@
+import { env } from './env'
+
 const store = new Map<string, number[]>()
-const DISABLED = ['1', 'true', 'yes'].includes((process.env.DISABLE_RATE_LIMIT ?? '').toLowerCase())
+const DISABLED = env.DISABLE_RATE_LIMIT
 
 function getClientIp(request: Request): string {
   return (

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { ProjectStatus } from '@/generated/prisma/enums'
 import {
   AdminInviteSchema,
   AdminNoteSchema,
@@ -178,7 +179,7 @@ export const ReviewProjectSchema = z.object({
   }),
   reviewNotes: z.string().optional().nullable(),
   feedbackToProposer: z.string().optional().nullable(),
-  targetStatus: z.string().optional().default('seeking_owner'),
+  targetStatus: z.enum([ProjectStatus.seeking_help, ProjectStatus.seeking_owner]).optional().default(ProjectStatus.seeking_owner),
 })
 
 export const OutcomeProjectSchema = z.object({

--- a/prisma/migrations/20260519225003_add_status_enums/migration.sql
+++ b/prisma/migrations/20260519225003_add_status_enums/migration.sql
@@ -1,0 +1,49 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_local_group_suggestions" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "country" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "suggested_by_id" INTEGER NOT NULL,
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "admin_notes" TEXT,
+    "merged_into_id" INTEGER,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "local_group_suggestions_suggested_by_id_fkey" FOREIGN KEY ("suggested_by_id") REFERENCES "volunteers" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "local_group_suggestions_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "local_group_suggestions_merged_into_id_fkey" FOREIGN KEY ("merged_into_id") REFERENCES "local_groups" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_local_group_suggestions" ("admin_notes", "country", "created_at", "id", "merged_into_id", "name", "reviewed_at", "reviewed_by_id", "status", "suggested_by_id", "updated_at") SELECT "admin_notes", "country", "created_at", "id", "merged_into_id", "name", "reviewed_at", "reviewed_by_id", "status", "suggested_by_id", "updated_at" FROM "local_group_suggestions";
+DROP TABLE "local_group_suggestions";
+ALTER TABLE "new_local_group_suggestions" RENAME TO "local_group_suggestions";
+CREATE INDEX "idx_local_group_suggestions_status" ON "local_group_suggestions"("status");
+CREATE INDEX "idx_local_group_suggestions_suggested_by" ON "local_group_suggestions"("suggested_by_id");
+CREATE TABLE "new_project_tasks" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "project_id" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "assigned_to_id" INTEGER,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "created_by_id" INTEGER NOT NULL,
+    "completed_at" DATETIME,
+    "nudge_sent_at" DATETIME,
+    "final_warning_sent_at" DATETIME,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "project_tasks_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "project_tasks_assigned_to_id_fkey" FOREIGN KEY ("assigned_to_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "project_tasks_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_project_tasks" ("assigned_to_id", "completed_at", "created_at", "created_by_id", "description", "final_warning_sent_at", "id", "nudge_sent_at", "project_id", "status", "title", "updated_at") SELECT "assigned_to_id", "completed_at", "created_at", "created_by_id", "description", "final_warning_sent_at", "id", "nudge_sent_at", "project_id", "status", "title", "updated_at" FROM "project_tasks";
+DROP TABLE "project_tasks";
+ALTER TABLE "new_project_tasks" RENAME TO "project_tasks";
+CREATE INDEX "idx_project_tasks_assigned" ON "project_tasks"("assigned_to_id");
+CREATE INDEX "idx_project_tasks_project" ON "project_tasks"("project_id");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+

--- a/prisma/migrations/20260519225737_lowercase_approval_status/migration.sql
+++ b/prisma/migrations/20260519225737_lowercase_approval_status/migration.sql
@@ -1,0 +1,65 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_volunteers" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+    "bio" TEXT,
+    "discord_handle" TEXT,
+    "signal_number" TEXT,
+    "whatsapp_number" TEXT,
+    "contact_preference" TEXT,
+    "contact_notes" TEXT,
+    "availability_hours_per_week" INTEGER,
+    "location" TEXT,
+    "other_skills" TEXT,
+    "consent_make_profile_visible_in_directory" BOOLEAN DEFAULT false,
+    "consent_contactable_by_project_owners" BOOLEAN DEFAULT false,
+    "consent_share_contact_info_with_project_owner" BOOLEAN DEFAULT false,
+    "consent_given_at" DATETIME,
+    "cookie_consent_analytics" BOOLEAN,
+    "auth_token" TEXT,
+    "auth_token_expires_at" DATETIME,
+    "password_hash" TEXT,
+    "is_admin" BOOLEAN DEFAULT false,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" DATETIME,
+    "country" TEXT,
+    "email_digest" TEXT DEFAULT 'none',
+    "local_group" TEXT,
+    "approval_status" TEXT NOT NULL DEFAULT 'pending',
+    "application_message" TEXT,
+    "application_admin_notes" TEXT,
+    "application_applicant_notes" TEXT,
+    "rejected_at" DATETIME,
+    "reviewer_id" INTEGER,
+    "email_confirmed" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "volunteers_reviewer_id_fkey" FOREIGN KEY ("reviewer_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+INSERT INTO "new_volunteers" ("application_admin_notes", "application_applicant_notes", "application_message", "approval_status", "auth_token", "auth_token_expires_at", "availability_hours_per_week", "bio", "consent_contactable_by_project_owners", "consent_given_at", "consent_make_profile_visible_in_directory", "consent_share_contact_info_with_project_owner", "contact_notes", "contact_preference", "cookie_consent_analytics", "country", "created_at", "deleted_at", "discord_handle", "email", "email_confirmed", "email_digest", "id", "is_admin", "local_group", "location", "name", "other_skills", "password_hash", "rejected_at", "reviewer_id", "signal_number", "updated_at", "whatsapp_number")
+SELECT "application_admin_notes", "application_applicant_notes", "application_message",
+  CASE "approval_status"
+    WHEN 'PENDING' THEN 'pending'
+    WHEN 'UNDER_REVIEW' THEN 'under_review'
+    WHEN 'APPROVED' THEN 'approved'
+    WHEN 'REJECTED' THEN 'rejected'
+    ELSE "approval_status"
+  END,
+  "auth_token", "auth_token_expires_at", "availability_hours_per_week", "bio", "consent_contactable_by_project_owners", "consent_given_at", "consent_make_profile_visible_in_directory", "consent_share_contact_info_with_project_owner", "contact_notes", "contact_preference", "cookie_consent_analytics", "country", "created_at", "deleted_at", "discord_handle", "email", "email_confirmed", "email_digest", "id", "is_admin", "local_group", "location", "name", "other_skills", "password_hash", "rejected_at", "reviewer_id", "signal_number", "updated_at", "whatsapp_number" FROM "volunteers";
+DROP TABLE "volunteers";
+ALTER TABLE "new_volunteers" RENAME TO "volunteers";
+Pragma writable_schema=1;
+CREATE UNIQUE INDEX "sqlite_autoindex_volunteers_1" ON "volunteers"("email");
+Pragma writable_schema=0;
+Pragma writable_schema=1;
+CREATE UNIQUE INDEX "sqlite_autoindex_volunteers_2" ON "volunteers"("auth_token");
+Pragma writable_schema=0;
+CREATE INDEX "idx_volunteers_local_group" ON "volunteers"("local_group");
+CREATE INDEX "idx_volunteers_country" ON "volunteers"("country");
+CREATE INDEX "idx_volunteers_deleted" ON "volunteers"("deleted_at");
+CREATE INDEX "idx_volunteers_auth_token" ON "volunteers"("auth_token");
+CREATE INDEX "idx_volunteers_email" ON "volunteers"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260519230931_add_missing_enum_values/migration.sql
+++ b/prisma/migrations/20260519230931_add_missing_enum_values/migration.sql
@@ -1,0 +1,4 @@
+-- Add completed and reviewed to StarterTaskStatus enum
+-- Add revoked to InviteStatus enum
+-- SQLite does not enforce enum constraints at the database level;
+-- these values are validated by Prisma at the application layer only.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,63 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum ProjectStatus {
+  pending_review
+  needs_discussion
+  in_progress
+  needs_tasks
+  seeking_help
+  seeking_owner
+  on_hold
+  completed
+  archived
+}
+
+enum TaskStatus {
+  open
+  assigned
+  done
+}
+
+enum StarterTaskStatus {
+  open
+  assigned
+  submitted
+  approved
+  rejected
+  completed
+  reviewed
+}
+
+enum InterestStatus {
+  pending
+  accepted
+  declined
+  withdrawn
+}
+
+enum ApprovalStatus {
+  pending
+  under_review
+  approved
+  rejected
+}
+
+enum InviteStatus {
+  pending
+  accepted
+  expired
+  revoked
+}
+
+enum LocalGroupSuggestionStatus {
+  pending
+  accepted
+  merged
+  on_hold
+  declined
+}
+
 model AdminInvite {
   id           Int        @id @default(autoincrement())
   /// @zod.string.email({ message: "A valid email address is required" })
@@ -22,7 +79,7 @@ model AdminInvite {
   /// @zod.custom.omit([model])
   inviteToken  String     @unique(map: "sqlite_autoindex_admin_invites_1") @map("invite_token")
   invitedById  Int        @map("invited_by_id")
-  status       String     @default("pending") // TODO: enum — pending, accepted, expired
+  status       InviteStatus @default(pending)
   acceptedById Int?       @map("accepted_by_id")
   acceptedAt   DateTime?  @map("accepted_at")
   expiresAt    DateTime   @map("expires_at")
@@ -159,7 +216,7 @@ model ProjectInterest {
   projectId       Int       @map("project_id")
   interestType    String    @map("interest_type") // TODO: enum — want_to_contribute, want_to_own
   message         String?
-  status          String    @default("pending") // TODO: enum — pending, accepted, declined, withdrawn
+  status          InterestStatus @default(pending)
   responseMessage String?   @map("response_message")
   createdAt       DateTime? @default(now()) @map("created_at")
   respondedAt     DateTime? @map("responded_at")
@@ -192,7 +249,7 @@ model ProjectTask {
   title        String
   description  String?
   assignedToId Int?       @map("assigned_to_id")
-  status       String     @default("open") // TODO: enum — open, assigned, done
+  status       TaskStatus @default(open)
   createdById  Int        @map("created_by_id")
   completedAt          DateTime?  @map("completed_at")
   nudgeSentAt          DateTime?  @map("nudge_sent_at")
@@ -228,7 +285,7 @@ model Project {
   title                      String
   /// @zod.string.min(10, { message: "Description must be at least 10 characters" })
   description                String
-  status                     String            @default("pending_review") // TODO: enum — pending_review, seeking_owner, seeking_help, needs_tasks, in_progress, on_hold, completed, archived, needs_discussion
+  status                     ProjectStatus     @default(pending_review)
   ownerId                    Int?              @map("owner_id")
   proposedById               Int?              @map("proposed_by_id")
   isOrgProposed              Boolean?          @default(false) @map("is_org_proposed")
@@ -287,7 +344,7 @@ model LocalGroupSuggestion {
   name          String
   /// @zod.string.min(1, { message: "Country is required" })
   country       String
-  status        String     @default("pending") // TODO: enum — pending, accepted, merged, on_hold, declined
+  status        LocalGroupSuggestionStatus @default(pending)
   suggestedById Int        @map("suggested_by_id")
   reviewedById  Int?       @map("reviewed_by_id")
   reviewedAt    DateTime?  @map("reviewed_at")
@@ -383,7 +440,7 @@ model StarterTask {
   skillId             Int?       @map("skill_id")
   assignedToId        Int?       @map("assigned_to_id")
   assignedById        Int?       @map("assigned_by_id")
-  status              String     @default("open") // TODO: enum — open, assigned, submitted, approved, rejected
+  status              StarterTaskStatus @default(open)
   reviewRating        String?    @map("review_rating") // TODO: enum — excellent, good, needs_improvement
   reviewNotes         String?    @map("review_notes")
   feedbackToVolunteer String?    @map("feedback_to_volunteer")
@@ -450,7 +507,7 @@ model Volunteer {
   country                                 String?
   emailDigest                             String?              @default("none") @map("email_digest") // TODO: enum — none, daily, weekly
   localGroup                              String?              @map("local_group")
-  approvalStatus                          String               @default("PENDING") @map("approval_status") // TODO: enum — PENDING, REVIEWING, APPROVED, REJECTED
+  approvalStatus                          ApprovalStatus       @default(pending) @map("approval_status")
   applicationMessage                      String?              @map("application_message")
   applicationAdminNotes                   String?              @map("application_admin_notes")
   applicationApplicantNotes               String?              @map("application_applicant_notes")

--- a/scripts/new-migration.ts
+++ b/scripts/new-migration.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process'
 import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
+import { resolveDbUrl } from '../lib/db-url'
 
 const name = process.argv[2]
 if (!name) {
@@ -23,8 +24,9 @@ const dirPath = join(process.cwd(), 'prisma', 'migrations', dirName)
 
 mkdirSync(dirPath, { recursive: true })
 
+const dbUrl = resolveDbUrl()
 const sql = execSync(
-  'npx prisma migrate diff --from-schema-datasource prisma/schema.prisma --to-schema-datamodel prisma/schema.prisma --script',
+  `npx prisma migrate diff --from-url "${dbUrl}" --to-schema-datamodel prisma/schema.prisma --script`,
   { encoding: 'utf8' },
 )
 

--- a/scripts/post-generate.ts
+++ b/scripts/post-generate.ts
@@ -39,31 +39,3 @@ if (dirty) {
 } else {
   console.log(`${file}: no changes needed`)
 }
-
-// ─── Zod generated file patches ──────────────────────────────────────────────
-
-const zodFile = 'generated/zod/index.ts'
-let zodContent: string = readFileSync(zodFile, 'utf8')
-let zodDirty = false
-
-// Strip the ENUMS section (Prisma internals: ScalarFieldEnum, SortOrder, etc.)
-// These duplicate types already in generated/prisma and aren't useful for validation.
-const ENUMS_MARKER = '/////////////////////////////////////////\n// ENUMS\n'
-const MODELS_MARKER = '/////////////////////////////////////////\n// MODELS\n'
-const enumsStart = zodContent.indexOf(ENUMS_MARKER)
-const modelsStart = zodContent.indexOf(MODELS_MARKER)
-
-if (enumsStart !== -1 && modelsStart !== -1 && enumsStart < modelsStart) {
-  zodContent = zodContent.slice(0, enumsStart) + zodContent.slice(modelsStart)
-  zodDirty = true
-  console.log('  patched: strip Prisma internal enum schemas from zod output')
-} else {
-  console.log('  already applied or not found: zod enum strip')
-}
-
-if (zodDirty) {
-  writeFileSync(zodFile, zodContent)
-  console.log(`Wrote ${zodFile}`)
-} else {
-  console.log(`${zodFile}: no changes needed`)
-}

--- a/server/routers/admin/admins.ts
+++ b/server/routers/admin/admins.ts
@@ -151,7 +151,7 @@ export const adminAdminsRouter = {
         prisma.volunteer.update({ where: { id: volunteer.id }, data: { isAdmin: true } }),
         prisma.adminInvite.update({
           where: { id: invite.id },
-          data: { status: 'accepted', acceptedById: volunteer.id, acceptedAt: new Date() },
+          data: { status: InviteStatus.accepted, acceptedById: volunteer.id, acceptedAt: new Date() },
         }),
       ])
 

--- a/server/routers/admin/admins.ts
+++ b/server/routers/admin/admins.ts
@@ -6,6 +6,7 @@ import { sendAdminInviteEmail } from '@/lib/email'
 import { InviteAdminSchema } from '@/lib/schemas'
 import { adminProcedure, authedProcedure } from '../../procedures'
 import { env } from '@/lib/env'
+import { InviteStatus } from '@/generated/prisma/enums'
 
 const APP_URL = env.APP_URL
 const STUB_EMAIL = env.STUB_EMAIL
@@ -75,7 +76,7 @@ export const adminAdminsRouter = {
 
     const now = new Date()
     const pending = await prisma.adminInvite.findFirst({
-      where: { email, status: 'pending', expiresAt: { gt: now } },
+      where: { email, status: InviteStatus.pending, expiresAt: { gt: now } },
       select: { id: true },
     })
     if (pending) {
@@ -111,14 +112,14 @@ export const adminAdminsRouter = {
     .input(z.object({ id: z.number().int() }))
     .handler(async ({ input }) => {
       const invite = await prisma.adminInvite.findFirst({
-        where: { id: input.id, status: 'pending' },
+        where: { id: input.id, status: InviteStatus.pending },
         select: { id: true },
       })
       if (!invite) throw new ORPCError('NOT_FOUND', { message: 'Invite not found or already used' })
 
       await prisma.adminInvite.update({
         where: { id: input.id },
-        data: { status: 'revoked' },
+        data: { status: InviteStatus.revoked },
       })
       return { message: 'Invite revoked' }
     }),
@@ -129,7 +130,11 @@ export const adminAdminsRouter = {
       const volunteer = context.volunteer
       const now = new Date()
       const invite = await prisma.adminInvite.findFirst({
-        where: { inviteToken: input.inviteToken, status: 'pending', expiresAt: { gt: now } },
+        where: {
+          inviteToken: input.inviteToken,
+          status: InviteStatus.pending,
+          expiresAt: { gt: now },
+        },
       })
 
       if (!invite) {

--- a/server/routers/admin/admins.ts
+++ b/server/routers/admin/admins.ts
@@ -5,9 +5,10 @@ import { prisma } from '@/lib/prisma'
 import { sendAdminInviteEmail } from '@/lib/email'
 import { InviteAdminSchema } from '@/lib/schemas'
 import { adminProcedure, authedProcedure } from '../../procedures'
+import { env } from '@/lib/env'
 
-const APP_URL = process.env.APP_URL!
-const STUB_EMAIL = ['1', 'true', 'yes'].includes((process.env.STUB_EMAIL ?? '').toLowerCase())
+const APP_URL = env.APP_URL
+const STUB_EMAIL = env.STUB_EMAIL
 
 export const adminAdminsRouter = {
   list: adminProcedure.handler(async () => {

--- a/server/routers/admin/applications.ts
+++ b/server/routers/admin/applications.ts
@@ -6,6 +6,7 @@ import { sendApplicationApprovedEmail, sendApplicationRejectedEmail } from '@/li
 import { APPLICATION_ANONYMISATION_MS } from '@/lib/applications'
 import { ApplicationActionSchema } from '@/lib/schemas'
 import { superAdminProcedure } from '../../procedures'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 export const adminApplicationsRouter = {
   list: superAdminProcedure
@@ -23,19 +24,19 @@ export const adminApplicationsRouter = {
           case 'mine':
             return {
               deletedAt: null,
-              approvalStatus: { in: ['PENDING', 'UNDER_REVIEW'] },
+              approvalStatus: { in: [ApprovalStatus.pending, ApprovalStatus.under_review] },
               OR: [{ reviewerId: null }, { reviewerId: admin.id }],
             }
           case 'others':
             return {
               deletedAt: null,
-              approvalStatus: 'UNDER_REVIEW',
+              approvalStatus: ApprovalStatus.under_review,
               reviewerId: { not: admin.id },
             }
           case 'approved':
-            return { deletedAt: null, approvalStatus: 'APPROVED' }
+            return { deletedAt: null, approvalStatus: ApprovalStatus.approved }
           case 'rejected':
-            return { deletedAt: null, approvalStatus: 'REJECTED' }
+            return { deletedAt: null, approvalStatus: ApprovalStatus.rejected }
         }
       })()
 
@@ -234,15 +235,18 @@ export const adminApplicationsRouter = {
       }
 
       if (action === 'start_review') {
-        if (!['PENDING', 'UNDER_REVIEW'].includes(volunteer.approvalStatus)) {
+        if (
+          volunteer.approvalStatus !== ApprovalStatus.pending &&
+          volunteer.approvalStatus !== ApprovalStatus.under_review
+        ) {
           throw new ORPCError('BAD_REQUEST', {
-            message: `Cannot start review on a ${volunteer.approvalStatus.toLowerCase()} application`,
+            message: `Cannot start review on a ${volunteer.approvalStatus} application`,
           })
         }
         await prisma.volunteer.update({
           where: { id: input.id },
           data: {
-            approvalStatus: 'UNDER_REVIEW',
+            approvalStatus: ApprovalStatus.under_review,
             reviewerId: admin.id,
             ...(adminNotes !== undefined && { applicationAdminNotes: adminNotes }),
             ...(applicantNotes !== undefined && { applicationApplicantNotes: applicantNotes }),
@@ -251,13 +255,16 @@ export const adminApplicationsRouter = {
         return { message: 'Review started' }
       }
 
-      if (volunteer.approvalStatus !== 'PENDING' && volunteer.approvalStatus !== 'UNDER_REVIEW') {
+      if (
+        volunteer.approvalStatus !== ApprovalStatus.pending &&
+        volunteer.approvalStatus !== ApprovalStatus.under_review
+      ) {
         throw new ORPCError('BAD_REQUEST', {
-          message: `Application already ${volunteer.approvalStatus.toLowerCase()}`,
+          message: `Application already ${volunteer.approvalStatus}`,
         })
       }
 
-      const newStatus = action === 'approve' ? 'APPROVED' : 'REJECTED'
+      const newStatus = action === 'approve' ? ApprovalStatus.approved : ApprovalStatus.rejected
 
       await prisma.volunteer.update({
         where: { id: input.id },

--- a/server/routers/admin/emailPreview.ts
+++ b/server/routers/admin/emailPreview.ts
@@ -19,8 +19,9 @@ import {
   buildTaskSurrenderedAssigneeHtml,
 } from '@/lib/email'
 import { adminProcedure } from '../../procedures'
+import { env } from '@/lib/env'
 
-const APP_URL = process.env.APP_URL!
+const APP_URL = env.APP_URL
 
 const SAMPLE_PROJECTS = [
   {

--- a/server/routers/admin/interests.ts
+++ b/server/routers/admin/interests.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
 import { adminProcedure } from '../../procedures'
+import { InterestStatus } from '@/generated/prisma/enums'
 
 export const adminInterestsRouter = {
   list: adminProcedure
-    .input(z.object({ status: z.string().optional() }))
+    .input(z.object({ status: z.nativeEnum(InterestStatus).optional() }))
     .handler(async ({ input }) => {
       const interests = await prisma.projectInterest.findMany({
         where: input.status ? { status: input.status } : {},

--- a/server/routers/admin/localGroups.ts
+++ b/server/routers/admin/localGroups.ts
@@ -6,14 +6,13 @@ import { BASE_LOCATION_OPTIONS } from '@/lib/filter-options'
 import { createNotification } from '@/lib/project'
 import { LocalGroupBodySchema, ReviewSuggestionSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
+import { LocalGroupSuggestionStatus } from '@/generated/prisma/enums'
 
 const VALID_COUNTRIES = new Set(
   BASE_LOCATION_OPTIONS.filter((o) => o.value && o.value !== 'Remote' && o.value !== 'Other').map(
     (o) => o.value,
   ),
 )
-
-const VALID_STATUSES = ['pending', 'on_hold', 'accepted', 'declined']
 
 const NOTIFICATION_TITLES: Record<string, (name: string) => string> = {
   accepted: (n) => `Your local group suggestion "${n}" was accepted`,
@@ -79,12 +78,12 @@ export const adminLocalGroupsRouter = {
   }),
 
   listSuggestions: adminProcedure
-    .input(z.object({ status: z.string().optional().default('pending') }))
+    .input(
+      z.object({
+        status: z.enum(['pending', 'on_hold', 'accepted', 'declined'] as const).default('pending'),
+      }),
+    )
     .handler(async ({ input }) => {
-      if (!VALID_STATUSES.includes(input.status)) {
-        throw new ORPCError('BAD_REQUEST', { message: 'Invalid status' })
-      }
-
       const suggestions = await prisma.localGroupSuggestion.findMany({
         where: { status: input.status },
         orderBy: { createdAt: 'asc' },
@@ -142,10 +141,16 @@ export const adminLocalGroupsRouter = {
           prisma.localGroup.create({ data: { name, country } }),
           prisma.localGroupSuggestion.update({
             where: { id: input.id },
-            data: { ...reviewBase, status: 'accepted', name, country, adminNotes },
+            data: {
+              ...reviewBase,
+              status: LocalGroupSuggestionStatus.accepted,
+              name,
+              country,
+              adminNotes,
+            },
           }),
         ])
-        notificationAction = 'accepted'
+        notificationAction = LocalGroupSuggestionStatus.accepted
       } else if (action === 'merge') {
         const mergedIntoId = body.mergedIntoId ?? null
         if (!mergedIntoId) {
@@ -156,20 +161,25 @@ export const adminLocalGroupsRouter = {
 
         await prisma.localGroupSuggestion.update({
           where: { id: input.id },
-          data: { ...reviewBase, status: 'accepted', mergedIntoId, adminNotes },
+          data: {
+            ...reviewBase,
+            status: LocalGroupSuggestionStatus.accepted,
+            mergedIntoId,
+            adminNotes,
+          },
         })
         notificationAction = 'merge'
       } else if (action === 'on_hold') {
         await prisma.localGroupSuggestion.update({
           where: { id: input.id },
-          data: { ...reviewBase, status: 'on_hold', adminNotes },
+          data: { ...reviewBase, status: LocalGroupSuggestionStatus.on_hold, adminNotes },
         })
       } else if (action === 'decline') {
         await prisma.localGroupSuggestion.update({
           where: { id: input.id },
-          data: { ...reviewBase, status: 'declined', adminNotes },
+          data: { ...reviewBase, status: LocalGroupSuggestionStatus.declined, adminNotes },
         })
-        notificationAction = 'declined'
+        notificationAction = LocalGroupSuggestionStatus.declined
       }
 
       const titleFn = NOTIFICATION_TITLES[notificationAction]

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
-import { notifyVolunteer } from '@/lib/notify'
+import { notifyUser } from '@/lib/notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
 import { ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
@@ -92,7 +92,7 @@ export const adminProjectsRouter = {
         })
 
         if (project.proposedById) {
-          await notifyVolunteer(
+          await notifyUser(
             project.proposedById,
             'project_approved',
             `Your project '${project.title}' has been approved!`,
@@ -121,7 +121,7 @@ export const adminProjectsRouter = {
 
         if (project.proposedById) {
           const feedback = feedbackToProposer || 'A team lead wants to chat about your proposal.'
-          await notifyVolunteer(
+          await notifyUser(
             project.proposedById,
             'project_needs_discussion',
             `Let's discuss your project '${project.title}'`,

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -5,6 +5,7 @@ import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/projec
 import { notifyVolunteer } from '@/lib/notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
+import { ProjectStatus } from '@/generated/prisma/enums'
 
 export const adminProjectsRouter = {
   create: adminProcedure.input(AdminCreateProjectSchema).handler(async ({ input, context }) => {
@@ -213,7 +214,7 @@ export const adminProjectsRouter = {
 
   triage: adminProcedure.handler(async () => {
     const projects = await prisma.project.findMany({
-      where: { status: { in: ['pending_review', 'needs_discussion'] } },
+      where: { status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] } },
       include: projectInclude,
       orderBy: { createdAt: 'asc' },
     })

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -1,13 +1,8 @@
 import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
-import { sendProjectNotificationEmail } from '@/lib/email'
-import {
-  withProjectExtras,
-  projectInclude,
-  EnrichedProject,
-  createNotification,
-} from '@/lib/project'
+import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
+import { notifyVolunteer } from '@/lib/notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
 
@@ -96,29 +91,19 @@ export const adminProjectsRouter = {
         })
 
         if (project.proposedById) {
-          createNotification(
+          await notifyVolunteer(
             project.proposedById,
             'project_approved',
             `Your project '${project.title}' has been approved!`,
             "It's now visible to other volunteers.",
             `/projects/${input.id}`,
-          ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
-          const proposer = await prisma.volunteer.findFirst({
-            where: { id: project.proposedById },
-            select: { name: true, email: true },
-          })
-          if (proposer?.email) {
-            sendProjectNotificationEmail({
-              to: proposer.email,
-              name: proposer.name,
-              subject: `Your project '${project.title}' has been approved!`,
+            {
               message:
                 'Great news! Your project has been approved and is now visible to all volunteers.',
               projectTitle: project.title,
               projectId: input.id,
-            }).catch((e) => console.error('[EMAIL ERROR]', e))
-          }
+            },
+          )
         }
       } else {
         await prisma.project.update({
@@ -135,31 +120,20 @@ export const adminProjectsRouter = {
 
         if (project.proposedById) {
           const feedback = feedbackToProposer || 'A team lead wants to chat about your proposal.'
-          createNotification(
+          await notifyVolunteer(
             project.proposedById,
             'project_needs_discussion',
             `Let's discuss your project '${project.title}'`,
             feedback,
             `/projects/${input.id}`,
-          ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
-          const proposer = await prisma.volunteer.findFirst({
-            where: { id: project.proposedById },
-            select: { name: true, email: true },
-          })
-          if (proposer?.email) {
-            const extra = `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Feedback:</strong> ${feedback}</div>`
-            sendProjectNotificationEmail({
-              to: proposer.email,
-              name: proposer.name,
-              subject: `Let's discuss your project '${project.title}'`,
+            {
               message:
                 'A team lead would like to discuss your project proposal before it goes live.',
               projectTitle: project.title,
               projectId: input.id,
-              extraHtml: extra,
-            }).catch((e) => console.error('[EMAIL ERROR]', e))
-          }
+              extraHtml: `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Feedback:</strong> ${feedback}</div>`,
+            },
+          )
         }
       }
 

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -5,7 +5,7 @@ import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/projec
 import { notifyVolunteer } from '@/lib/notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
-import { ProjectStatus } from '@/generated/prisma/enums'
+import { ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 
 export const adminProjectsRouter = {
   create: adminProcedure.input(AdminCreateProjectSchema).handler(async ({ input, context }) => {
@@ -17,7 +17,7 @@ export const adminProjectsRouter = {
         data: {
           title: input.title,
           description: input.description,
-          status: tasks.length > 0 ? 'in_progress' : 'needs_tasks',
+          status: tasks.length > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks,
           ownerId: wantToOwn ? admin.id : null,
           proposedById: admin.id,
           isOrgProposed: true,
@@ -72,11 +72,11 @@ export const adminProjectsRouter = {
       if (status === 'approved') {
         const hasOwner = project.ownerId !== null
         const openTaskCount = await prisma.projectTask.count({
-          where: { projectId: input.id, status: { not: 'done' } },
+          where: { projectId: input.id, status: { not: TaskStatus.done } },
         })
-        const newStatus = openTaskCount > 0 ? 'in_progress' : 'needs_tasks'
-        const isSeekingHelp = targetStatus === 'seeking_help' || targetStatus === 'seeking_owner'
-        const isSeekingOwner = targetStatus === 'seeking_owner' && !hasOwner
+        const newStatus = openTaskCount > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks
+        const isSeekingHelp = targetStatus === ProjectStatus.seeking_help || targetStatus === ProjectStatus.seeking_owner
+        const isSeekingOwner = targetStatus === ProjectStatus.seeking_owner && !hasOwner
 
         await prisma.project.update({
           where: { id: input.id },
@@ -110,7 +110,7 @@ export const adminProjectsRouter = {
         await prisma.project.update({
           where: { id: input.id },
           data: {
-            status: 'needs_discussion',
+            status: ProjectStatus.needs_discussion,
             reviewNotes,
             feedbackToProposer,
             reviewedById: admin.id,
@@ -157,7 +157,7 @@ export const adminProjectsRouter = {
           outcome,
           outcomeNotes,
           completedAt: isCompleted ? new Date() : null,
-          ...(isCompleted ? { status: 'completed' } : {}),
+          ...(isCompleted ? { status: ProjectStatus.completed } : {}),
           updatedAt: new Date(),
         },
       })

--- a/server/routers/admin/stats.ts
+++ b/server/routers/admin/stats.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { adminProcedure } from '../../procedures'
+import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
 export const adminStatsRouter = {
   get: adminProcedure.handler(async () => {
@@ -20,14 +21,14 @@ export const adminStatsRouter = {
         WHERE deleted_at IS NULL AND created_at >= date('now', '-30 days')
       `,
       prisma.project.count(),
-      prisma.project.count({ where: { status: 'pending_review' } }),
+      prisma.project.count({ where: { status: ProjectStatus.pending_review } }),
       prisma.project.count({
         where: { OR: [{ isSeekingHelp: true }, { isSeekingOwner: true }] },
       }),
-      prisma.project.count({ where: { status: 'in_progress' } }),
-      prisma.project.count({ where: { status: 'completed' } }),
+      prisma.project.count({ where: { status: ProjectStatus.in_progress } }),
+      prisma.project.count({ where: { status: ProjectStatus.completed } }),
       prisma.projectInterest.count(),
-      prisma.projectInterest.count({ where: { status: 'pending' } }),
+      prisma.projectInterest.count({ where: { status: InterestStatus.pending } }),
     ])
 
     return {

--- a/server/routers/admin/triage.ts
+++ b/server/routers/admin/triage.ts
@@ -1,11 +1,12 @@
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
 import { adminProcedure } from '../../procedures'
+import { ProjectStatus } from '@/generated/prisma/enums'
 
 export const adminTriageRouter = {
   list: adminProcedure.handler(async () => {
     const projects = await prisma.project.findMany({
-      where: { status: { in: ['pending_review', 'needs_discussion'] } },
+      where: { status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] } },
       include: projectInclude,
       orderBy: { createdAt: 'asc' },
     })

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -26,7 +26,7 @@ import {
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
 import { env } from '@/lib/env'
-import { ApprovalStatus } from '@/generated/prisma/enums'
+import { ApprovalStatus, ProjectStatus } from '@/generated/prisma/enums'
 
 const STUB_EMAIL = env.STUB_EMAIL
 const GOOGLE_CLIENT_ID = env.GOOGLE_CLIENT_ID
@@ -70,7 +70,7 @@ async function sendAccountDeletionNotifications(deletedId: number, deletedName: 
     GROUP BY p.id
   `
   const ownedProjects = await prisma.project.findMany({
-    where: { ownerId: deletedId, status: { notIn: ['completed', 'archived'] } },
+    where: { ownerId: deletedId, status: { notIn: [ProjectStatus.completed, ProjectStatus.archived] } },
     select: { id: true, title: true },
   })
   if (!taskRows.length && !ownedProjects.length) return

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -26,6 +26,7 @@ import {
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
 import { env } from '@/lib/env'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 const STUB_EMAIL = env.STUB_EMAIL
 const GOOGLE_CLIENT_ID = env.GOOGLE_CLIENT_ID
@@ -285,7 +286,7 @@ export const authRouter = {
       if (!platformSettings.requireApplicationApproval) {
         await prisma.volunteer.update({
           where: { id: volunteer.id },
-          data: { approvalStatus: 'APPROVED' },
+          data: { approvalStatus: ApprovalStatus.approved },
         })
       }
       sendWelcomeAndConfirmEmail({ to: email, token: vt.token, name: input.name }).catch((e) =>
@@ -491,7 +492,7 @@ export const authRouter = {
       ])
 
       if (!volunteer.emailConfirmed && volunteer.email) {
-        if (volunteer.approvalStatus === 'APPROVED') {
+        if (volunteer.approvalStatus === ApprovalStatus.approved) {
           const settings = await prisma.platformSettings
             .upsert({
               where: { id: 1 },
@@ -508,7 +509,7 @@ export const authRouter = {
               console.error('[VERIFY_EMAIL]', e),
             )
           }
-        } else if (volunteer.approvalStatus === 'PENDING') {
+        } else if (volunteer.approvalStatus === ApprovalStatus.pending) {
           sendApplicationReceivedEmail({ to: volunteer.email, name: volunteer.name }).catch((e) =>
             console.error('[VERIFY_EMAIL]', e),
           )

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -25,10 +25,11 @@ import {
   ResetPasswordSchema,
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
+import { env } from '@/lib/env'
 
-const STUB_EMAIL = ['1', 'true', 'yes'].includes((process.env.STUB_EMAIL ?? '').toLowerCase())
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID
-const STUB_GOOGLE = !GOOGLE_CLIENT_ID && process.env.NODE_ENV !== 'production'
+const STUB_EMAIL = env.STUB_EMAIL
+const GOOGLE_CLIENT_ID = env.GOOGLE_CLIENT_ID
+const STUB_GOOGLE = !GOOGLE_CLIENT_ID && env.NODE_ENV !== 'production'
 
 async function verifyGoogleToken(credential: string) {
   if (!GOOGLE_CLIENT_ID) return null

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
 import { authedProcedure } from '../procedures'
+import { ProjectStatus } from '@/generated/prisma/enums'
 
 export const dashboardRouter = {
   get: authedProcedure.handler(async ({ context }) => {
@@ -50,7 +51,7 @@ export const dashboardRouter = {
                 OR: [
                   { isSeekingHelp: true },
                   { isSeekingOwner: true },
-                  { status: { in: ['seeking_owner', 'seeking_help'] } },
+                  { status: { in: [ProjectStatus.seeking_owner, ProjectStatus.seeking_help] } },
                 ],
                 ownerId: { not: volunteer.id },
                 id: { notIn: interestedProjectIds.length > 0 ? interestedProjectIds : [-1] },

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { Prisma } from '@/generated/prisma/client'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
-import { notifyVolunteer } from '@/lib/notify'
+import { notifyUser } from '@/lib/notify'
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
@@ -234,7 +234,7 @@ export const projectsRouter = {
     })
 
     for (const admin of admins) {
-      await notifyVolunteer(
+      await notifyUser(
         admin.id,
         'new_project_proposal',
         `New project proposal: ${project.title}`,
@@ -539,7 +539,7 @@ export const projectsRouter = {
         }
 
         for (const vid of notifyIds) {
-          await notifyVolunteer(
+          await notifyUser(
             vid,
             'project_status_changed',
             `'${project.title}' is now ${statusLabel}`,
@@ -630,7 +630,7 @@ export const projectsRouter = {
       const interestLabel = interestType === 'want_to_own' ? 'own / lead' : 'contribute to'
 
       if (project.ownerId) {
-        await notifyVolunteer(
+        await notifyUser(
           project.ownerId,
           'new_interest',
           `Someone's interested in '${project.title}'!`,
@@ -711,7 +711,7 @@ export const projectsRouter = {
         })
       }
 
-      await notifyVolunteer(
+      await notifyUser(
         interest.volunteerId,
         `interest_${input.status}`,
         `Your interest in '${project.title}' was ${input.status}`,
@@ -786,7 +786,7 @@ export const projectsRouter = {
         })
       }
 
-      await notifyVolunteer(
+      await notifyUser(
         input.volunteerId,
         'assigned_to_project',
         `You've been assigned to '${project.title}'`,

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -2,13 +2,8 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { Prisma } from '@/generated/prisma/client'
 import { prisma } from '@/lib/prisma'
-import { sendProjectNotificationEmail } from '@/lib/email'
-import {
-  withProjectExtras,
-  projectInclude,
-  EnrichedProject,
-  createNotification,
-} from '@/lib/project'
+import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
+import { notifyVolunteer } from '@/lib/notify'
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
@@ -236,24 +231,18 @@ export const projectsRouter = {
     })
 
     for (const admin of admins) {
-      createNotification(
+      await notifyVolunteer(
         admin.id,
         'new_project_proposal',
         `New project proposal: ${project.title}`,
         `Proposed by ${volunteer.name}`,
         '/admin/triage',
-      ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
-      if (admin.email) {
-        sendProjectNotificationEmail({
-          to: admin.email,
-          name: admin.name,
-          subject: `New project proposal: ${project.title}`,
+        {
           message: `<strong>${volunteer.name}</strong> has submitted a new project proposal: <strong>${project.title}</strong>. Please review it in the triage queue.`,
           projectTitle: project.title,
           projectId: project.id,
-        }).catch((e) => console.error('[EMAIL ERROR]', e))
-      }
+        },
+      )
     }
 
     return { id: project.id, message: 'Project submitted for review' }
@@ -536,28 +525,18 @@ export const projectsRouter = {
         }
 
         for (const vid of notifyIds) {
-          createNotification(
+          await notifyVolunteer(
             vid,
             'project_status_changed',
             `'${project.title}' is now ${statusLabel}`,
             `Status changed by ${volunteer.name}`,
             `/projects/${input.id}`,
-          ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
-          const vol = await prisma.volunteer.findFirst({
-            where: { id: vid, deletedAt: null },
-            select: { name: true, email: true },
-          })
-          if (vol?.email) {
-            sendProjectNotificationEmail({
-              to: vol.email,
-              name: vol.name,
-              subject: `'${project.title}' is now ${statusLabel}`,
+            {
               message: `The project <strong>${project.title}</strong> has been updated to <strong>${statusLabel}</strong>.`,
               projectTitle: project.title,
               projectId: input.id,
-            }).catch((e) => console.error('[EMAIL ERROR]', e))
-          }
+            },
+          )
         }
       }
 
@@ -631,32 +610,22 @@ export const projectsRouter = {
       const interestLabel = interestType === 'want_to_own' ? 'own / lead' : 'contribute to'
 
       if (project.ownerId) {
-        createNotification(
+        await notifyVolunteer(
           project.ownerId,
           'new_interest',
           `Someone's interested in '${project.title}'!`,
           `${volunteer.name} wants to ${interestLabel}`,
           `/projects/${input.projectId}`,
-        ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
-        const owner = await prisma.volunteer.findFirst({
-          where: { id: project.ownerId },
-          select: { name: true, email: true },
-        })
-        if (owner?.email) {
-          const extra = message
-            ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Their message:</strong> ${message}</div>`
-            : ''
-          sendProjectNotificationEmail({
-            to: owner.email,
-            name: owner.name,
+          {
             subject: `${volunteer.name} wants to ${interestLabel} '${project.title}'`,
             message: `<strong>${volunteer.name}</strong> has expressed interest in your project <strong>${project.title}</strong>.`,
             projectTitle: project.title,
             projectId: input.projectId,
-            extraHtml: extra,
-          }).catch((e) => console.error('[EMAIL ERROR]', e))
-        }
+            extraHtml: message
+              ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Their message:</strong> ${message}</div>`
+              : undefined,
+          },
+        )
       }
 
       return { message: 'Interest expressed successfully' }
@@ -705,14 +674,6 @@ export const projectsRouter = {
         },
       })
 
-      createNotification(
-        interest.volunteerId,
-        `interest_${input.status}`,
-        `Your interest in '${project.title}' was ${input.status}`,
-        input.responseMessage ?? null,
-        `/projects/${input.projectId}`,
-      ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
       if (input.status === 'accepted' && interest.interestType === 'want_to_own') {
         const openTaskCount = await prisma.projectTask.count({
           where: { projectId: input.projectId, status: { not: 'done' } },
@@ -726,24 +687,21 @@ export const projectsRouter = {
         })
       }
 
-      const vol = await prisma.volunteer.findFirst({
-        where: { id: interest.volunteerId, deletedAt: null },
-        select: { name: true, email: true },
-      })
-      if (vol?.email) {
-        const extra = input.responseMessage
-          ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Message:</strong> ${input.responseMessage}</div>`
-          : ''
-        sendProjectNotificationEmail({
-          to: vol.email,
-          name: vol.name,
-          subject: `Your interest in '${project.title}' was ${input.status}`,
+      await notifyVolunteer(
+        interest.volunteerId,
+        `interest_${input.status}`,
+        `Your interest in '${project.title}' was ${input.status}`,
+        input.responseMessage ?? null,
+        `/projects/${input.projectId}`,
+        {
           message: `The team has <strong>${input.status}</strong> your interest in the project <strong>${project.title}</strong>.`,
           projectTitle: project.title,
           projectId: input.projectId,
-          extraHtml: extra,
-        }).catch((e) => console.error('[EMAIL ERROR]', e))
-      }
+          extraHtml: input.responseMessage
+            ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Message:</strong> ${input.responseMessage}</div>`
+            : undefined,
+        },
+      )
 
       return { message: `Interest ${input.status}` }
     }),
@@ -804,31 +762,18 @@ export const projectsRouter = {
         })
       }
 
-      const assignee = await prisma.volunteer.findFirst({
-        where: { id: input.volunteerId },
-        select: { name: true, email: true },
-      })
-
-      if (assignee) {
-        createNotification(
-          input.volunteerId,
-          'assigned_to_project',
-          `You've been assigned to '${project.title}'`,
-          `Assigned by ${volunteer.name}`,
-          `/projects/${input.projectId}`,
-        ).catch((e) => console.error('[NOTIFY ERROR]', e))
-
-        if (assignee.email) {
-          sendProjectNotificationEmail({
-            to: assignee.email,
-            name: assignee.name,
-            subject: `You've been assigned to '${project.title}'`,
-            message: `<strong>${volunteer.name}</strong> has assigned you to the project <strong>${project.title}</strong>.`,
-            projectTitle: project.title,
-            projectId: input.projectId,
-          }).catch((e) => console.error('[EMAIL ERROR]', e))
-        }
-      }
+      await notifyVolunteer(
+        input.volunteerId,
+        'assigned_to_project',
+        `You've been assigned to '${project.title}'`,
+        `Assigned by ${volunteer.name}`,
+        `/projects/${input.projectId}`,
+        {
+          message: `<strong>${volunteer.name}</strong> has assigned you to the project <strong>${project.title}</strong>.`,
+          projectTitle: project.title,
+          projectId: input.projectId,
+        },
+      )
 
       return { message: 'Volunteer assigned to project' }
     }),

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -13,6 +13,7 @@ import {
   CreateProjectUpdateSchema,
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure, adminProcedure } from '../procedures'
+import { ApprovalStatus, InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 
 const STATUS_LABELS: Record<string, string> = {
   seeking_owner: 'Seeking Owner',
@@ -24,14 +25,14 @@ const STATUS_LABELS: Record<string, string> = {
   archived: 'Archived',
 }
 
-const OWNER_ALLOWED_STATUSES = new Set([
-  'seeking_owner',
-  'seeking_help',
-  'needs_tasks',
-  'in_progress',
-  'on_hold',
-  'completed',
-])
+const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
+  ProjectStatus.seeking_owner,
+  ProjectStatus.seeking_help,
+  ProjectStatus.needs_tasks,
+  ProjectStatus.in_progress,
+  ProjectStatus.on_hold,
+  ProjectStatus.completed,
+]
 
 export const projectsRouter = {
   list: publicProcedure
@@ -63,7 +64,7 @@ export const projectsRouter = {
       }
 
       const isPending = Boolean(
-        volunteer && volunteer.approvalStatus !== 'APPROVED' && !volunteer.isAdmin,
+        volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
       )
 
       let volunteerSkillIds: Set<number> | undefined
@@ -81,7 +82,9 @@ export const projectsRouter = {
         conditions.push(Prisma.sql`status = ${input.status}`)
       } else {
         conditions.push(
-          Prisma.raw(`status NOT IN ('archived', 'pending_review', 'needs_discussion')`),
+          Prisma.raw(
+            `status NOT IN ('${ProjectStatus.archived}', '${ProjectStatus.pending_review}', '${ProjectStatus.needs_discussion}')`,
+          ),
         )
       }
 
@@ -171,7 +174,7 @@ export const projectsRouter = {
 
   create: authedProcedure.input(CreateProjectSchema).handler(async ({ input, context }) => {
     const volunteer = context.volunteer
-    if (volunteer.approvalStatus !== 'APPROVED' && !volunteer.isAdmin) {
+    if (volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin) {
       throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
     }
 
@@ -187,7 +190,7 @@ export const projectsRouter = {
         data: {
           title: input.title,
           description: input.description,
-          status: 'pending_review',
+          status: ProjectStatus.pending_review,
           ownerId: wantToOwn ? volunteer.id : null,
           proposedById: volunteer.id,
           isOrgProposed: false,
@@ -253,7 +256,7 @@ export const projectsRouter = {
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
       const isPending = Boolean(
-        volunteer && volunteer.approvalStatus !== 'APPROVED' && !volunteer.isAdmin,
+        volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
       )
 
       const project = await prisma.project.findUnique({
@@ -263,7 +266,10 @@ export const projectsRouter = {
 
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      const hiddenStatuses = ['pending_review', 'needs_discussion']
+      const hiddenStatuses: ProjectStatus[] = [
+        ProjectStatus.pending_review,
+        ProjectStatus.needs_discussion,
+      ]
       if (hiddenStatuses.includes(project.status)) {
         if (!volunteer) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
         const isProposer = project.proposedById === volunteer.id
@@ -402,7 +408,11 @@ export const projectsRouter = {
         }
 
         const rawMyInterest = await prisma.projectInterest.findFirst({
-          where: { projectId: input.id, volunteerId: volunteer.id, status: { not: 'withdrawn' } },
+          where: {
+            projectId: input.id,
+            volunteerId: volunteer.id,
+            status: { not: InterestStatus.withdrawn },
+          },
         })
         myInterest = rawMyInterest
           ? {
@@ -445,9 +455,13 @@ export const projectsRouter = {
       const body = input
       const newStatus = body.status
 
-      if (newStatus && newStatus === 'in_progress' && project.status !== 'in_progress') {
+      if (
+        newStatus &&
+        newStatus === ProjectStatus.in_progress &&
+        project.status !== ProjectStatus.in_progress
+      ) {
         const openTaskCount = await prisma.projectTask.count({
-          where: { projectId: input.id, status: { not: 'done' } },
+          where: { projectId: input.id, status: { not: TaskStatus.done } },
         })
         if (openTaskCount === 0) {
           throw new ORPCError('BAD_REQUEST', {
@@ -479,7 +493,7 @@ export const projectsRouter = {
       if (newStatus !== undefined) {
         if (volunteer.isAdmin) {
           data.status = newStatus
-        } else if (isOwner && OWNER_ALLOWED_STATUSES.has(newStatus)) {
+        } else if (isOwner && OWNER_ALLOWED_STATUSES.includes(newStatus)) {
           data.status = newStatus
         }
       }
@@ -487,7 +501,7 @@ export const projectsRouter = {
       if (body.isSeekingHelp !== undefined) data.isSeekingHelp = body.isSeekingHelp
       if (body.isSeekingOwner !== undefined) data.isSeekingOwner = body.isSeekingOwner
 
-      if (data.status === 'completed' || data.status === 'archived') {
+      if (data.status === ProjectStatus.completed || data.status === ProjectStatus.archived) {
         if (data.isSeekingHelp === undefined) data.isSeekingHelp = false
         if (data.isSeekingOwner === undefined) data.isSeekingOwner = false
       }
@@ -517,7 +531,7 @@ export const projectsRouter = {
           notifyIds.add(project.proposedById)
 
         const accepted = await prisma.projectInterest.findMany({
-          where: { projectId: input.id, status: 'accepted' },
+          where: { projectId: input.id, status: InterestStatus.accepted },
           select: { volunteerId: true },
         })
         for (const row of accepted) {
@@ -558,18 +572,18 @@ export const projectsRouter = {
     .input(z.object({ projectId: z.number().int() }).merge(ProjectInterestBodySchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      if (volunteer.approvalStatus !== 'APPROVED' && !volunteer.isAdmin) {
+      if (volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
       }
 
       const project = await prisma.project.findFirst({
         where: {
           id: input.projectId,
-          status: { notIn: ['completed', 'archived'] },
+          status: { notIn: [ProjectStatus.completed, ProjectStatus.archived] },
           OR: [
             { isSeekingHelp: true },
             { isSeekingOwner: true },
-            { status: { in: ['seeking_owner', 'seeking_help'] } },
+            { status: { in: [ProjectStatus.seeking_owner, ProjectStatus.seeking_help] } },
           ],
         },
       })
@@ -582,7 +596,7 @@ export const projectsRouter = {
       const existing = await prisma.projectInterest.findFirst({
         where: { projectId: input.projectId, volunteerId: volunteer.id },
       })
-      if (existing && existing.status !== 'withdrawn') {
+      if (existing && existing.status !== InterestStatus.withdrawn) {
         throw new ORPCError('BAD_REQUEST', { message: "You've already expressed interest" })
       }
 
@@ -596,14 +610,20 @@ export const projectsRouter = {
           data: {
             interestType,
             message,
-            status: 'pending',
+            status: InterestStatus.pending,
             respondedAt: null,
             responseMessage: null,
           },
         })
       } else {
         await prisma.projectInterest.create({
-          data: { volunteerId: volunteer.id, projectId: input.projectId, interestType, message },
+          data: {
+            volunteerId: volunteer.id,
+            projectId: input.projectId,
+            interestType,
+            message,
+            status: InterestStatus.pending,
+          },
         })
       }
 
@@ -635,8 +655,12 @@ export const projectsRouter = {
     .input(z.object({ projectId: z.number().int() }))
     .handler(async ({ input, context }) => {
       const result = await prisma.projectInterest.updateMany({
-        where: { projectId: input.projectId, volunteerId: context.volunteer.id, status: 'pending' },
-        data: { status: 'withdrawn' },
+        where: {
+          projectId: input.projectId,
+          volunteerId: context.volunteer.id,
+          status: InterestStatus.pending,
+        },
+        data: { status: InterestStatus.withdrawn },
       })
       if (result.count === 0)
         throw new ORPCError('NOT_FOUND', { message: 'No pending interest found' })
@@ -648,7 +672,7 @@ export const projectsRouter = {
       z.object({
         projectId: z.number().int(),
         interestId: z.number().int(),
-        status: z.enum(['accepted', 'declined']),
+        status: z.enum([InterestStatus.accepted, InterestStatus.declined]),
         responseMessage: z.string().optional().nullable(),
       }),
     )
@@ -674,15 +698,15 @@ export const projectsRouter = {
         },
       })
 
-      if (input.status === 'accepted' && interest.interestType === 'want_to_own') {
+      if (input.status === InterestStatus.accepted && interest.interestType === 'want_to_own') {
         const openTaskCount = await prisma.projectTask.count({
-          where: { projectId: input.projectId, status: { not: 'done' } },
+          where: { projectId: input.projectId, status: { not: TaskStatus.done } },
         })
         await prisma.project.update({
           where: { id: input.projectId },
           data: {
             ownerId: interest.volunteerId,
-            status: openTaskCount > 0 ? 'in_progress' : 'needs_tasks',
+            status: openTaskCount > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks,
           },
         })
       }
@@ -729,17 +753,17 @@ export const projectsRouter = {
         where: {
           projectId: input.projectId,
           volunteerId: input.volunteerId,
-          status: { not: 'withdrawn' },
+          status: { not: InterestStatus.withdrawn },
         },
       })
 
       if (existing) {
-        if (existing.status === 'pending') {
+        if (existing.status === InterestStatus.pending) {
           await prisma.projectInterest.update({
             where: { id: existing.id },
-            data: { status: 'accepted', respondedAt: new Date() },
+            data: { status: InterestStatus.accepted, respondedAt: new Date() },
           })
-        } else if (existing.status === 'accepted') {
+        } else if (existing.status === InterestStatus.accepted) {
           return { message: 'This volunteer is already assigned to this project' }
         }
       } else {
@@ -749,7 +773,7 @@ export const projectsRouter = {
             projectId: input.projectId,
             interestType: input.interestType,
             message: 'Assigned by admin/owner',
-            status: 'accepted',
+            status: InterestStatus.accepted,
             respondedAt: new Date(),
           },
         })
@@ -783,7 +807,7 @@ export const projectsRouter = {
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
       const isPending = Boolean(
-        volunteer && volunteer.approvalStatus !== 'APPROVED' && !volunteer.isAdmin,
+        volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
       )
 
       const tasks = await prisma.projectTask.findMany({
@@ -839,10 +863,10 @@ export const projectsRouter = {
             createdById: volunteer.id,
           },
         })
-        if (project.status === 'needs_tasks') {
+        if (project.status === ProjectStatus.needs_tasks) {
           await tx.project.update({
             where: { id: input.projectId },
-            data: { status: 'in_progress' },
+            data: { status: ProjectStatus.in_progress },
           })
         }
         return newTask
@@ -877,8 +901,11 @@ export const projectsRouter = {
         const newStatus = input.data.status
         const newAssignedToId = input.data.assignedToId
         const isSelfClaim =
-          newStatus === 'assigned' && newAssignedToId === volunteer.id && task.status === 'open'
-        const isMarkingDone = newStatus === 'done' && isAssignee && task.status === 'assigned'
+          newStatus === TaskStatus.assigned &&
+          newAssignedToId === volunteer.id &&
+          task.status === TaskStatus.open
+        const isMarkingDone =
+          newStatus === TaskStatus.done && isAssignee && task.status === TaskStatus.assigned
         if (!isSelfClaim && !isMarkingDone) {
           throw new ORPCError('FORBIDDEN', { message: 'Not authorized to update this task' })
         }
@@ -889,8 +916,8 @@ export const projectsRouter = {
       if (input.data.description !== undefined) data.description = input.data.description
       if (input.data.status !== undefined) {
         data.status = input.data.status
-        if (input.data.status === 'done') data.completedAt = new Date()
-        else if (input.data.status === 'open') {
+        if (input.data.status === TaskStatus.done) data.completedAt = new Date()
+        else if (input.data.status === TaskStatus.open) {
           data.assignedToId = null
           data.completedAt = null
         }

--- a/server/routers/starterTasks.ts
+++ b/server/routers/starterTasks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
-import { createNotification } from '@/lib/project'
+import { notifyUser } from '@/lib/notify'
 import {
   CreateStarterTaskSchema,
   AssignStarterTaskSchema,
@@ -149,13 +149,13 @@ export const starterTasksRouter = {
         },
       })
 
-      createNotification(
+      notifyUser(
         input.volunteerId,
         'starter_task_assigned',
         `You've been assigned a starter task: ${task.title}`,
         task.description.slice(0, 200),
         '/dashboard',
-      ).catch((e) => console.error('[NOTIFY ERROR]', e))
+      )
 
       return { message: 'Task assigned' }
     }),
@@ -192,13 +192,13 @@ export const starterTasksRouter = {
       })
 
       if (task.assignedById) {
-        createNotification(
+        notifyUser(
           task.assignedById,
           'starter_task_submitted',
           `${volunteer.name} submitted: ${task.title}`,
           'Ready for review',
           '/admin/starter-tasks',
-        ).catch((e) => console.error('[NOTIFY ERROR]', e))
+        )
       }
 
       return { message: 'Task submitted for review' }
@@ -270,13 +270,13 @@ export const starterTasksRouter = {
           })
         }
 
-        createNotification(
+        notifyUser(
           task.assignedToId,
           'starter_task_reviewed',
           `Your starter task was reviewed: ${task.title}`,
           `Rating: ${input.reviewRating}${input.feedbackToVolunteer ? ` - ${input.feedbackToVolunteer}` : ''}`,
           '/dashboard',
-        ).catch((e) => console.error('[NOTIFY ERROR]', e))
+        )
       }
 
       return { message: 'Task reviewed' }

--- a/server/routers/starterTasks.ts
+++ b/server/routers/starterTasks.ts
@@ -8,10 +8,16 @@ import {
   ReviewStarterTaskSchema,
 } from '@/lib/schemas'
 import { adminProcedure, authedProcedure, publicProcedure } from '../procedures'
+import { StarterTaskStatus } from '@/generated/prisma/enums'
 
 export const starterTasksRouter = {
   list: adminProcedure
-    .input(z.object({ status: z.string().optional(), skillId: z.number().int().optional() }))
+    .input(
+      z.object({
+        status: z.nativeEnum(StarterTaskStatus).optional(),
+        skillId: z.number().int().optional(),
+      }),
+    )
     .handler(async ({ input }) => {
       const tasks = await prisma.starterTask.findMany({
         where: {
@@ -54,7 +60,7 @@ export const starterTasksRouter = {
 
   available: publicProcedure.handler(async () => {
     const tasks = await prisma.starterTask.findMany({
-      where: { status: 'open', assignedToId: null },
+      where: { status: StarterTaskStatus.open, assignedToId: null },
       include: {
         skill: { include: { category: true } },
         project: { select: { title: true } },
@@ -138,7 +144,7 @@ export const starterTasksRouter = {
         data: {
           assignedToId: input.volunteerId,
           assignedById: admin.id,
-          status: 'assigned',
+          status: StarterTaskStatus.assigned,
           updatedAt: new Date(),
         },
       })
@@ -160,7 +166,12 @@ export const starterTasksRouter = {
 
     await prisma.starterTask.update({
       where: { id: input.id },
-      data: { assignedToId: null, assignedById: null, status: 'open', updatedAt: new Date() },
+      data: {
+        assignedToId: null,
+        assignedById: null,
+        status: StarterTaskStatus.open,
+        updatedAt: new Date(),
+      },
     })
     return { message: 'Task unassigned' }
   }),
@@ -177,7 +188,7 @@ export const starterTasksRouter = {
 
       await prisma.starterTask.update({
         where: { id: input.id },
-        data: { status: 'submitted', updatedAt: new Date() },
+        data: { status: StarterTaskStatus.submitted, updatedAt: new Date() },
       })
 
       if (task.assignedById) {
@@ -199,12 +210,12 @@ export const starterTasksRouter = {
       const admin = context.volunteer
       const task = await prisma.starterTask.findUnique({ where: { id: input.id } })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
-      if (task.status !== 'submitted')
+      if (task.status !== StarterTaskStatus.submitted)
         throw new ORPCError('BAD_REQUEST', { message: 'Task is not in submitted status' })
 
       const newStatus = ['excellent', 'good'].includes(input.reviewRating)
-        ? 'completed'
-        : 'reviewed'
+        ? StarterTaskStatus.completed
+        : StarterTaskStatus.reviewed
 
       await prisma.starterTask.update({
         where: { id: input.id },

--- a/server/routers/version.ts
+++ b/server/routers/version.ts
@@ -1,8 +1,9 @@
 import { publicProcedure } from '../procedures'
+import { env } from '@/lib/env'
 
 export const versionRouter = {
   get: publicProcedure.handler(async () => ({
-    sha: process.env.RAILWAY_GIT_COMMIT_SHA ?? 'dev',
-    env: process.env.RAILWAY_ENVIRONMENT_NAME ?? null,
+    sha: env.RAILWAY_GIT_COMMIT_SHA ?? 'dev',
+    env: env.RAILWAY_ENVIRONMENT_NAME ?? null,
   })),
 }

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma'
 import { redactVolunteer } from '@/lib/auth'
 import { UpdateVolunteerSchema } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
-import { ApprovalStatus, StarterTaskStatus } from '@/generated/prisma/enums'
+import { ApprovalStatus, ProjectStatus, StarterTaskStatus } from '@/generated/prisma/enums'
 
 export const volunteersRouter = {
   list: publicProcedure
@@ -166,7 +166,7 @@ export const volunteersRouter = {
         prisma.project.findMany({
           where: {
             OR: [{ ownerId: input.id }, { proposedById: input.id }],
-            status: { notIn: ['archived', 'pending_review', 'needs_discussion'] },
+            status: { notIn: [ProjectStatus.archived, ProjectStatus.pending_review, ProjectStatus.needs_discussion] },
           },
           orderBy: { createdAt: 'desc' },
           select: {

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma'
 import { redactVolunteer } from '@/lib/auth'
 import { UpdateVolunteerSchema } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
+import { ApprovalStatus, StarterTaskStatus } from '@/generated/prisma/enums'
 
 export const volunteersRouter = {
   list: publicProcedure
@@ -21,7 +22,7 @@ export const volunteersRouter = {
       const currentVolunteer = context.volunteer
       if (
         currentVolunteer &&
-        currentVolunteer.approvalStatus !== 'APPROVED' &&
+        currentVolunteer.approvalStatus !== ApprovalStatus.approved &&
         !currentVolunteer.isAdmin
       ) {
         throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
@@ -107,7 +108,7 @@ export const volunteersRouter = {
       const currentVolunteer = context.volunteer
       if (
         currentVolunteer &&
-        currentVolunteer.approvalStatus !== 'APPROVED' &&
+        currentVolunteer.approvalStatus !== ApprovalStatus.approved &&
         !currentVolunteer.isAdmin
       ) {
         throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
@@ -182,7 +183,7 @@ export const volunteersRouter = {
         prisma.starterTask.findMany({
           where: {
             assignedToId: input.id,
-            status: { in: ['completed', 'reviewed'] },
+            status: { in: [StarterTaskStatus.completed, StarterTaskStatus.reviewed] },
             reviewRating: { in: ['excellent', 'good'] },
           },
           orderBy: { reviewedAt: 'desc' },


### PR DESCRIPTION
## Summary

- **#148** — Centralise all `process.env` reads into a typed `lib/env.ts` export; eliminates scattered env access and catches missing vars at startup
- **#89** — Extract `notifyVolunteer()` helper in `lib/notify.ts`; deduplicates the create-notification + send-email pattern repeated across 7 call sites
- **#111** — Extract `useRequireAuth`, `useRequireAdmin`, `useRequireSuperAdmin` hooks into `lib/hooks/auth.ts`; removes ~80 lines of duplicated `useEffect` redirect boilerplate from 24 pages
- **#82** — Replace hand-rolled `lib/constants.ts` status constants with Prisma enums; Prisma is now the single source of truth for all status types. Includes data migration to lowercase `ApprovalStatus` values for consistency. Fixes `scripts/new-migration.ts` path resolution bug.

Issues #112 and #113 are obsolete — the patterns they planned to address were already eliminated by the oRPC migration in #157.

Closes #148
Closes #89
Closes #111
Closes #82

## Test plan

- [x] `npm run check-all` passes (typecheck, lint, format, tests)
- [x] All 3 migrations applied cleanly against anonymised prod DB
- [x] Enum values in DB confirmed lowercase after `lowercase_approval_status` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)