### PR TITLE
feat: unify Project/ProjectTask/StarterTask into WorkItem model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Database
 *.db
 *.db-*
+db/
 backups/
 
 # Dependencies

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -28,7 +28,6 @@ interface StarterTask {
   status: string
   reviewRating: string | null
   reviewNotes: string | null
-  feedbackToVolunteer: string | null
   estimatedHours: number | null
   createdAt: string
 }
@@ -40,9 +39,8 @@ interface Volunteer {
 
 const STATUS_STYLES: Record<string, { background: string; color: string }> = {
   open: { background: '#FED7AA', color: '#9A3412' },
-  assigned: { background: '#DBEAFE', color: '#1E40AF' },
-  submitted: { background: '#FEF3C7', color: '#92400E' },
-  reviewed: { background: '#E9D5FF', color: '#6B21A8' },
+  in_progress: { background: '#DBEAFE', color: '#1E40AF' },
+  under_review: { background: '#FEF3C7', color: '#92400E' },
   completed: { background: '#D1FAE5', color: '#065F46' },
 }
 
@@ -77,9 +75,8 @@ export default function AdminStarterTasksPage() {
     [
       { value: '', label: 'All' },
       { value: 'open', label: 'Open' },
-      { value: 'assigned', label: 'Assigned' },
-      { value: 'submitted', label: 'Submitted (needs review)' },
-      { value: 'reviewed', label: 'Reviewed' },
+      { value: 'in_progress', label: 'In progress' },
+      { value: 'under_review', label: 'Submitted (needs review)' },
       { value: 'completed', label: 'Completed' },
     ],
     '',
@@ -119,7 +116,7 @@ export default function AdminStarterTasksPage() {
 
   const { data: tasksRaw = [], isPending: loadingData } = useQuery({
     ...orpc.starterTasks.list.queryOptions({
-      input: statusFilter ? { status: statusFilter } : {},
+      input: statusFilter ? { status: statusFilter as StarterTaskStatus } : {},
     }),
     enabled: !!user?.isAdmin,
   })
@@ -304,7 +301,7 @@ export default function AdminStarterTasksPage() {
     reviewTaskMutation.mutate({
       id: reviewModal.id,
       reviewRating,
-      feedbackToVolunteer: reviewFeedback || null,
+      comment: reviewFeedback || null,
       reviewNotes: reviewNotes || null,
     })
   }
@@ -453,19 +450,6 @@ export default function AdminStarterTasksPage() {
                         Notes: {task.reviewNotes}
                       </p>
                     )}
-                    {task.feedbackToVolunteer && (
-                      <div
-                        style={{
-                          background: 'var(--accent)',
-                          borderRadius: 'var(--radius)',
-                          padding: '10px 14px',
-                          marginBottom: 12,
-                          fontSize: '0.875rem',
-                        }}
-                      >
-                        <strong>Feedback to volunteer:</strong> {task.feedbackToVolunteer}
-                      </div>
-                    )}
 
                     <div
                       style={{
@@ -536,7 +520,7 @@ export default function AdminStarterTasksPage() {
                             Unassign
                           </Button>
                         )}
-                        {task.status === StarterTaskStatus.submitted && (
+                        {task.status === StarterTaskStatus.under_review && (
                           <Button
                             size="sm"
                             onClick={(e) => {

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -454,7 +454,7 @@ export default function AdminStarterTasksPage() {
 
                     <div className="mb-3">
                       <strong className="text-sm">Comments</strong>
-                      <CommentThread workItemId={task.id} canPost />
+                      <CommentThread workItemId={task.id} />
                     </div>
 
                     <div

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -5,6 +5,7 @@ import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
+import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
@@ -450,6 +451,11 @@ export default function AdminStarterTasksPage() {
                         Notes: {task.reviewNotes}
                       </p>
                     )}
+
+                    <div className="mb-3">
+                      <strong className="text-sm">Comments</strong>
+                      <CommentThread workItemId={task.id} canPost />
+                    </div>
 
                     <div
                       style={{

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -14,22 +14,14 @@ import {
   CARD_GRID_CLASSES,
 } from '@/components/ProjectCard'
 import Tabs from '@/components/Tabs'
+import CommentThread from '@/components/CommentThread'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
-interface ProjectComment {
-  id: number
-  authorId: number | null
-  authorName: string | null
-  content: string
-  createdAt: string | Date | null
-}
-
 interface Project extends CardProject {
   ownerId: number | null
   reviewNotes: string | null
-  comments: ProjectComment[]
 }
 
 interface ReviewModal {
@@ -47,7 +39,6 @@ export default function TriagePage() {
   const [decision, setDecision] = useState<'approved' | 'needs_discussion'>('approved')
   const [feedback, setFeedback] = useState('')
   const [reviewNotes, setReviewNotes] = useState('')
-  const [followUp, setFollowUp] = useState('')
 
   const {
     value: interestStatusFilter,
@@ -91,37 +82,6 @@ export default function TriagePage() {
     },
   })
 
-  const addCommentMutation = useMutation({
-    ...orpc.admin.triage.addComment.mutationOptions(),
-    onSuccess: (_, variables) => {
-      showToast('Message sent', 'success')
-      setFollowUp('')
-      void queryClient.invalidateQueries({ queryKey: orpc.admin.triage.list.key() })
-      setModal((m) =>
-        m && m.project.id === variables.projectId
-          ? {
-              project: {
-                ...m.project,
-                comments: [
-                  ...m.project.comments,
-                  {
-                    id: Date.now(),
-                    authorId: user?.id ?? null,
-                    authorName: user?.name ?? null,
-                    content: variables.content,
-                    createdAt: new Date(),
-                  },
-                ],
-              },
-            }
-          : m,
-      )
-    },
-    onError: (err: unknown) => {
-      showToast(err instanceof Error ? err.message : 'Failed to send message', 'error')
-    },
-  })
-
   const respondInterestMutation = useMutation({
     ...orpc.projects.respondToInterest.mutationOptions(),
     onError: (err: unknown) => {
@@ -136,7 +96,6 @@ export default function TriagePage() {
     setModal({ project })
     setDecision('approved')
     setFeedback('')
-    setFollowUp('')
     setReviewNotes(project.reviewNotes || '')
   }
 
@@ -410,54 +369,16 @@ export default function TriagePage() {
                 {modal.project.description}
               </p>
 
-              {modal.project.comments.length > 0 && (
-                <div className="mb-5">
-                  <label>Discussion</label>
-                  <ul className="list-none p-0 m-0 mt-2 max-h-50 overflow-auto">
-                    {modal.project.comments.map((c) => (
-                      <li key={c.id} className="py-2 border-b border-brand-border last:border-0">
-                        <p className="m-0 mb-1 text-sm whitespace-pre-wrap">{c.content}</p>
-                        <span className="text-xs text-text-light">
-                          {c.authorName ?? 'Unknown'} ·{' '}
-                          {c.createdAt ? new Date(c.createdAt).toLocaleDateString() : ''}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {modal.project.status === ProjectStatus.needs_discussion && (
-                <form
-                  className="mb-5"
-                  onSubmit={(e) => {
-                    e.preventDefault()
-                    if (!followUp.trim()) return
-                    addCommentMutation.mutate({
-                      projectId: modal.project.id,
-                      content: followUp.trim(),
-                    })
-                  }}
-                >
-                  <label htmlFor="follow-up">Add follow-up message</label>
-                  <textarea
-                    id="follow-up"
-                    aria-label="Add follow-up message"
-                    rows={2}
-                    value={followUp}
-                    onChange={(e) => setFollowUp(e.target.value)}
+              <div className="mb-5">
+                <label>Discussion</label>
+                <div className="mt-2 max-h-60 overflow-auto">
+                  <CommentThread
+                    workItemId={modal.project.id}
+                    canPost
                     placeholder="Reply to the proposer…"
-                    style={{ width: '100%' }}
                   />
-                  <Button
-                    type="submit"
-                    size="sm"
-                    disabled={!followUp.trim() || addCommentMutation.isPending}
-                  >
-                    {addCommentMutation.isPending ? 'Sending…' : 'Send message'}
-                  </Button>
-                </form>
-              )}
+                </div>
+              </div>
 
               <form onSubmit={submitReview}>
                 <div className="mb-5">

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -18,9 +18,18 @@ import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
+interface ProjectComment {
+  id: number
+  authorId: number | null
+  authorName: string | null
+  content: string
+  createdAt: string | Date | null
+}
+
 interface Project extends CardProject {
   ownerId: number | null
   reviewNotes: string | null
+  comments: ProjectComment[]
 }
 
 interface ReviewModal {
@@ -38,6 +47,7 @@ export default function TriagePage() {
   const [decision, setDecision] = useState<'approved' | 'needs_discussion'>('approved')
   const [feedback, setFeedback] = useState('')
   const [reviewNotes, setReviewNotes] = useState('')
+  const [followUp, setFollowUp] = useState('')
 
   const {
     value: interestStatusFilter,
@@ -81,6 +91,37 @@ export default function TriagePage() {
     },
   })
 
+  const addCommentMutation = useMutation({
+    ...orpc.admin.triage.addComment.mutationOptions(),
+    onSuccess: (_, variables) => {
+      showToast('Message sent', 'success')
+      setFollowUp('')
+      void queryClient.invalidateQueries({ queryKey: orpc.admin.triage.list.key() })
+      setModal((m) =>
+        m && m.project.id === variables.projectId
+          ? {
+              project: {
+                ...m.project,
+                comments: [
+                  ...m.project.comments,
+                  {
+                    id: Date.now(),
+                    authorId: user?.id ?? null,
+                    authorName: user?.name ?? null,
+                    content: variables.content,
+                    createdAt: new Date(),
+                  },
+                ],
+              },
+            }
+          : m,
+      )
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to send message', 'error')
+    },
+  })
+
   const respondInterestMutation = useMutation({
     ...orpc.projects.respondToInterest.mutationOptions(),
     onError: (err: unknown) => {
@@ -95,6 +136,7 @@ export default function TriagePage() {
     setModal({ project })
     setDecision('approved')
     setFeedback('')
+    setFollowUp('')
     setReviewNotes(project.reviewNotes || '')
   }
 
@@ -108,7 +150,7 @@ export default function TriagePage() {
     reviewMutation.mutate({
       id: modal.project.id,
       status: decision,
-      feedbackToProposer: decision === 'needs_discussion' ? feedback : null,
+      comment: decision === 'needs_discussion' ? feedback : null,
       reviewNotes: reviewNotes || null,
       targetStatus: modal.project.ownerId ? 'seeking_help' : 'seeking_owner',
     })
@@ -367,6 +409,55 @@ export default function TriagePage() {
               >
                 {modal.project.description}
               </p>
+
+              {modal.project.comments.length > 0 && (
+                <div className="mb-5">
+                  <label>Discussion</label>
+                  <ul className="list-none p-0 m-0 mt-2 max-h-50 overflow-auto">
+                    {modal.project.comments.map((c) => (
+                      <li key={c.id} className="py-2 border-b border-brand-border last:border-0">
+                        <p className="m-0 mb-1 text-sm whitespace-pre-wrap">{c.content}</p>
+                        <span className="text-xs text-text-light">
+                          {c.authorName ?? 'Unknown'} ·{' '}
+                          {c.createdAt ? new Date(c.createdAt).toLocaleDateString() : ''}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {modal.project.status === ProjectStatus.needs_discussion && (
+                <form
+                  className="mb-5"
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    if (!followUp.trim()) return
+                    addCommentMutation.mutate({
+                      projectId: modal.project.id,
+                      content: followUp.trim(),
+                    })
+                  }}
+                >
+                  <label htmlFor="follow-up">Add follow-up message</label>
+                  <textarea
+                    id="follow-up"
+                    aria-label="Add follow-up message"
+                    rows={2}
+                    value={followUp}
+                    onChange={(e) => setFollowUp(e.target.value)}
+                    placeholder="Reply to the proposer…"
+                    style={{ width: '100%' }}
+                  />
+                  <Button
+                    type="submit"
+                    size="sm"
+                    disabled={!followUp.trim() || addCommentMutation.isPending}
+                  >
+                    {addCommentMutation.isPending ? 'Sending…' : 'Send message'}
+                  </Button>
+                </form>
+              )}
 
               <form onSubmit={submitReview}>
                 <div className="mb-5">

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -374,7 +374,6 @@ export default function TriagePage() {
                 <div className="mt-2 max-h-60 overflow-auto">
                   <CommentThread
                     workItemId={modal.project.id}
-                    canPost
                     placeholder="Reply to the proposer…"
                   />
                 </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -225,7 +225,7 @@ export default function DashboardPage() {
                     )}
                     <div className="mt-3">
                       <strong className="text-sm">Comments</strong>
-                      <CommentThread workItemId={task.id} canPost />
+                      <CommentThread workItemId={task.id} />
                     </div>
                   </div>
                 )}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useRequireAuth } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
+import CommentThread from '@/components/CommentThread'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
@@ -222,6 +223,10 @@ export default function DashboardPage() {
                         Mark as Complete
                       </Button>
                     )}
+                    <div className="mt-3">
+                      <strong className="text-sm">Comments</strong>
+                      <CommentThread workItemId={task.id} canPost />
+                    </div>
                   </div>
                 )}
               </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -67,7 +67,8 @@ export default function DashboardPage() {
     enabled: !!user,
   })
   const starterTasks = starterTasksRaw.filter(
-    (t) => t.status === StarterTaskStatus.assigned || t.status === StarterTaskStatus.submitted,
+    (t) =>
+      t.status === StarterTaskStatus.in_progress || t.status === StarterTaskStatus.under_review,
   )
 
   const { data: notifications = [] } = useQuery({
@@ -212,12 +213,7 @@ export default function DashboardPage() {
                 {expandedTasks.has(task.id) && (
                   <div className="mt-3">
                     <p className="text-text-light text-sm mb-3">{task.description}</p>
-                    {task.feedbackToVolunteer && (
-                      <p className="text-sm mb-3">
-                        <strong>Feedback:</strong> {task.feedbackToVolunteer}
-                      </p>
-                    )}
-                    {task.status === StarterTaskStatus.assigned && (
+                    {task.status === StarterTaskStatus.in_progress && (
                       <Button
                         size="sm"
                         disabled={submitTaskMutation.isPending}

--- a/app/projects/[id]/edit/layout.tsx
+++ b/app/projects/[id]/edit/layout.tsx
@@ -7,8 +7,8 @@ export async function generateMetadata({
   params: Promise<{ id: string }>
 }): Promise<Metadata> {
   const { id } = await params
-  const project = await prisma.project.findUnique({
-    where: { id: parseInt(id) },
+  const project = await prisma.workItem.findFirst({
+    where: { id: parseInt(id), type: 'PROJECT' },
     select: { title: true },
   })
   return { title: project ? `Edit ${project.title}` : 'Edit Project' }

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -70,7 +70,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     setInitialized(true)
     const data = projectData
     setTitle(data.title)
-    setDescription(data.description)
+    setDescription(data.description ?? '')
     setCollaborationLink(data.collaborationLink ?? '')
     setSkills((data.skills ?? []).map((s) => ({ skillId: s.id, proficiencyLevel: 'intermediate' })))
     setProjectType(data.projectType ?? '')

--- a/app/projects/[id]/layout.tsx
+++ b/app/projects/[id]/layout.tsx
@@ -7,8 +7,8 @@ export async function generateMetadata({
   params: Promise<{ id: string }>
 }): Promise<Metadata> {
   const { id } = await params
-  const project = await prisma.project.findUnique({
-    where: { id: parseInt(id) },
+  const project = await prisma.workItem.findFirst({
+    where: { id: parseInt(id), type: 'PROJECT' },
     select: { title: true },
   })
   return { title: project?.title ?? 'Project' }

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
+import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
@@ -78,9 +79,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   // Interest section
   const [interestType, setInterestType] = useState('want_to_contribute')
   const [interestMessage, setInterestMessage] = useState('')
-
-  // Update section
-  const [updateContent, setUpdateContent] = useState('')
 
   // Transfer ownership
   const [transferTo, setTransferTo] = useState('')
@@ -259,16 +257,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       showToast(err instanceof Error ? err.message : 'Failed to record outcome', 'error'),
   })
 
-  const createUpdateMutation = useMutation({
-    ...orpc.projects.createUpdate.mutationOptions(),
-    onSuccess: () => {
-      setUpdateContent('')
-      void invalidateProject()
-    },
-    onError: (err: unknown) =>
-      showToast(err instanceof Error ? err.message : 'Failed to post update', 'error'),
-  })
-
   const reviewMutation = useMutation({
     ...orpc.admin.projects.review.mutationOptions(),
     onSuccess: (_data, variables) => {
@@ -432,15 +420,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       id: parseInt(idParam, 10),
       outcome: outcomeValue,
       outcomeNotes: outcomeNotes.trim() || null,
-    })
-  }
-
-  function handlePostUpdate(e: React.FormEvent) {
-    e.preventDefault()
-    if (!updateContent.trim()) return
-    createUpdateMutation.mutate({
-      projectId: parseInt(idParam, 10),
-      content: updateContent.trim(),
     })
   }
 
@@ -925,41 +904,12 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
         {/* Project Updates */}
         <div className={card}>
           <h2>Project Updates</h2>
-          {isOwnerOrAdmin && (
-            <form onSubmit={handlePostUpdate} className="mb-4">
-              <div className="mb-3">
-                <label htmlFor="add-update">Add Update</label>
-                <textarea
-                  id="add-update"
-                  aria-label="Add Update"
-                  rows={3}
-                  value={updateContent}
-                  onChange={(e) => setUpdateContent(e.target.value)}
-                  placeholder="Share a progress update…"
-                />
-              </div>
-              <Button
-                type="submit"
-                disabled={!updateContent.trim() || createUpdateMutation.isPending}
-              >
-                {createUpdateMutation.isPending ? 'Posting…' : 'Post Update'}
-              </Button>
-            </form>
-          )}
-          {project.comments.length === 0 ? (
-            <p className="text-text-light">No updates yet.</p>
-          ) : (
-            <ul className="list-none p-0 m-0">
-              {project.comments.map((u) => (
-                <li key={u.id} className="py-3 border-b border-brand-border last:border-0">
-                  <p className="m-0 mb-1">{u.content}</p>
-                  <span className="text-xs text-text-light">
-                    {u.authorName} · {u.createdAt ? new Date(u.createdAt).toLocaleDateString() : ''}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
+          <CommentThread
+            workItemId={project.id}
+            canPost={isOwnerOrAdmin || project.myInterest?.status === 'accepted'}
+            emptyText="No updates yet."
+            placeholder="Share a progress update…"
+          />
         </div>
       </main>
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -171,9 +171,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   const updateTaskMutation = useMutation({
     ...orpc.projects.updateTask.mutationOptions(),
     onSuccess: (_data, variables) => {
-      if (variables.data.status === TaskStatus.assigned) {
+      if (variables.data.status === TaskStatus.in_progress) {
         showToast('Task claimed!', 'success')
-      } else if (variables.data.status === TaskStatus.done) {
+      } else if (variables.data.status === TaskStatus.completed) {
         showToast('Task completed!', 'success')
       }
       void invalidateProject()
@@ -349,7 +349,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     updateTaskMutation.mutate({
       projectId: parseInt(idParam, 10),
       taskId,
-      data: { status: TaskStatus.assigned, assignedToId: user!.id },
+      data: { status: TaskStatus.in_progress, assigneeId: user!.id },
     })
   }
 
@@ -357,7 +357,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     updateTaskMutation.mutate({
       projectId: parseInt(idParam, 10),
       taskId,
-      data: { status: TaskStatus.done },
+      data: { status: TaskStatus.completed },
     })
   }
 
@@ -419,7 +419,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     e.preventDefault()
     if (!transferTo) return
     if (!window.confirm('Transfer ownership to this volunteer?')) return
-    updateProjectMutation.mutate({ id: parseInt(idParam, 10), ownerId: parseInt(transferTo, 10) })
+    updateProjectMutation.mutate({
+      id: parseInt(idParam, 10),
+      assigneeId: parseInt(transferTo, 10),
+    })
   }
 
   function handleRecordOutcome(e: React.FormEvent) {
@@ -446,7 +449,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     reviewMutation.mutate({
       id: parseInt(idParam, 10),
       status: reviewStatus as 'approved' | 'needs_discussion',
-      ...(reviewStatus === 'needs_discussion' ? { feedbackToProposer: reviewMessage } : {}),
+      ...(reviewStatus === 'needs_discussion' ? { comment: reviewMessage } : {}),
       targetStatus: 'seeking_owner',
     })
   }
@@ -475,12 +478,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
         <h1 role="heading" aria-level={1}>
           {project.title}
         </h1>
-
-        {project.feedbackToProposer && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEF3C7] text-[#92400E] border border-[#FCD34D] dark:bg-[#78350F] dark:text-[#FDE68A] dark:border-[#D97706]">
-            <strong>Feedback from review:</strong> {project.feedbackToProposer}
-          </div>
-        )}
 
         {/* Main project card */}
         <div className={card}>
@@ -690,10 +687,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                   className="flex items-center gap-2 py-2 border-b border-brand-border last:border-0 flex-wrap"
                 >
                   <span className="flex-1">{task.title}</span>
-                  {task.status === TaskStatus.done && (
+                  {task.status === TaskStatus.completed && (
                     <span className="text-success text-sm font-semibold">done</span>
                   )}
-                  {task.assignedToName && task.status !== TaskStatus.done && (
+                  {task.assignedToName && task.status !== TaskStatus.completed && (
                     <span className="text-text-light text-sm">→ {task.assignedToName}</span>
                   )}
                   {task.status === TaskStatus.open && (
@@ -701,7 +698,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                       Claim
                     </Button>
                   )}
-                  {task.status === TaskStatus.assigned && task.assignedToId === user.id && (
+                  {task.status === TaskStatus.in_progress && task.assignedToId === user.id && (
                     <Button variant="secondary" size="sm" onClick={() => handleDoneTask(task.id)}>
                       Done
                     </Button>
@@ -949,11 +946,11 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
               </Button>
             </form>
           )}
-          {project.updates.length === 0 ? (
+          {project.comments.length === 0 ? (
             <p className="text-text-light">No updates yet.</p>
           ) : (
             <ul className="list-none p-0 m-0">
-              {project.updates.map((u) => (
+              {project.comments.map((u) => (
                 <li key={u.id} className="py-3 border-b border-brand-border last:border-0">
                   <p className="m-0 mb-1">{u.content}</p>
                   <span className="text-xs text-text-light">

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -906,7 +906,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           <h2>Project Updates</h2>
           <CommentThread
             workItemId={project.id}
-            canPost={isOwnerOrAdmin || project.myInterest?.status === 'accepted'}
             emptyText="No updates yet."
             placeholder="Share a progress update…"
           />

--- a/app/starter-tasks/page.tsx
+++ b/app/starter-tasks/page.tsx
@@ -66,7 +66,7 @@ export default function StarterTasksPage() {
               <div className="flex justify-between items-start mb-2">
                 <h3 className="m-0">{task.title}</h3>
                 <span
-                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === StarterTaskStatus.completed || task.status === StarterTaskStatus.reviewed ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
+                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === StarterTaskStatus.completed ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
                 >
                   {STATUS_LABELS[task.status] ?? task.status}
                 </span>
@@ -88,16 +88,7 @@ export default function StarterTasksPage() {
 
               <p className="whitespace-pre-wrap mb-4">{task.description}</p>
 
-              {task.feedbackToVolunteer && (
-                <div className="bg-surface rounded-lg p-3 mb-3">
-                  <strong className="text-sm">Feedback:</strong>
-                  <p className="mt-1 italic text-text-light">
-                    &ldquo;{task.feedbackToVolunteer}&rdquo;
-                  </p>
-                </div>
-              )}
-
-              {task.status === StarterTaskStatus.assigned && (
+              {task.status === StarterTaskStatus.in_progress && (
                 <Button
                   onClick={() => submitMutation.mutate({ id: task.id })}
                   disabled={submitMutation.isPending && submitMutation.variables?.id === task.id}

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -175,11 +175,6 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                       {t.skillName}
                     </span>
                   )}
-                  {t.feedbackToVolunteer && (
-                    <p className="mt-2 text-sm text-text-light italic">
-                      &ldquo;{t.feedbackToVolunteer}&rdquo;
-                    </p>
-                  )}
                 </div>
               ))}
             </div>

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import Button from './Button'
+import { orpc } from '@/lib/orpc'
+import { useToast } from '@/lib/toast'
+
+interface CommentThreadProps {
+  workItemId: number
+  /** Show the post form (server still enforces authorization). */
+  canPost?: boolean
+  emptyText?: string
+  placeholder?: string
+}
+
+export default function CommentThread({
+  workItemId,
+  canPost = false,
+  emptyText = 'No comments yet.',
+  placeholder = 'Add a comment…',
+}: CommentThreadProps) {
+  const queryClient = useQueryClient()
+  const showToast = useToast()
+  const [content, setContent] = useState('')
+
+  const { data: comments = [], isPending } = useQuery({
+    ...orpc.workItemComments.list.queryOptions({ input: { workItemId } }),
+  })
+
+  const addMutation = useMutation({
+    ...orpc.workItemComments.add.mutationOptions(),
+    onSuccess: () => {
+      setContent('')
+      void queryClient.invalidateQueries({ queryKey: orpc.workItemComments.list.key() })
+      showToast('Comment added', 'success')
+    },
+    onError: (err: unknown) =>
+      showToast(err instanceof Error ? err.message : 'Failed to add comment', 'error'),
+  })
+
+  return (
+    <div>
+      {canPost && (
+        <form
+          className="mb-4"
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (!content.trim()) return
+            addMutation.mutate({ workItemId, content: content.trim() })
+          }}
+        >
+          <textarea
+            aria-label="Add a comment"
+            rows={3}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder={placeholder}
+          />
+          <Button type="submit" size="sm" disabled={!content.trim() || addMutation.isPending}>
+            {addMutation.isPending ? 'Posting…' : 'Post Comment'}
+          </Button>
+        </form>
+      )}
+
+      {isPending ? (
+        <p className="text-text-light">Loading comments…</p>
+      ) : comments.length === 0 ? (
+        <p className="text-text-light">{emptyText}</p>
+      ) : (
+        <ul className="list-none p-0 m-0">
+          {comments.map((c) => (
+            <li key={c.id} className="py-3 border-b border-brand-border last:border-0">
+              <p className="m-0 mb-1 whitespace-pre-wrap">{c.content}</p>
+              <span className="text-xs text-text-light">
+                {c.authorName ?? 'Unknown'} ·{' '}
+                {c.createdAt ? new Date(c.createdAt).toLocaleDateString() : ''}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -8,15 +8,12 @@ import { useToast } from '@/lib/toast'
 
 interface CommentThreadProps {
   workItemId: number
-  /** Show the post form (server still enforces authorization). */
-  canPost?: boolean
   emptyText?: string
   placeholder?: string
 }
 
 export default function CommentThread({
   workItemId,
-  canPost = false,
   emptyText = 'No comments yet.',
   placeholder = 'Add a comment…',
 }: CommentThreadProps) {
@@ -24,9 +21,11 @@ export default function CommentThread({
   const showToast = useToast()
   const [content, setContent] = useState('')
 
-  const { data: comments = [], isPending } = useQuery({
+  const { data, isPending } = useQuery({
     ...orpc.workItemComments.list.queryOptions({ input: { workItemId } }),
   })
+  const comments = data?.comments ?? []
+  const canPost = data?.canPost ?? false
 
   const addMutation = useMutation({
     ...orpc.workItemComments.add.mutationOptions(),

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -82,7 +82,7 @@ export async function confirmVolunteerEmail(baseUrl: string, token: string): Pro
   await api.auth.verifyEmail({ body: { token } })
 }
 
-function readAdminToken(baseUrl: string): string | null {
+export function readAdminToken(baseUrl: string): string | null {
   const parallelIndex = parallelIndexFromBaseUrl(baseUrl)
   const authFile = workerAuthFile(parallelIndex)
   try {

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -68,6 +68,52 @@ test.describe('Project Lifecycle', () => {
     })
   })
 
+  test('Discussion message and admin follow-up appear in the proposer comment thread', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const title = fake.projectTitle()
+    const feedbackText = fake.feedbackText()
+    const projectId = await proposeProject(baseUrl, volunteer.page, title, 'Discussion thread test')
+
+    // Admin sends it back for discussion with a message
+    await adminPage.goto(`${baseUrl}/admin/triage`)
+    const card = adminPage.locator('.card').filter({ hasText: title })
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    await card.getByRole('button', { name: 'Review' }).click()
+    await expect(adminPage.getByRole('heading', { name: 'Review Project' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await adminPage.getByRole('radio', { name: /Needs Discussion/ }).click()
+    await adminPage.getByLabel('Message to Proposer').fill(feedbackText)
+    await adminPage.getByRole('button', { name: 'Submit Review' }).click()
+    await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
+
+    // Proposer sees the review message as a comment on their project
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.getByText(feedbackText)).toBeVisible({ timeout: 10_000 })
+
+    // Admin posts a follow-up reply via the triage modal thread
+    const followUp = fake.feedbackText()
+    await adminPage.goto(`${baseUrl}/admin/triage`)
+    await adminPage.getByRole('tab', { name: 'Needs Discussion' }).click()
+    const discussionCard = adminPage.locator('.card').filter({ hasText: title })
+    await expect(discussionCard).toBeVisible({ timeout: 10_000 })
+    await discussionCard.getByRole('button', { name: 'Review' }).click()
+    await expect(adminPage.getByRole('heading', { name: 'Review Project' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await adminPage.getByLabel('Add a comment').fill(followUp)
+    await adminPage.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(getAlert(adminPage)).toContainText('Comment added', { timeout: 10_000 })
+
+    // Proposer sees the follow-up too
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByText(followUp)).toBeVisible({ timeout: 10_000 })
+  })
+
   test('Admin creates an org-proposed project', async ({ adminPage, baseUrl }) => {
     const title = fake.projectTitle()
     await adminCreateProject(baseUrl, adminPage, title, 'Admin-created project description')

--- a/e2e/tests/07-project-management-owner.spec.ts
+++ b/e2e/tests/07-project-management-owner.spec.ts
@@ -77,8 +77,8 @@ test.describe('Project Management (Owner)', () => {
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
     await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
 
-    await volunteer.page.getByLabel('Add Update').fill(updateText)
-    await volunteer.page.getByRole('button', { name: 'Post Update' }).click()
+    await volunteer.page.getByLabel('Add a comment').fill(updateText)
+    await volunteer.page.getByRole('button', { name: 'Post Comment' }).click()
 
     await expect(volunteer.page.getByText(updateText)).toBeVisible({ timeout: 10_000 })
   })

--- a/e2e/tests/07-project-management-owner.spec.ts
+++ b/e2e/tests/07-project-management-owner.spec.ts
@@ -82,4 +82,33 @@ test.describe('Project Management (Owner)', () => {
 
     await expect(volunteer.page.getByText(updateText)).toBeVisible({ timeout: 10_000 })
   })
+
+  test('Project owner and admin exchange comments in a back-and-forth thread', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupOwnedProject(baseUrl, adminPage, volunteer)
+    const adminComment = `admin update ${Date.now()}`
+    const volunteerReply = `volunteer reply ${Date.now()}`
+
+    // Admin posts the opening comment
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    await adminPage.getByLabel('Add a comment').fill(adminComment)
+    await adminPage.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(adminPage.getByText(adminComment)).toBeVisible({ timeout: 10_000 })
+
+    // Owner sees admin's comment and replies
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByText(adminComment)).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.getByLabel('Add a comment').fill(volunteerReply)
+    await volunteer.page.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(volunteer.page.getByText(volunteerReply)).toBeVisible({ timeout: 10_000 })
+
+    // Admin reloads and sees both messages in the thread
+    await adminPage.reload()
+    await expect(adminPage.getByText(adminComment)).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.getByText(volunteerReply)).toBeVisible({ timeout: 10_000 })
+  })
 })

--- a/e2e/tests/08-project-tasks.spec.ts
+++ b/e2e/tests/08-project-tasks.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect, getAlert } from '../fixtures'
+import { test, expect, getAlert, readAdminToken, confirmVolunteerEmail, approveVolunteer } from '../fixtures'
 import { fake } from '../fake'
 import { proposeProject, adminCreateProject, adminApproveProject } from '../actions/projects'
 import { Page } from '@playwright/test'
+import { createApiClient } from '../client'
 
 // Produces an in_progress project with one open task ("Initial task") proposed by the volunteer
 async function setupInProgressProject(
@@ -79,6 +80,85 @@ test.describe('Project Tasks', () => {
       timeout: 10_000,
     })
     await expect(volunteer.page.getByText('done', { exact: true })).toBeVisible({ timeout: 10_000 })
+  })
+
+  // TODO: project task cards have no comment thread UI — convert this to a UI test once
+  // a CommentThread is added to each task card on the project page (similar to how
+  // starter tasks show comments on the dashboard and admin pages).
+  test('Admin and task assignee exchange comments on a project task', async ({ baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    expect(adminToken).toBeTruthy()
+    const adminApi = createApiClient(baseUrl, adminToken)
+
+    // Admin creates a project and a task
+    const projectCreated = await adminApi.admin.projects.create({
+      body: { title: fake.projectTitle(), description: 'Task comment back-and-forth test' },
+    })
+    expect(projectCreated.status).toBe(200)
+    const projectId = (projectCreated.body as { id: number }).id
+
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: 'Back-and-forth comment task' },
+    })
+    expect(taskCreated.status).toBe(200)
+    const taskId = (taskCreated.body as { id: number }).id
+
+    // A fresh volunteer signs up, gets approved, and claims the task
+    const person = fake.person()
+    const api = createApiClient(baseUrl)
+    const signup = await api.auth.signup({
+      body: {
+        name: person.name,
+        email: person.email,
+        password: 'testpassword1',
+        consentMakeProfileVisibleInDirectory: true,
+        consentContactableByProjectOwners: true,
+      },
+    })
+    expect(signup.status).toBe(200)
+    const {
+      id: volId,
+      token: volToken,
+      emailVerificationToken,
+    } = signup.body as { id: number; token: string; emailVerificationToken?: string }
+    if (emailVerificationToken) await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+    await approveVolunteer(baseUrl, volId)
+    const volApi = createApiClient(baseUrl, volToken)
+
+    const claim = await volApi.projects.updateTask({
+      body: { projectId, taskId, data: { status: 'in_progress', assigneeId: volId } },
+    })
+    expect(claim.status).toBe(200)
+
+    // Admin posts the first comment on the task
+    const adminComment = `admin feedback ${Date.now()}`
+    const adminPost = await adminApi.workItemComments.add({
+      body: { workItemId: taskId, content: adminComment },
+    })
+    expect(adminPost.status).toBe(200)
+
+    // Volunteer reads the thread and sees admin's comment
+    const volList = await volApi.workItemComments.list({ body: { workItemId: taskId } })
+    expect(volList.status).toBe(200)
+    expect(
+      (volList.body as { comments: { content: string }[] }).comments.some(
+        (c) => c.content === adminComment,
+      ),
+    ).toBe(true)
+
+    // Volunteer replies
+    const volunteerReply = `volunteer reply ${Date.now()}`
+    const volPost = await volApi.workItemComments.add({
+      body: { workItemId: taskId, content: volunteerReply },
+    })
+    expect(volPost.status).toBe(200)
+
+    // Admin reads the thread and sees both messages
+    const adminList = await adminApi.workItemComments.list({ body: { workItemId: taskId } })
+    expect(adminList.status).toBe(200)
+    const finalComments = (adminList.body as { comments: { content: string }[] }).comments
+    expect(finalComments.some((c) => c.content === adminComment)).toBe(true)
+    expect(finalComments.some((c) => c.content === volunteerReply)).toBe(true)
   })
 
   test('Admin deletes a task', async ({ adminPage, baseUrl }) => {

--- a/e2e/tests/09-project-interests-assignment.spec.ts
+++ b/e2e/tests/09-project-interests-assignment.spec.ts
@@ -166,6 +166,62 @@ test.describe('Project Interests and Assignment', () => {
     ).toBeVisible({ timeout: 10_000 })
   })
 
+  test('Non-participant can read a project comment thread but cannot post', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const commentText = `admin note ${Date.now()}`
+
+    // Admin posts a comment on the project
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    await adminPage.getByLabel('Add a comment').fill(commentText)
+    await adminPage.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(adminPage.getByText(commentText)).toBeVisible({ timeout: 10_000 })
+
+    // A non-participant volunteer can read the thread but has no post form
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.getByText(commentText)).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.getByLabel('Add a comment')).not.toBeVisible({ timeout: 5_000 })
+    await expect(volunteer.page.getByRole('button', { name: 'Post Comment' })).not.toBeVisible({
+      timeout: 5_000,
+    })
+  })
+
+  test('Accepted helper can post in the project comment thread', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupSeekingProject(baseUrl, adminPage)
+
+    // Volunteer expresses interest to contribute
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByRole('button', { name: 'Express Interest' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await volunteer.page.getByRole('button', { name: 'Express Interest' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Interest expressed!', { timeout: 10_000 })
+
+    // Admin accepts the interest, making the volunteer a participant
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    const interestCard = adminPage.locator('.interest-card').filter({ hasText: volunteer.name })
+    await expect(interestCard).toBeVisible({ timeout: 10_000 })
+    await interestCard.getByRole('button', { name: 'Accept' }).click()
+    await expect(getAlert(adminPage)).toContainText('Interest accepted', { timeout: 10_000 })
+
+    // The accepted helper can now post a comment
+    const commentText = `helper comment ${Date.now()}`
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByLabel('Add a comment')).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.getByLabel('Add a comment').fill(commentText)
+    await volunteer.page.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(volunteer.page.getByText(commentText)).toBeVisible({ timeout: 10_000 })
+  })
+
   test('Volunteer cannot express interest in their own project', async ({
     adminPage,
     volunteer,

--- a/e2e/tests/09-project-interests-assignment.spec.ts
+++ b/e2e/tests/09-project-interests-assignment.spec.ts
@@ -222,6 +222,37 @@ test.describe('Project Interests and Assignment', () => {
     await expect(volunteer.page.getByText(commentText)).toBeVisible({ timeout: 10_000 })
   })
 
+  test('Posting a comment notifies other participants but not the author', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const title = fake.projectTitle()
+    const projectId = await adminCreateProject(baseUrl, adminPage, title, 'Notify-on-comment test')
+    // Admin is the creator; make the volunteer the owner (assignee)
+    await transferProjectOwnership(baseUrl, adminPage, projectId, volunteer.name)
+
+    // Owner (volunteer) posts a comment
+    const commentText = `owner update ${Date.now()}`
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByLabel('Add a comment')).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.getByLabel('Add a comment').fill(commentText)
+    await volunteer.page.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(volunteer.page.getByText(commentText)).toBeVisible({ timeout: 10_000 })
+
+    // Admin (the project creator) receives a comment notification
+    await goToDashboardNotifications(baseUrl, adminPage)
+    await expect(adminPage.locator('strong').filter({ hasText: 'New comment on' })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // The author (volunteer) is NOT notified of their own comment
+    await goToDashboardNotifications(baseUrl, volunteer.page)
+    await expect(
+      volunteer.page.locator('strong').filter({ hasText: 'New comment on' }),
+    ).not.toBeVisible({ timeout: 5_000 })
+  })
+
   test('Volunteer cannot express interest in their own project', async ({
     adminPage,
     volunteer,

--- a/e2e/tests/12-starter-tasks.spec.ts
+++ b/e2e/tests/12-starter-tasks.spec.ts
@@ -137,6 +137,24 @@ test.describe('Starter Tasks', () => {
     ).toBeVisible({ timeout: 10_000 })
   })
 
+  test('Admin posts a comment on a starter task and it appears in the thread', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const skill = await createSkill(baseUrl, adminPage)
+    const taskTitle = await createOpenStarterTask(baseUrl, adminPage, skill)
+    const commentText = `comment ${Date.now()}`
+
+    const taskCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
+    await expect(taskCard).toBeVisible({ timeout: 10_000 })
+    await taskCard.getByText(taskTitle, { exact: true }).click()
+
+    await taskCard.getByLabel('Add a comment').fill(commentText)
+    await taskCard.getByRole('button', { name: 'Post Comment' }).click()
+
+    await expect(taskCard.getByText(commentText)).toBeVisible({ timeout: 10_000 })
+  })
+
   test('Volunteer views their assigned starter task on the dashboard', async ({
     adminPage,
     volunteer,

--- a/e2e/tests/12-starter-tasks.spec.ts
+++ b/e2e/tests/12-starter-tasks.spec.ts
@@ -1,10 +1,18 @@
-import { test, expect, getAlert } from '../fixtures'
+import {
+  test,
+  expect,
+  getAlert,
+  readAdminToken,
+  approveVolunteer,
+  confirmVolunteerEmail,
+} from '../fixtures'
 import type { Page } from '@playwright/test'
 import { createSkill } from '../actions/skills'
 import type { SkillInfo } from '../actions/skills'
 import { goToDashboardNotifications } from '../actions/dashboard'
 import { fake } from '../fake'
 import { selectFilterDropdown } from '../actions/ui'
+import { createApiClient } from '../client'
 
 async function createOpenStarterTask(
   baseUrl: string,
@@ -363,5 +371,63 @@ test.describe('Starter Tasks', () => {
     await expect(deepLinkCard.getByRole('button', { name: 'Edit' })).toBeVisible({
       timeout: 10_000,
     })
+  })
+
+  test('Starter task comments are hidden from non-assignee volunteers', async ({ baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    expect(adminToken).toBeTruthy()
+    const adminApi = createApiClient(baseUrl, adminToken)
+
+    // Admin creates a starter task and posts a comment on it
+    const created = await adminApi.starterTasks.create({
+      body: { title: `Iso task ${Date.now()}`, description: 'isolation test description' },
+    })
+    expect(created.status).toBe(200)
+    const workItemId = (created.body as { id: number }).id
+
+    const commentText = `admin-only ${Date.now()}`
+    const added = await adminApi.workItemComments.add({
+      body: { workItemId, content: commentText },
+    })
+    expect(added.status).toBe(200)
+
+    // Admin can read the thread
+    const adminList = await adminApi.workItemComments.list({ body: { workItemId } })
+    expect(adminList.status).toBe(200)
+    expect(
+      (adminList.body as { comments: { content: string }[] }).comments.some(
+        (c) => c.content === commentText,
+      ),
+    ).toBe(true)
+
+    // A fresh, approved volunteer who is not the assignee
+    const api = createApiClient(baseUrl)
+    const person = fake.person()
+    const signup = await api.auth.signup({
+      body: {
+        name: person.name,
+        email: person.email,
+        password: 'testpassword1',
+        consentMakeProfileVisibleInDirectory: true,
+        consentContactableByProjectOwners: true,
+      },
+    })
+    expect(signup.status).toBe(200)
+    const {
+      id: volId,
+      token,
+      emailVerificationToken,
+    } = signup.body as { id: number; token: string; emailVerificationToken?: string }
+    if (emailVerificationToken) await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+    await approveVolunteer(baseUrl, volId)
+    const volApi = createApiClient(baseUrl, token)
+
+    // Cannot read the thread (work item not visible) or post to it
+    const volList = await volApi.workItemComments.list({ body: { workItemId } })
+    expect(volList.status).toBe(404)
+    const volAdd = await volApi.workItemComments.add({
+      body: { workItemId, content: 'should be rejected' },
+    })
+    expect(volAdd.status).toBe(403)
   })
 })

--- a/e2e/tests/12-starter-tasks.spec.ts
+++ b/e2e/tests/12-starter-tasks.spec.ts
@@ -128,7 +128,7 @@ test.describe('Starter Tasks', () => {
     await assignDialog.getByRole('button', { name: 'Assign' }).click()
 
     await expect(getAlert(adminPage)).toContainText('Task assigned!', { timeout: 10_000 })
-    await expect(taskCard.getByRole('status')).toContainText('assigned', { timeout: 10_000 })
+    await expect(taskCard.getByRole('status')).toContainText('in_progress', { timeout: 10_000 })
 
     // Volunteer receives an assignment notification
     await goToDashboardNotifications(baseUrl, volunteer.page)
@@ -155,7 +155,7 @@ test.describe('Starter Tasks', () => {
     const banner = volunteer.page.getByRole('region', { name: 'Starter Tasks' })
     const taskCard = banner.getByRole('article').filter({ hasText: taskTitle })
     await expect(taskCard).toBeVisible({ timeout: 10_000 })
-    await expect(taskCard.getByRole('status')).toContainText('assigned')
+    await expect(taskCard.getByRole('status')).toContainText('in_progress')
   })
 
   test('Volunteer submits a completed starter task; task status becomes submitted and admin receives a notification', async ({
@@ -185,13 +185,13 @@ test.describe('Starter Tasks', () => {
       timeout: 10_000,
     })
 
-    // Task status changes to 'submitted' on the admin page
+    // Task status changes to 'under_review' on the admin page
     await adminPage.goto(`${baseUrl}/admin/starter-tasks`)
     await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
       timeout: 10_000,
     })
     const adminTaskCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
-    await expect(adminTaskCard.getByRole('status')).toContainText('submitted', {
+    await expect(adminTaskCard.getByRole('status')).toContainText('under_review', {
       timeout: 10_000,
     })
 
@@ -249,7 +249,7 @@ test.describe('Starter Tasks', () => {
     await expect(adminPage.locator('#endorsements')).toContainText(skill.name, { timeout: 10_000 })
   })
 
-  test('Admin reviews a starter task as needs_improvement; task becomes reviewed and no skill endorsement is created', async ({
+  test('Admin reviews a starter task as needs_improvement; task becomes completed and no skill endorsement is created', async ({
     adminPage,
     volunteer,
     baseUrl,
@@ -281,8 +281,8 @@ test.describe('Starter Tasks', () => {
 
     await expect(getAlert(adminPage)).toContainText('Task reviewed!', { timeout: 10_000 })
 
-    // Task status becomes 'reviewed'
-    await expect(taskCard.getByRole('status')).toContainText('reviewed', { timeout: 10_000 })
+    // Task status becomes 'completed'
+    await expect(taskCard.getByRole('status')).toContainText('completed', { timeout: 10_000 })
 
     // Volunteer receives a feedback notification
     await goToDashboardNotifications(baseUrl, volunteer.page)

--- a/e2e/tests/12-starter-tasks.spec.ts
+++ b/e2e/tests/12-starter-tasks.spec.ts
@@ -163,6 +163,46 @@ test.describe('Starter Tasks', () => {
     await expect(taskCard.getByText(commentText)).toBeVisible({ timeout: 10_000 })
   })
 
+  test('Admin and assignee exchange comments on a starter task in a back-and-forth thread', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const skill = await createSkill(baseUrl, adminPage)
+    const taskTitle = await createOpenStarterTask(baseUrl, adminPage, skill)
+    await assignStarterTask(baseUrl, adminPage, taskTitle, volunteer.name)
+    const adminComment = `admin note ${Date.now()}`
+    const volunteerReply = `volunteer reply ${Date.now()}`
+
+    // Admin expands the task and posts the first comment
+    await adminPage.goto(`${baseUrl}/admin/starter-tasks`)
+    const adminCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
+    await expect(adminCard).toBeVisible({ timeout: 10_000 })
+    await adminCard.getByText(taskTitle, { exact: true }).click()
+    await adminCard.getByLabel('Add a comment').fill(adminComment)
+    await adminCard.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(adminCard.getByText(adminComment)).toBeVisible({ timeout: 10_000 })
+
+    // Assignee sees admin's comment on the dashboard and replies
+    await volunteer.page.goto(`${baseUrl}/dashboard`)
+    const volBanner = volunteer.page.getByRole('region', { name: 'Starter Tasks' })
+    const volCard = volBanner.getByRole('article').filter({ hasText: taskTitle })
+    await expect(volCard).toBeVisible({ timeout: 10_000 })
+    await volCard.getByText(taskTitle, { exact: true }).click()
+    await expect(volCard.getByText(adminComment)).toBeVisible({ timeout: 10_000 })
+    await volCard.getByLabel('Add a comment').fill(volunteerReply)
+    await volCard.getByRole('button', { name: 'Post Comment' }).click()
+    await expect(volCard.getByText(volunteerReply)).toBeVisible({ timeout: 10_000 })
+
+    // Admin reloads and sees both messages in the thread
+    await adminPage.goto(`${baseUrl}/admin/starter-tasks`)
+    const refreshedCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
+    await expect(refreshedCard).toBeVisible({ timeout: 10_000 })
+    await refreshedCard.getByText(taskTitle, { exact: true }).click()
+    await expect(refreshedCard.getByText(adminComment)).toBeVisible({ timeout: 10_000 })
+    await expect(refreshedCard.getByText(volunteerReply)).toBeVisible({ timeout: 10_000 })
+  })
+
   test('Volunteer views their assigned starter task on the dashboard', async ({
     adminPage,
     volunteer,

--- a/jobs/digest.ts
+++ b/jobs/digest.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { sendDigestEmail, isEmailConfigured } from '@/lib/email'
+import { WorkItemType } from '@/generated/prisma/enums'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -23,8 +24,9 @@ export async function runDigestJob(): Promise<Record<string, unknown>> {
   }
 
   const cutoff = daysAgo(14)
-  const rawProjects = await prisma.project.findMany({
+  const rawProjects = await prisma.workItem.findMany({
     where: {
+      type: WorkItemType.PROJECT,
       status: { notIn: ['archived', 'pending_review', 'needs_discussion'] },
       createdAt: { gte: cutoff },
     },

--- a/jobs/nudges.ts
+++ b/jobs/nudges.ts
@@ -6,6 +6,7 @@ import {
   sendTaskSurrenderedAssigneeEmail,
   isEmailConfigured,
 } from '@/lib/email'
+import { TaskStatus, WorkItemType } from '@/generated/prisma/enums'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -23,16 +24,17 @@ export async function runNudgesJob(): Promise<Record<string, unknown>> {
     return { skipped: true, reason: 'email not configured' }
   }
 
-  const assignedTasks = await prisma.projectTask.findMany({
+  const assignedTasks = await prisma.workItem.findMany({
     where: {
-      status: 'assigned',
-      assignedToId: { not: null },
+      type: WorkItemType.TASK,
+      status: TaskStatus.in_progress,
+      assigneeId: { not: null },
       updatedAt: { lt: daysAgo(14) },
-      assignedTo: { email: { not: null }, deletedAt: null },
+      assignee: { email: { not: null }, deletedAt: null },
     },
     include: {
-      assignedTo: true,
-      project: { include: { owner: true } },
+      assignee: true,
+      parent: { include: { assignee: true } },
     },
   })
 
@@ -41,18 +43,19 @@ export async function runNudgesJob(): Promise<Record<string, unknown>> {
   let surrendered = 0
 
   for (const task of assignedTasks) {
-    const assignee = task.assignedTo!
+    const assignee = task.assignee!
+    const project = task.parent!
     const updatedAt = task.updatedAt!
     const now = new Date()
     const daysInactive = Math.floor((now.getTime() - updatedAt.getTime()) / DAY_MS)
     const lastActivityDate = formatDate(updatedAt)
 
     if (daysInactive >= 28) {
-      await prisma.projectTask.update({
+      await prisma.workItem.update({
         where: { id: task.id },
         data: {
-          status: 'open',
-          assignedToId: null,
+          status: TaskStatus.open,
+          assigneeId: null,
           updatedAt: now,
           nudgeSentAt: null,
           finalWarningSentAt: null,
@@ -62,17 +65,17 @@ export async function runNudgesJob(): Promise<Record<string, unknown>> {
         to: assignee.email!,
         name: assignee.name,
         taskTitle: task.title,
-        projectTitle: task.project.title,
-        projectId: task.projectId,
+        projectTitle: project.title,
+        projectId: task.parentId!,
       })
-      if (task.project.owner?.email) {
+      if (project.assignee?.email) {
         await sendTaskSurrenderedOwnerEmail({
-          to: task.project.owner.email,
-          ownerName: task.project.owner.name,
+          to: project.assignee.email,
+          ownerName: project.assignee.name,
           volunteerName: assignee.name,
           taskTitle: task.title,
-          projectTitle: task.project.title,
-          projectId: task.projectId,
+          projectTitle: project.title,
+          projectId: task.parentId!,
         })
       }
       surrendered++
@@ -83,8 +86,8 @@ export async function runNudgesJob(): Promise<Record<string, unknown>> {
         to: assignee.email!,
         name: assignee.name,
         taskTitle: task.title,
-        projectTitle: task.project.title,
-        projectId: task.projectId,
+        projectTitle: project.title,
+        projectId: task.parentId!,
         taskId: task.id,
         daysInactive,
         activityPhrase: 'you last updated',
@@ -92,7 +95,7 @@ export async function runNudgesJob(): Promise<Record<string, unknown>> {
         surrenderDate,
       })
       if (sent) {
-        await prisma.projectTask.update({
+        await prisma.workItem.update({
           where: { id: task.id },
           data: { finalWarningSentAt: now },
         })
@@ -104,15 +107,15 @@ export async function runNudgesJob(): Promise<Record<string, unknown>> {
         to: assignee.email!,
         name: assignee.name,
         taskTitle: task.title,
-        projectTitle: task.project.title,
-        projectId: task.projectId,
+        projectTitle: project.title,
+        projectId: task.parentId!,
         taskId: task.id,
         daysInactive,
         activityPhrase: 'you last updated',
         lastActivityDate,
       })
       if (sent) {
-        await prisma.projectTask.update({ where: { id: task.id }, data: { nudgeSentAt: now } })
+        await prisma.workItem.update({ where: { id: task.id }, data: { nudgeSentAt: now } })
         nudgesSent++
         console.log(`[CRON NUDGES] Nudge sent for task ${task.id} (${daysInactive} days)`)
       }

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,6 +1,17 @@
 import { prisma } from './prisma'
-import { createNotification } from './project'
 import { sendProjectNotificationEmail } from './email'
+
+export async function createNotification(
+  volunteerId: number,
+  type: string,
+  title: string,
+  body?: string | null,
+  link?: string | null,
+) {
+  return prisma.notification.create({
+    data: { volunteerId, type, title, body: body ?? null, link: link ?? null },
+  })
+}
 
 export async function notifyUser(
   volunteerId: number,

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -6,12 +6,11 @@ import {
   BugReportSchema,
   LocalGroupSchema,
   LocalGroupSuggestionSchema,
-  ProjectSchema,
-  ProjectTaskSchema,
-  ProjectUpdateSchema,
   SkillSchema,
   SkillCategorySchema,
-  StarterTaskSchema,
+  TaskStatusSchema,
+  WorkItemSchema,
+  WorkItemCommentSchema,
   VolunteerSchema,
 } from '@/generated/zod'
 
@@ -94,7 +93,7 @@ const TaskInputSchema = z.object({
   description: z.string().optional(),
 })
 
-export const CreateProjectSchema = ProjectSchema.pick({
+const PROJECT_INPUT_FIELDS = {
   title: true,
   description: true,
   projectType: true,
@@ -106,22 +105,21 @@ export const CreateProjectSchema = ProjectSchema.pick({
   localGroup: true,
   isSeekingHelp: true,
   isSeekingOwner: true,
-}).extend({
+} as const
+
+export const CreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS).extend({
   tasks: z.array(TaskInputSchema).optional().default([]),
   wantToOwn: z.boolean().optional().default(false),
   skillIds: z.array(z.number().int()).optional().default([]),
   skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
 })
 
-export const UpdateProjectSchema = ProjectSchema.omit({
-  ...BASE_OMIT,
-  proposedById: true,
-  isOrgProposed: true,
-  reviewNotes: true,
-  reviewedById: true,
-  reviewedAt: true,
-  feedbackToProposer: true,
-  completedAt: true,
+export const UpdateProjectSchema = WorkItemSchema.pick({
+  ...PROJECT_INPUT_FIELDS,
+  status: true,
+  assigneeId: true,
+  outcome: true,
+  outcomeNotes: true,
 })
   .partial()
   .extend({
@@ -136,37 +134,26 @@ export const ProjectInterestBodySchema = z.object({
   message: z.string().optional().nullable(),
 })
 
-export const CreateProjectTaskSchema = ProjectTaskSchema.pick({
+export const CreateProjectTaskSchema = WorkItemSchema.pick({
   title: true,
   description: true,
 }).partial({ description: true })
 
-export const UpdateProjectTaskSchema = ProjectTaskSchema.pick({
+export const UpdateProjectTaskSchema = WorkItemSchema.pick({
   title: true,
   description: true,
-  status: true,
-  assignedToId: true,
-}).partial()
+  assigneeId: true,
+})
+  .partial()
+  .extend({ status: TaskStatusSchema.optional() })
 
-export const CreateProjectUpdateSchema = ProjectUpdateSchema.pick({
+export const CreateProjectUpdateSchema = WorkItemCommentSchema.pick({
   content: true,
 })
 
 // ─── Admin: projects ──────────────────────────────────────────────────────────
 
-export const AdminCreateProjectSchema = ProjectSchema.pick({
-  title: true,
-  description: true,
-  projectType: true,
-  estimatedDuration: true,
-  timeCommitmentHoursPerWeek: true,
-  urgency: true,
-  collaborationLink: true,
-  country: true,
-  localGroup: true,
-  isSeekingHelp: true,
-  isSeekingOwner: true,
-}).extend({
+export const AdminCreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS).extend({
   tasks: z.array(TaskInputSchema).optional().default([]),
   wantToOwn: z.boolean().optional().default(false),
   skillIds: z.array(z.number().int()).optional().default([]),
@@ -178,7 +165,7 @@ export const ReviewProjectSchema = z.object({
     error: 'Status must be approved or needs_discussion',
   }),
   reviewNotes: z.string().optional().nullable(),
-  feedbackToProposer: z.string().optional().nullable(),
+  comment: z.string().optional().nullable(),
   targetStatus: z
     .enum([ProjectStatus.seeking_help, ProjectStatus.seeking_owner])
     .optional()
@@ -207,8 +194,8 @@ export const ApplicationActionSchema = z.object({
 export const CreateNoteSchema = AdminNoteSchema.pick({
   content: true,
   category: true,
-  relatedProjectId: true,
-}).partial({ category: true, relatedProjectId: true })
+  relatedWorkItemId: true,
+}).partial({ category: true, relatedWorkItemId: true })
 
 export const UpdateNoteSchema = AdminNoteSchema.pick({
   content: true,
@@ -287,13 +274,13 @@ export const PlatformSettingsSchema = z.object({
 
 // ─── Starter tasks ────────────────────────────────────────────────────────────
 
-export const CreateStarterTaskSchema = StarterTaskSchema.pick({
+export const CreateStarterTaskSchema = WorkItemSchema.pick({
   title: true,
   description: true,
   skillId: true,
-  projectId: true,
+  contextProjectId: true,
   estimatedHours: true,
-}).partial({ skillId: true, projectId: true, estimatedHours: true })
+}).partial({ skillId: true, contextProjectId: true, estimatedHours: true })
 
 export const AssignStarterTaskSchema = z.object({
   volunteerId: z.number().int({ message: 'volunteerId is required' }),
@@ -304,7 +291,7 @@ export const ReviewStarterTaskSchema = z.object({
     error: 'reviewRating must be excellent, good, or needs_improvement',
   }),
   reviewNotes: z.string().optional().nullable(),
-  feedbackToVolunteer: z.string().optional().nullable(),
+  comment: z.string().optional().nullable(),
 })
 
 // ─── Bug reports ──────────────────────────────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,7 +32,7 @@ import type {
   LocalGroupSuggestionBodySchema,
   UpdateVolunteerSchema,
 } from './schemas'
-import type { withProjectExtras } from './project'
+import type { withProjectExtras } from './work-item'
 import type { redactVolunteer } from './auth'
 
 // ─── Request body types ───────────────────────────────────────────────────────

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -1,9 +1,8 @@
 import { Prisma } from '@/generated/prisma/client'
 import { calculateMatchScore } from './matching'
-import { prisma } from './prisma'
 import { InterestStatus } from '@/generated/prisma/enums'
 
-export type ProjectSkillWithRelations = {
+export type WorkItemSkillWithRelations = {
   skillId: number
   isRequired: boolean | null
   skill: {
@@ -20,10 +19,11 @@ export type ProjectSkillWithRelations = {
 export type EnrichedProject = {
   id: number
   title: string
-  description: string
+  description: string | null
   status: string
-  ownerId: number | null
-  proposedById: number | null
+  assigneeId: number | null
+  creatorId: number | null
+  stakeholderId: number | null
   isOrgProposed: boolean | null
   projectType: string | null
   estimatedDuration: string | null
@@ -32,7 +32,6 @@ export type EnrichedProject = {
   reviewNotes: string | null
   reviewedById: number | null
   reviewedAt: Date | null
-  feedbackToProposer: string | null
   collaborationLink: string | null
   outcome: string | null
   outcomeNotes: string | null
@@ -43,11 +42,15 @@ export type EnrichedProject = {
   isSeekingHelp: boolean | null
   isSeekingOwner: boolean | null
   localGroup: string | null
-  skills: ProjectSkillWithRelations[]
-  owner: { id: number; name: string } | null
-  proposedBy: { id: number; name: string } | null
+  skills: WorkItemSkillWithRelations[]
+  assignee: { id: number; name: string } | null
+  creator: { id: number; name: string } | null
   _count: { interests: number }
 }
+
+// The serialized view keeps the public field names `owner`/`proposedBy`
+// (mapped from the WorkItem `assignee`/`creator` columns) so the ProjectCard
+// contract and all consuming pages stay stable.
 
 export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<number>) {
   const matchInput = p.skills.map((ps) => ({ id: ps.skillId, isRequired: ps.isRequired }))
@@ -59,8 +62,9 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
     title: p.title,
     description: p.description,
     status: p.status,
-    ownerId: p.ownerId,
-    proposedById: p.proposedById,
+    ownerId: p.assigneeId,
+    proposedById: p.creatorId,
+    stakeholderId: p.stakeholderId,
     isOrgProposed: p.isOrgProposed,
     projectType: p.projectType,
     estimatedDuration: p.estimatedDuration,
@@ -69,7 +73,6 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
     reviewNotes: p.reviewNotes,
     reviewedById: p.reviewedById,
     reviewedAt: p.reviewedAt,
-    feedbackToProposer: p.feedbackToProposer,
     collaborationLink: p.collaborationLink,
     outcome: p.outcome,
     outcomeNotes: p.outcomeNotes,
@@ -90,8 +93,8 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
       categoryName: ps.skill.category.name,
       isRequired: ps.isRequired,
     })),
-    owner: p.owner,
-    proposedBy: p.proposedBy,
+    owner: p.assignee,
+    proposedBy: p.creator,
     pendingInterestCount: p._count.interests,
     ...(match !== undefined ? { match } : {}),
   }
@@ -106,19 +109,7 @@ export const projectInclude = {
       { skill: { sortOrder: Prisma.SortOrder.asc } },
     ],
   },
-  owner: { select: { id: true, name: true } },
-  proposedBy: { select: { id: true, name: true } },
+  assignee: { select: { id: true, name: true } },
+  creator: { select: { id: true, name: true } },
   _count: { select: { interests: { where: { status: InterestStatus.pending } } } },
-} satisfies Prisma.ProjectInclude
-
-export async function createNotification(
-  volunteerId: number,
-  type: string,
-  title: string,
-  body?: string | null,
-  link?: string | null,
-) {
-  return prisma.notification.create({
-    data: { volunteerId, type, title, body: body ?? null, link: link ?? null },
-  })
-}
+} satisfies Prisma.WorkItemInclude

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -1,6 +1,79 @@
 import { Prisma } from '@/generated/prisma/client'
 import { calculateMatchScore } from './matching'
-import { InterestStatus } from '@/generated/prisma/enums'
+import { InterestStatus, ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
+
+// ── Comment access ────────────────────────────────────────────────────────────
+// Reading a work item's comment thread is gated identically to viewing the work
+// item itself. Posting is restricted to participants.
+
+export type WorkItemForAccess = {
+  type: string
+  status: string
+  creatorId: number | null
+  assigneeId: number | null
+}
+
+export type CommentViewer = { id: number; isAdmin: boolean } | null
+
+const PROJECT_HIDDEN_STATUSES: string[] = [
+  ProjectStatus.pending_review,
+  ProjectStatus.needs_discussion,
+]
+
+/**
+ * Can `viewer` see this work item (and therefore its comment thread)?
+ * For TASK, pass the parent PROJECT — task visibility follows the project.
+ */
+export function canViewWorkItem(
+  item: WorkItemForAccess,
+  viewer: CommentViewer,
+  parent?: WorkItemForAccess | null,
+): boolean {
+  switch (item.type) {
+    case WorkItemType.PROJECT:
+      if (!PROJECT_HIDDEN_STATUSES.includes(item.status)) return true
+      return Boolean(viewer && (viewer.isAdmin || viewer.id === item.creatorId))
+    case WorkItemType.TASK:
+      return parent ? canViewWorkItem(parent, viewer) : Boolean(viewer?.isAdmin)
+    case WorkItemType.STARTER_TASK:
+      return Boolean(
+        viewer && (viewer.isAdmin || viewer.id === item.assigneeId || viewer.id === item.creatorId),
+      )
+    default:
+      return Boolean(viewer?.isAdmin)
+  }
+}
+
+/**
+ * Can `viewer` post a comment? Participants only.
+ * `isAcceptedHelper` = viewer has an accepted WorkItemInterest on the project
+ * (for TASK, on the parent project). The caller resolves it.
+ */
+export function canPostComment(
+  item: WorkItemForAccess,
+  viewer: { id: number; isAdmin: boolean },
+  opts: { parent?: WorkItemForAccess | null; isAcceptedHelper?: boolean } = {},
+): boolean {
+  if (viewer.isAdmin) return true
+  switch (item.type) {
+    case WorkItemType.PROJECT:
+      return (
+        viewer.id === item.creatorId ||
+        viewer.id === item.assigneeId ||
+        Boolean(opts.isAcceptedHelper)
+      )
+    case WorkItemType.TASK:
+      return (
+        viewer.id === item.assigneeId ||
+        viewer.id === (opts.parent?.assigneeId ?? null) ||
+        Boolean(opts.isAcceptedHelper)
+      )
+    case WorkItemType.STARTER_TASK:
+      return viewer.id === item.assigneeId
+    default:
+      return false
+  }
+}
 
 export type WorkItemSkillWithRelations = {
   skillId: number

--- a/prisma/migrations/20260520150004_unified_work_items/migration.sql
+++ b/prisma/migrations/20260520150004_unified_work_items/migration.sql
@@ -1,0 +1,250 @@
+-- Unified WorkItem model: collapses projects + project_tasks + starter_tasks into
+-- a single work_items table, with project_updates + feedback fields folded into a
+-- work_item_comments thread. Data is backfilled before old tables are dropped.
+--
+-- ID strategy (so existing /projects/:id links keep resolving):
+--   PROJECT      → original id
+--   TASK         → original id + 1,000,000
+--   STARTER_TASK → original id + 2,000,000
+--
+-- defer_foreign_keys=ON defers FK validation to COMMIT (works inside the
+-- transaction Prisma wraps the migration in, unlike PRAGMA foreign_keys).
+PRAGMA defer_foreign_keys=ON;
+
+-- ─── New tables ─────────────────────────────────────────────────────────────
+CREATE TABLE "work_items" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "parent_id" INTEGER,
+    "context_project_id" INTEGER,
+    "creator_id" INTEGER,
+    "assignee_id" INTEGER,
+    "stakeholder_id" INTEGER,
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "review_notes" TEXT,
+    "review_rating" TEXT,
+    "project_type" TEXT,
+    "urgency" TEXT DEFAULT 'medium',
+    "estimated_duration" TEXT,
+    "time_commitment_hours_per_week" INTEGER,
+    "collaboration_link" TEXT,
+    "is_org_proposed" BOOLEAN DEFAULT false,
+    "is_seeking_help" BOOLEAN DEFAULT false,
+    "is_seeking_owner" BOOLEAN DEFAULT false,
+    "outcome" TEXT,
+    "outcome_notes" TEXT,
+    "completed_at" DATETIME,
+    "skill_id" INTEGER,
+    "estimated_hours" REAL,
+    "nudge_sent_at" DATETIME,
+    "final_warning_sent_at" DATETIME,
+    "country" TEXT,
+    "local_group" TEXT,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "work_items_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_context_project_id_fkey" FOREIGN KEY ("context_project_id") REFERENCES "work_items" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_creator_id_fkey" FOREIGN KEY ("creator_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_stakeholder_id_fkey" FOREIGN KEY ("stakeholder_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+CREATE TABLE "work_item_comments" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "work_item_id" INTEGER NOT NULL,
+    "author_id" INTEGER,
+    "content" TEXT NOT NULL,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "work_item_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_item_comments_work_item_id_fkey" FOREIGN KEY ("work_item_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE TABLE "work_item_skills" (
+    "work_item_id" INTEGER NOT NULL,
+    "skill_id" INTEGER NOT NULL,
+    "is_required" BOOLEAN DEFAULT true,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("work_item_id", "skill_id"),
+    CONSTRAINT "work_item_skills_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "work_item_skills_work_item_id_fkey" FOREIGN KEY ("work_item_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE TABLE "work_item_interests" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "volunteer_id" INTEGER NOT NULL,
+    "work_item_id" INTEGER NOT NULL,
+    "interest_type" TEXT NOT NULL,
+    "message" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "response_message" TEXT,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "responded_at" DATETIME,
+    CONSTRAINT "work_item_interests_work_item_id_fkey" FOREIGN KEY ("work_item_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "work_item_interests_volunteer_id_fkey" FOREIGN KEY ("volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- ─── Backfill work_items ──────────────────────────────────────────────────────
+-- PROJECT (keep original id). creator=proposer, assignee=owner, stakeholder=reviewer.
+INSERT INTO "work_items" (
+    "id", "type", "status", "title", "description",
+    "creator_id", "assignee_id", "stakeholder_id",
+    "reviewed_by_id", "reviewed_at", "review_notes",
+    "project_type", "urgency", "estimated_duration", "time_commitment_hours_per_week",
+    "collaboration_link", "is_org_proposed", "is_seeking_help", "is_seeking_owner",
+    "outcome", "outcome_notes", "completed_at",
+    "country", "local_group", "created_at", "updated_at"
+)
+SELECT
+    "id", 'PROJECT', "status", "title", "description",
+    "proposed_by_id", "owner_id", "reviewed_by_id",
+    "reviewed_by_id", "reviewed_at", "review_notes",
+    "project_type", "urgency", "estimated_duration", "time_commitment_hours_per_week",
+    "collaboration_link", "is_org_proposed", "is_seeking_help", "is_seeking_owner",
+    "outcome", "outcome_notes", "completed_at",
+    "country", "local_group", "created_at", "updated_at"
+FROM "projects";
+
+-- TASK (id + 1,000,000). parent = its project. status remap assigned→in_progress, done→completed.
+INSERT INTO "work_items" (
+    "id", "type", "status", "title", "description",
+    "parent_id", "creator_id", "assignee_id",
+    "nudge_sent_at", "final_warning_sent_at",
+    "completed_at", "created_at", "updated_at"
+)
+SELECT
+    "id" + 1000000, 'TASK',
+    CASE "status" WHEN 'assigned' THEN 'in_progress' WHEN 'done' THEN 'completed' ELSE "status" END,
+    "title", "description",
+    "project_id", "created_by_id", "assigned_to_id",
+    "nudge_sent_at", "final_warning_sent_at",
+    "completed_at", "created_at", "updated_at"
+FROM "project_tasks";
+
+-- STARTER_TASK (id + 2,000,000). context = its project. creator=assigner, assignee=doer.
+-- status remap: assigned→in_progress, submitted→under_review, approved/reviewed/rejected→completed.
+INSERT INTO "work_items" (
+    "id", "type", "status", "title", "description",
+    "context_project_id", "creator_id", "assignee_id",
+    "reviewed_by_id", "reviewed_at", "review_notes", "review_rating",
+    "skill_id", "estimated_hours", "created_at", "updated_at"
+)
+SELECT
+    "id" + 2000000, 'STARTER_TASK',
+    CASE "status"
+        WHEN 'assigned' THEN 'in_progress'
+        WHEN 'submitted' THEN 'under_review'
+        WHEN 'approved' THEN 'completed'
+        WHEN 'reviewed' THEN 'completed'
+        WHEN 'rejected' THEN 'completed'
+        ELSE "status"
+    END,
+    "title", "description",
+    "project_id", "assigned_by_id", "assigned_to_id",
+    "reviewed_by_id", "reviewed_at", "review_notes", "review_rating",
+    "skill_id", "estimated_hours", "created_at", "updated_at"
+FROM "starter_tasks";
+
+-- ─── Backfill work_item_skills (project skills; project ids unchanged) ──────────
+INSERT INTO "work_item_skills" ("work_item_id", "skill_id", "is_required", "created_at")
+SELECT "project_id", "skill_id", "is_required", "created_at" FROM "project_skills";
+
+-- ─── Backfill work_item_interests (project ids unchanged) ───────────────────────
+INSERT INTO "work_item_interests" (
+    "id", "volunteer_id", "work_item_id", "interest_type", "message",
+    "status", "response_message", "created_at", "responded_at"
+)
+SELECT
+    "id", "volunteer_id", "project_id", "interest_type", "message",
+    "status", "response_message", "created_at", "responded_at"
+FROM "project_interests";
+
+-- ─── Backfill work_item_comments ────────────────────────────────────────────────
+-- project_updates → comments (chronological, author preserved incl. NULL).
+INSERT INTO "work_item_comments" ("work_item_id", "author_id", "content", "created_at")
+SELECT "project_id", "author_id", "content", "created_at" FROM "project_updates";
+
+-- feedback_to_proposer → comment on the project (author/date = reviewer/reviewed_at).
+INSERT INTO "work_item_comments" ("work_item_id", "author_id", "content", "created_at")
+SELECT "id", "reviewed_by_id", "feedback_to_proposer", COALESCE("reviewed_at", "created_at")
+FROM "projects"
+WHERE "feedback_to_proposer" IS NOT NULL AND "feedback_to_proposer" <> '';
+
+-- feedback_to_volunteer → comment on the starter task (id + 2,000,000).
+INSERT INTO "work_item_comments" ("work_item_id", "author_id", "content", "created_at")
+SELECT "id" + 2000000, "reviewed_by_id", "feedback_to_volunteer", COALESCE("reviewed_at", "created_at")
+FROM "starter_tasks"
+WHERE "feedback_to_volunteer" IS NOT NULL AND "feedback_to_volunteer" <> '';
+
+-- ─── Redefine admin_notes / contact_messages: related_project_id → related_work_item_id ──
+-- Project ids are preserved as work_item ids, so the FK value carries over directly.
+CREATE TABLE "new_admin_notes" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "volunteer_id" INTEGER NOT NULL,
+    "author_id" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "category" TEXT DEFAULT 'general',
+    "related_work_item_id" INTEGER,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "admin_notes_related_work_item_id_fkey" FOREIGN KEY ("related_work_item_id") REFERENCES "work_items" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "admin_notes_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "admin_notes_volunteer_id_fkey" FOREIGN KEY ("volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_admin_notes" ("id", "volunteer_id", "author_id", "content", "category", "related_work_item_id", "created_at", "updated_at")
+SELECT "id", "volunteer_id", "author_id", "content", "category", "related_project_id", "created_at", "updated_at" FROM "admin_notes";
+DROP TABLE "admin_notes";
+ALTER TABLE "new_admin_notes" RENAME TO "admin_notes";
+CREATE INDEX "idx_admin_notes_volunteer" ON "admin_notes"("volunteer_id");
+
+CREATE TABLE "new_contact_messages" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "from_volunteer_id" INTEGER NOT NULL,
+    "to_volunteer_id" INTEGER NOT NULL,
+    "subject" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "related_work_item_id" INTEGER,
+    "read_at" DATETIME,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "contact_messages_related_work_item_id_fkey" FOREIGN KEY ("related_work_item_id") REFERENCES "work_items" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "contact_messages_to_volunteer_id_fkey" FOREIGN KEY ("to_volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "contact_messages_from_volunteer_id_fkey" FOREIGN KEY ("from_volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_contact_messages" ("id", "from_volunteer_id", "to_volunteer_id", "subject", "message", "related_work_item_id", "read_at", "created_at")
+SELECT "id", "from_volunteer_id", "to_volunteer_id", "subject", "message", "related_project_id", "read_at", "created_at" FROM "contact_messages";
+DROP TABLE "contact_messages";
+ALTER TABLE "new_contact_messages" RENAME TO "contact_messages";
+CREATE INDEX "idx_contact_messages_from" ON "contact_messages"("from_volunteer_id");
+CREATE INDEX "idx_contact_messages_to" ON "contact_messages"("to_volunteer_id");
+
+-- ─── Drop old tables (after backfill) ─────────────────────────────────────────
+DROP TABLE "project_interests";
+DROP TABLE "project_skills";
+-- project_task_comments existed only as drift on some databases; guard the drop.
+DROP TABLE IF EXISTS "project_task_comments";
+DROP TABLE "project_tasks";
+DROP TABLE "project_updates";
+DROP TABLE "starter_tasks";
+DROP TABLE "projects";
+
+-- ─── Indexes on new tables ────────────────────────────────────────────────────
+CREATE INDEX "idx_work_items_type" ON "work_items"("type");
+CREATE INDEX "idx_work_items_status" ON "work_items"("status");
+CREATE INDEX "idx_work_items_parent" ON "work_items"("parent_id");
+CREATE INDEX "idx_work_items_context" ON "work_items"("context_project_id");
+CREATE INDEX "idx_work_items_creator" ON "work_items"("creator_id");
+CREATE INDEX "idx_work_items_assignee" ON "work_items"("assignee_id");
+CREATE INDEX "idx_work_items_skill" ON "work_items"("skill_id");
+CREATE INDEX "idx_work_items_local_group" ON "work_items"("local_group");
+CREATE INDEX "idx_work_items_country" ON "work_items"("country");
+CREATE INDEX "idx_work_item_comments_thread" ON "work_item_comments"("work_item_id", "created_at");
+CREATE INDEX "idx_work_item_skills_skill" ON "work_item_skills"("skill_id");
+CREATE INDEX "idx_work_item_interests_volunteer" ON "work_item_interests"("volunteer_id");
+CREATE INDEX "idx_work_item_interests_work_item" ON "work_item_interests"("work_item_id");
+CREATE UNIQUE INDEX "uq_work_item_interests_volunteer_item" ON "work_item_interests"("volunteer_id", "work_item_id");

--- a/prisma/migrations/20260521120000_normalize_comment_timestamps/migration.sql
+++ b/prisma/migrations/20260521120000_normalize_comment_timestamps/migration.sql
@@ -1,0 +1,9 @@
+-- The unified_work_items backfill copied comment timestamps verbatim from the
+-- old tables, which mixed storage formats: project_updates used epoch-ms
+-- integers (Prisma's native SQLite DateTime), while the legacy feedback columns
+-- were ISO text. SQLite orders integers before text, so a mixed column can't be
+-- sorted chronologically. Normalize the text rows to epoch ms so every row is
+-- comparable and matches what Prisma writes for new comments.
+UPDATE "work_item_comments"
+SET "created_at" = CAST(strftime('%s', "created_at") AS INTEGER) * 1000
+WHERE typeof("created_at") = 'text';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,20 +27,23 @@ enum ProjectStatus {
   archived
 }
 
+enum WorkItemType {
+  PROJECT
+  TASK
+  STARTER_TASK
+}
+
 enum TaskStatus {
   open
-  assigned
-  done
+  in_progress
+  completed
 }
 
 enum StarterTaskStatus {
   open
-  assigned
-  submitted
-  approved
-  rejected
+  in_progress
+  under_review
   completed
-  reviewed
 }
 
 enum InterestStatus {
@@ -73,19 +76,19 @@ enum LocalGroupSuggestionStatus {
 }
 
 model AdminInvite {
-  id           Int        @id @default(autoincrement())
+  id           Int          @id @default(autoincrement())
   /// @zod.string.email({ message: "A valid email address is required" })
   email        String
   /// @zod.custom.omit([model])
-  inviteToken  String     @unique(map: "sqlite_autoindex_admin_invites_1") @map("invite_token")
-  invitedById  Int        @map("invited_by_id")
+  inviteToken  String       @unique(map: "sqlite_autoindex_admin_invites_1") @map("invite_token")
+  invitedById  Int          @map("invited_by_id")
   status       InviteStatus @default(pending)
-  acceptedById Int?       @map("accepted_by_id")
-  acceptedAt   DateTime?  @map("accepted_at")
-  expiresAt    DateTime   @map("expires_at")
-  createdAt    DateTime?  @default(now()) @map("created_at")
-  acceptedBy   Volunteer? @relation("AdminInviteAcceptedBy", fields: [acceptedById], references: [id], onUpdate: NoAction)
-  invitedBy    Volunteer  @relation("AdminInviteInvitedBy", fields: [invitedById], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  acceptedById Int?         @map("accepted_by_id")
+  acceptedAt   DateTime?    @map("accepted_at")
+  expiresAt    DateTime     @map("expires_at")
+  createdAt    DateTime?    @default(now()) @map("created_at")
+  acceptedBy   Volunteer?   @relation("AdminInviteAcceptedBy", fields: [acceptedById], references: [id], onUpdate: NoAction)
+  invitedBy    Volunteer    @relation("AdminInviteInvitedBy", fields: [invitedById], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([inviteToken], map: "idx_admin_invites_token")
   @@index([email], map: "idx_admin_invites_email")
@@ -93,18 +96,18 @@ model AdminInvite {
 }
 
 model AdminNote {
-  id               Int       @id @default(autoincrement())
-  volunteerId      Int       @map("volunteer_id")
-  authorId         Int       @map("author_id")
+  id                Int       @id @default(autoincrement())
+  volunteerId       Int       @map("volunteer_id")
+  authorId          Int       @map("author_id")
   /// @zod.string.min(1, { message: "Content is required" })
-  content          String
-  category         String?   @default("general") // TODO: enum — general (others unknown)
-  relatedProjectId Int?      @map("related_project_id")
-  createdAt        DateTime? @default(now()) @map("created_at")
-  updatedAt        DateTime? @default(now()) @map("updated_at")
-  relatedProject   Project?  @relation(fields: [relatedProjectId], references: [id], onUpdate: NoAction)
-  author           Volunteer @relation("AdminNoteAuthor", fields: [authorId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  volunteer        Volunteer @relation("AdminNoteVolunteer", fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  content           String
+  category          String?   @default("general") // TODO: enum — general (others unknown)
+  relatedWorkItemId Int?      @map("related_work_item_id")
+  createdAt         DateTime? @default(now()) @map("created_at")
+  updatedAt         DateTime? @default(now()) @map("updated_at")
+  relatedWorkItem   WorkItem? @relation(fields: [relatedWorkItemId], references: [id], onUpdate: NoAction)
+  author            Volunteer @relation("AdminNoteAuthor", fields: [authorId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  volunteer         Volunteer @relation("AdminNoteVolunteer", fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([volunteerId], map: "idx_admin_notes_volunteer")
   @@map("admin_notes")
@@ -135,17 +138,17 @@ model BugReport {
 }
 
 model Message {
-  id               Int       @id @default(autoincrement())
-  fromVolunteerId  Int       @map("from_volunteer_id")
-  toVolunteerId    Int       @map("to_volunteer_id")
-  subject          String
-  message          String
-  relatedProjectId Int?      @map("related_project_id")
-  readAt           DateTime? @map("read_at")
-  createdAt        DateTime? @default(now()) @map("created_at")
-  relatedProject   Project?  @relation(fields: [relatedProjectId], references: [id], onUpdate: NoAction)
-  to               Volunteer @relation("MessageTo", fields: [toVolunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  from             Volunteer @relation("MessageFrom", fields: [fromVolunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id                Int       @id @default(autoincrement())
+  fromVolunteerId   Int       @map("from_volunteer_id")
+  toVolunteerId     Int       @map("to_volunteer_id")
+  subject           String
+  message           String
+  relatedWorkItemId Int?      @map("related_work_item_id")
+  readAt            DateTime? @map("read_at")
+  createdAt         DateTime? @default(now()) @map("created_at")
+  relatedWorkItem   WorkItem? @relation(fields: [relatedWorkItemId], references: [id], onUpdate: NoAction)
+  to                Volunteer @relation("MessageTo", fields: [toVolunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  from              Volunteer @relation("MessageFrom", fields: [fromVolunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([fromVolunteerId], map: "idx_contact_messages_from")
   @@index([toVolunteerId], map: "idx_contact_messages_to")
@@ -210,120 +213,126 @@ model EmailVerificationToken {
   @@map("email_verification_tokens")
 }
 
-model ProjectInterest {
-  id              Int       @id @default(autoincrement())
-  volunteerId     Int       @map("volunteer_id")
-  projectId       Int       @map("project_id")
-  interestType    String    @map("interest_type") // TODO: enum — want_to_contribute, want_to_own
-  message         String?
-  status          InterestStatus @default(pending)
-  responseMessage String?   @map("response_message")
-  createdAt       DateTime? @default(now()) @map("created_at")
-  respondedAt     DateTime? @map("responded_at")
-  project         Project   @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  volunteer       Volunteer @relation(fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+model WorkItem {
+  id          Int     @id @default(autoincrement())
+  type        String // PROJECT | TASK | STARTER_TASK
+  status      String // type-specific, enforced at app layer
+  /// @zod.string.min(1, { message: "Title is required" })
+  title       String
+  description String?
 
-  @@unique([volunteerId, projectId], map: "sqlite_autoindex_project_interests_1")
-  @@index([volunteerId], map: "idx_project_interests_volunteer")
-  @@index([projectId], map: "idx_project_interests_project")
-  @@map("project_interests")
+  // Hierarchy: TASK has parentId → PROJECT
+  parentId Int?       @map("parent_id")
+  parent   WorkItem?  @relation("WorkItemChildren", fields: [parentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  children WorkItem[] @relation("WorkItemChildren")
+
+  // Context: STARTER_TASK optionally references a PROJECT (not hierarchical)
+  contextProjectId Int?       @map("context_project_id")
+  contextProject   WorkItem?  @relation("WorkItemContext", fields: [contextProjectId], references: [id], onUpdate: NoAction)
+  contextTasks     WorkItem[] @relation("WorkItemContext")
+
+  // People roles
+  creatorId     Int? @map("creator_id")
+  assigneeId    Int? @map("assignee_id")
+  stakeholderId Int? @map("stakeholder_id")
+
+  // Review
+  reviewedById Int?      @map("reviewed_by_id")
+  reviewedAt   DateTime? @map("reviewed_at")
+  reviewNotes  String?   @map("review_notes")
+  reviewRating String?   @map("review_rating") // STARTER_TASK only
+
+  // Project-specific (nullable for TASK/STARTER_TASK)
+  projectType                String?   @map("project_type") // TODO: enum — sprint, container, ongoing, one_off
+  urgency                    String?   @default("medium") // TODO: enum — low, medium, high
+  estimatedDuration          String?   @map("estimated_duration")
+  timeCommitmentHoursPerWeek Int?      @map("time_commitment_hours_per_week")
+  collaborationLink          String?   @map("collaboration_link")
+  isOrgProposed              Boolean?  @default(false) @map("is_org_proposed")
+  isSeekingHelp              Boolean?  @default(false) @map("is_seeking_help")
+  isSeekingOwner             Boolean?  @default(false) @map("is_seeking_owner")
+  outcome                    String? // TODO: enum — successful, partial, not_completed, ongoing
+  outcomeNotes               String?   @map("outcome_notes")
+  completedAt                DateTime? @map("completed_at")
+
+  // Task / starter-task-specific (nullable for PROJECT)
+  skillId            Int?      @map("skill_id")
+  estimatedHours     Float?    @map("estimated_hours")
+  nudgeSentAt        DateTime? @map("nudge_sent_at")
+  finalWarningSentAt DateTime? @map("final_warning_sent_at")
+
+  country    String?
+  localGroup String?   @map("local_group")
+  createdAt  DateTime? @default(now()) @map("created_at")
+  updatedAt  DateTime? @default(now()) @map("updated_at")
+
+  creator     Volunteer?         @relation("WorkItemCreator", fields: [creatorId], references: [id], onUpdate: NoAction)
+  assignee    Volunteer?         @relation("WorkItemAssignee", fields: [assigneeId], references: [id], onUpdate: NoAction)
+  stakeholder Volunteer?         @relation("WorkItemStakeholder", fields: [stakeholderId], references: [id], onUpdate: NoAction)
+  reviewedBy  Volunteer?         @relation("WorkItemReviewedBy", fields: [reviewedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  skill       Skill?             @relation(fields: [skillId], references: [id], onUpdate: NoAction)
+  comments    WorkItemComment[]
+  skills      WorkItemSkill[]
+  interests   WorkItemInterest[]
+  adminNotes  AdminNote[]
+  messages    Message[]
+
+  @@index([type], map: "idx_work_items_type")
+  @@index([status], map: "idx_work_items_status")
+  @@index([parentId], map: "idx_work_items_parent")
+  @@index([contextProjectId], map: "idx_work_items_context")
+  @@index([creatorId], map: "idx_work_items_creator")
+  @@index([assigneeId], map: "idx_work_items_assignee")
+  @@index([skillId], map: "idx_work_items_skill")
+  @@index([localGroup], map: "idx_work_items_local_group")
+  @@index([country], map: "idx_work_items_country")
+  @@map("work_items")
 }
 
-model ProjectSkill {
-  projectId  Int       @map("project_id")
+model WorkItemComment {
+  id         Int        @id @default(autoincrement())
+  workItemId Int        @map("work_item_id")
+  authorId   Int?       @map("author_id")
+  /// @zod.string.min(1, { message: "Content is required" })
+  content    String
+  createdAt  DateTime?  @default(now()) @map("created_at")
+  author     Volunteer? @relation("WorkItemCommentAuthor", fields: [authorId], references: [id], onUpdate: NoAction)
+  workItem   WorkItem   @relation(fields: [workItemId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([workItemId, createdAt], map: "idx_work_item_comments_thread")
+  @@map("work_item_comments")
+}
+
+model WorkItemSkill {
+  workItemId Int       @map("work_item_id")
   skillId    Int       @map("skill_id")
   isRequired Boolean?  @default(true) @map("is_required")
   createdAt  DateTime? @default(now()) @map("created_at")
   skill      Skill     @relation(fields: [skillId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  project    Project   @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  workItem   WorkItem  @relation(fields: [workItemId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
-  @@id([projectId, skillId])
-  @@index([skillId], map: "idx_project_skills_skill")
-  @@map("project_skills")
+  @@id([workItemId, skillId])
+  @@index([skillId], map: "idx_work_item_skills_skill")
+  @@map("work_item_skills")
 }
 
-model ProjectTask {
-  id           Int        @id @default(autoincrement())
-  projectId    Int        @map("project_id")
-  /// @zod.string.min(1, { message: "Title is required" })
-  title        String
-  description  String?
-  assignedToId Int?       @map("assigned_to_id")
-  status       TaskStatus @default(open)
-  createdById  Int        @map("created_by_id")
-  completedAt          DateTime?  @map("completed_at")
-  nudgeSentAt          DateTime?  @map("nudge_sent_at")
-  finalWarningSentAt   DateTime?  @map("final_warning_sent_at")
-  createdAt            DateTime?  @default(now()) @map("created_at")
-  updatedAt            DateTime?  @default(now()) @map("updated_at")
-  createdBy    Volunteer  @relation("ProjectTaskCreatedBy", fields: [createdById], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  assignedTo   Volunteer? @relation("ProjectTaskAssignedTo", fields: [assignedToId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  project      Project    @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+model WorkItemInterest {
+  id              Int            @id @default(autoincrement())
+  volunteerId     Int            @map("volunteer_id")
+  workItemId      Int            @map("work_item_id")
+  interestType    String         @map("interest_type") // TODO: enum — want_to_contribute, want_to_own
+  message         String?
+  status          InterestStatus @default(pending)
+  responseMessage String?        @map("response_message")
+  createdAt       DateTime?      @default(now()) @map("created_at")
+  respondedAt     DateTime?      @map("responded_at")
+  workItem        WorkItem       @relation(fields: [workItemId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  volunteer       Volunteer      @relation(fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
-  @@index([assignedToId], map: "idx_project_tasks_assigned")
-  @@index([projectId], map: "idx_project_tasks_project")
-  @@map("project_tasks")
-}
-
-model ProjectUpdate {
-  id        Int        @id @default(autoincrement())
-  projectId Int        @map("project_id")
-  authorId  Int?       @map("author_id")
-  /// @zod.string.min(1, { message: "Content is required" })
-  content   String
-  createdAt DateTime?  @default(now()) @map("created_at")
-  author    Volunteer? @relation(fields: [authorId], references: [id], onUpdate: NoAction)
-  project   Project    @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-
-  @@index([projectId], map: "idx_project_updates_project")
-  @@map("project_updates")
-}
-
-model Project {
-  id                         Int               @id @default(autoincrement())
-  /// @zod.string.min(1, { message: "Title is required" })
-  title                      String
-  /// @zod.string.min(10, { message: "Description must be at least 10 characters" })
-  description                String
-  status                     ProjectStatus     @default(pending_review)
-  ownerId                    Int?              @map("owner_id")
-  proposedById               Int?              @map("proposed_by_id")
-  isOrgProposed              Boolean?          @default(false) @map("is_org_proposed")
-  projectType                String?           @map("project_type") // TODO: enum — sprint, container, ongoing, one_off
-  estimatedDuration          String?           @map("estimated_duration")
-  timeCommitmentHoursPerWeek Int?              @map("time_commitment_hours_per_week")
-  urgency                    String?           @default("medium") // TODO: enum — low, medium, high
-  reviewNotes                String?           @map("review_notes")
-  reviewedById               Int?              @map("reviewed_by_id")
-  reviewedAt                 DateTime?         @map("reviewed_at")
-  feedbackToProposer         String?           @map("feedback_to_proposer")
-  collaborationLink          String?           @map("collaboration_link")
-  outcome                    String? // TODO: enum — successful, partial, not_completed, ongoing
-  outcomeNotes               String?           @map("outcome_notes")
-  completedAt                DateTime?         @map("completed_at")
-  createdAt                  DateTime?         @default(now()) @map("created_at")
-  updatedAt                  DateTime?         @default(now()) @map("updated_at")
-  country                    String?
-  isSeekingHelp              Boolean?          @default(false) @map("is_seeking_help")
-  isSeekingOwner             Boolean?          @default(false) @map("is_seeking_owner")
-  localGroup                 String?           @map("local_group")
-  adminNotes                 AdminNote[]
-  messages                   Message[]
-  interests                  ProjectInterest[]
-  skills                     ProjectSkill[]
-  tasks                      ProjectTask[]
-  updates                    ProjectUpdate[]
-  reviewedBy                 Volunteer?        @relation("ProjectReviewedBy", fields: [reviewedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  proposedBy                 Volunteer?        @relation("ProjectProposedBy", fields: [proposedById], references: [id], onUpdate: NoAction)
-  owner                      Volunteer?        @relation("ProjectOwner", fields: [ownerId], references: [id], onUpdate: NoAction)
-  starterTasks               StarterTask[]
-
-  @@index([localGroup], map: "idx_projects_local_group")
-  @@index([country], map: "idx_projects_country")
-  @@index([proposedById], map: "idx_projects_proposed_by")
-  @@index([ownerId], map: "idx_projects_owner")
-  @@index([status], map: "idx_projects_status")
-  @@map("projects")
+  @@unique([volunteerId, workItemId], map: "uq_work_item_interests_volunteer_item")
+  @@index([volunteerId], map: "idx_work_item_interests_volunteer")
+  @@index([workItemId], map: "idx_work_item_interests_work_item")
+  @@map("work_item_interests")
 }
 
 model LocalGroup {
@@ -339,19 +348,19 @@ model LocalGroup {
 }
 
 model LocalGroupSuggestion {
-  id            Int        @id @default(autoincrement())
+  id            Int                        @id @default(autoincrement())
   /// @zod.string.min(1, { message: "Group name is required" })
   name          String
   /// @zod.string.min(1, { message: "Country is required" })
   country       String
   status        LocalGroupSuggestionStatus @default(pending)
-  suggestedById Int        @map("suggested_by_id")
-  reviewedById  Int?       @map("reviewed_by_id")
-  reviewedAt    DateTime?  @map("reviewed_at")
-  adminNotes    String?    @map("admin_notes")
-  mergedIntoId  Int?       @map("merged_into_id")
-  createdAt     DateTime?  @default(now()) @map("created_at")
-  updatedAt     DateTime?  @default(now()) @map("updated_at")
+  suggestedById Int                        @map("suggested_by_id")
+  reviewedById  Int?                       @map("reviewed_by_id")
+  reviewedAt    DateTime?                  @map("reviewed_at")
+  adminNotes    String?                    @map("admin_notes")
+  mergedIntoId  Int?                       @map("merged_into_id")
+  createdAt     DateTime?                  @default(now()) @map("created_at")
+  updatedAt     DateTime?                  @default(now()) @map("updated_at")
 
   suggestedBy Volunteer   @relation("LocalGroupSuggestionSuggestedBy", fields: [suggestedById], references: [id])
   reviewedBy  Volunteer?  @relation("LocalGroupSuggestionReviewedBy", fields: [reviewedById], references: [id])
@@ -419,46 +428,15 @@ model Skill {
   description     String?
   sortOrder       Int?               @default(0) @map("sort_order")
   createdAt       DateTime?          @default(now()) @map("created_at")
-  projectSkills   ProjectSkill[]
+  workItemSkills  WorkItemSkill[]
   endorsements    SkillEndorsement[]
   category        SkillCategory      @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  starterTasks    StarterTask[]
+  workItems       WorkItem[]
   volunteerSkills VolunteerSkill[]
 
   @@unique([categoryId, name], map: "sqlite_autoindex_skills_1")
   @@index([categoryId], map: "idx_skills_category")
   @@map("skills")
-}
-
-model StarterTask {
-  id                  Int        @id @default(autoincrement())
-  projectId           Int?       @map("project_id")
-  /// @zod.string.min(1, { message: "Title is required" })
-  title               String
-  /// @zod.string.min(1, { message: "Description is required" })
-  description         String
-  skillId             Int?       @map("skill_id")
-  assignedToId        Int?       @map("assigned_to_id")
-  assignedById        Int?       @map("assigned_by_id")
-  status              StarterTaskStatus @default(open)
-  reviewRating        String?    @map("review_rating") // TODO: enum — excellent, good, needs_improvement
-  reviewNotes         String?    @map("review_notes")
-  feedbackToVolunteer String?    @map("feedback_to_volunteer")
-  reviewedById        Int?       @map("reviewed_by_id")
-  reviewedAt          DateTime?  @map("reviewed_at")
-  estimatedHours      Float?     @map("estimated_hours")
-  createdAt           DateTime?  @default(now()) @map("created_at")
-  updatedAt           DateTime?  @default(now()) @map("updated_at")
-  reviewedBy          Volunteer? @relation("StarterTaskReviewedBy", fields: [reviewedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  assignedBy          Volunteer? @relation("StarterTaskAssignedBy", fields: [assignedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  assignedTo          Volunteer? @relation("StarterTaskAssignedTo", fields: [assignedToId], references: [id], onUpdate: NoAction)
-  skill               Skill?     @relation(fields: [skillId], references: [id], onUpdate: NoAction)
-  project             Project?   @relation(fields: [projectId], references: [id], onUpdate: NoAction)
-
-  @@index([skillId], map: "idx_starter_tasks_skill")
-  @@index([assignedToId], map: "idx_starter_tasks_assigned")
-  @@index([projectId], map: "idx_starter_tasks_project")
-  @@map("starter_tasks")
 }
 
 model VolunteerSkill {
@@ -475,73 +453,69 @@ model VolunteerSkill {
 }
 
 model Volunteer {
-  id                                      Int                  @id @default(autoincrement())
+  id                                      Int                      @id @default(autoincrement())
   /// @zod.string.min(1, { message: "Name is required" })
   name                                    String
   /// @zod.string.email({ message: "A valid email address is required" })
-  email                                   String?              @unique(map: "sqlite_autoindex_volunteers_1")
+  email                                   String?                  @unique(map: "sqlite_autoindex_volunteers_1")
   bio                                     String?
-  discordHandle                           String?              @map("discord_handle")
-  signalNumber                            String?              @map("signal_number")
-  whatsappNumber                          String?              @map("whatsapp_number")
-  contactPreference                       String?              @map("contact_preference") // TODO: enum — email, discord, signal, whatsapp (others unknown)
-  contactNotes                            String?              @map("contact_notes")
-  availabilityHoursPerWeek                Int?                 @map("availability_hours_per_week")
+  discordHandle                           String?                  @map("discord_handle")
+  signalNumber                            String?                  @map("signal_number")
+  whatsappNumber                          String?                  @map("whatsapp_number")
+  contactPreference                       String?                  @map("contact_preference") // TODO: enum — email, discord, signal, whatsapp (others unknown)
+  contactNotes                            String?                  @map("contact_notes")
+  availabilityHoursPerWeek                Int?                     @map("availability_hours_per_week")
   location                                String?
-  otherSkills                             String?              @map("other_skills")
-  consentMakeProfileVisibleInDirectory    Boolean?             @default(false) @map("consent_make_profile_visible_in_directory")
-  consentContactableByProjectOwners       Boolean?             @default(false) @map("consent_contactable_by_project_owners")
-  consentShareContactInfoWithProjectOwner Boolean?             @default(false) @map("consent_share_contact_info_with_project_owner")
-  consentGivenAt                          DateTime?            @map("consent_given_at")
-  cookieConsentAnalytics                  Boolean?             @map("cookie_consent_analytics")
+  otherSkills                             String?                  @map("other_skills")
+  consentMakeProfileVisibleInDirectory    Boolean?                 @default(false) @map("consent_make_profile_visible_in_directory")
+  consentContactableByProjectOwners       Boolean?                 @default(false) @map("consent_contactable_by_project_owners")
+  consentShareContactInfoWithProjectOwner Boolean?                 @default(false) @map("consent_share_contact_info_with_project_owner")
+  consentGivenAt                          DateTime?                @map("consent_given_at")
+  cookieConsentAnalytics                  Boolean?                 @map("cookie_consent_analytics")
   /// @zod.custom.omit([model])
-  authToken                               String?              @unique(map: "sqlite_autoindex_volunteers_2") @map("auth_token")
+  authToken                               String?                  @unique(map: "sqlite_autoindex_volunteers_2") @map("auth_token")
   /// @zod.custom.omit([model])
-  authTokenExpiresAt                      DateTime?            @map("auth_token_expires_at")
+  authTokenExpiresAt                      DateTime?                @map("auth_token_expires_at")
   /// @zod.custom.omit([model])
-  passwordHash                            String?              @map("password_hash")
-  isAdmin                                 Boolean?             @default(false) @map("is_admin")
-  createdAt                               DateTime?            @default(now()) @map("created_at")
-  updatedAt                               DateTime?            @default(now()) @map("updated_at")
-  deletedAt                               DateTime?            @map("deleted_at")
+  passwordHash                            String?                  @map("password_hash")
+  isAdmin                                 Boolean?                 @default(false) @map("is_admin")
+  createdAt                               DateTime?                @default(now()) @map("created_at")
+  updatedAt                               DateTime?                @default(now()) @map("updated_at")
+  deletedAt                               DateTime?                @map("deleted_at")
   country                                 String?
-  emailDigest                             String?              @default("none") @map("email_digest") // TODO: enum — none, daily, weekly
-  localGroup                              String?              @map("local_group")
-  approvalStatus                          ApprovalStatus       @default(pending) @map("approval_status")
-  applicationMessage                      String?              @map("application_message")
-  applicationAdminNotes                   String?              @map("application_admin_notes")
-  applicationApplicantNotes               String?              @map("application_applicant_notes")
-  rejectedAt                              DateTime?            @map("rejected_at")
-  reviewerId                              Int?                 @map("reviewer_id")
-  reviewer                                Volunteer?           @relation("ApplicationReviewer", fields: [reviewerId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  reviewerOf                              Volunteer[]          @relation("ApplicationReviewer")
-  emailConfirmed                          Boolean              @default(false) @map("email_confirmed")
-  invitesAccepted                         AdminInvite[]        @relation("AdminInviteAcceptedBy")
-  invitesSent                             AdminInvite[]        @relation("AdminInviteInvitedBy")
-  adminNotesAuthored                      AdminNote[]          @relation("AdminNoteAuthor")
-  adminNotesAbout                         AdminNote[]          @relation("AdminNoteVolunteer")
-  bugReportsResolved                      BugReport[]          @relation("BugReportResolvedBy")
-  bugReportsReported                      BugReport[]          @relation("BugReportReporter")
-  messagesSent                            Message[]            @relation("MessageFrom")
-  messagesReceived                        Message[]            @relation("MessageTo")
+  emailDigest                             String?                  @default("none") @map("email_digest") // TODO: enum — none, daily, weekly
+  localGroup                              String?                  @map("local_group")
+  approvalStatus                          ApprovalStatus           @default(pending) @map("approval_status")
+  applicationMessage                      String?                  @map("application_message")
+  applicationAdminNotes                   String?                  @map("application_admin_notes")
+  applicationApplicantNotes               String?                  @map("application_applicant_notes")
+  rejectedAt                              DateTime?                @map("rejected_at")
+  reviewerId                              Int?                     @map("reviewer_id")
+  reviewer                                Volunteer?               @relation("ApplicationReviewer", fields: [reviewerId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  reviewerOf                              Volunteer[]              @relation("ApplicationReviewer")
+  emailConfirmed                          Boolean                  @default(false) @map("email_confirmed")
+  invitesAccepted                         AdminInvite[]            @relation("AdminInviteAcceptedBy")
+  invitesSent                             AdminInvite[]            @relation("AdminInviteInvitedBy")
+  adminNotesAuthored                      AdminNote[]              @relation("AdminNoteAuthor")
+  adminNotesAbout                         AdminNote[]              @relation("AdminNoteVolunteer")
+  bugReportsResolved                      BugReport[]              @relation("BugReportResolvedBy")
+  bugReportsReported                      BugReport[]              @relation("BugReportReporter")
+  messagesSent                            Message[]                @relation("MessageFrom")
+  messagesReceived                        Message[]                @relation("MessageTo")
   notifications                           Notification[]
   emailVerificationTokens                 EmailVerificationToken[]
   passwordResetTokens                     PasswordResetToken[]
-  projectInterests                        ProjectInterest[]
-  projectTasksCreated                     ProjectTask[]        @relation("ProjectTaskCreatedBy")
-  projectTasksAssigned                    ProjectTask[]        @relation("ProjectTaskAssignedTo")
-  projectUpdates                          ProjectUpdate[]
-  projectsReviewed                        Project[]            @relation("ProjectReviewedBy")
-  projectsProposed                        Project[]            @relation("ProjectProposedBy")
-  projectsOwned                           Project[]            @relation("ProjectOwner")
-  skillEndorsementsGiven                  SkillEndorsement[]   @relation("SkillEndorsementEndorsedBy")
-  skillEndorsementsReceived               SkillEndorsement[]   @relation("SkillEndorsementVolunteer")
-  starterTasksReviewed                    StarterTask[]        @relation("StarterTaskReviewedBy")
-  starterTasksAssignedBy                  StarterTask[]        @relation("StarterTaskAssignedBy")
-  starterTasksAssigned                    StarterTask[]        @relation("StarterTaskAssignedTo")
+  workItemInterests                       WorkItemInterest[]
+  workItemComments                        WorkItemComment[]        @relation("WorkItemCommentAuthor")
+  workItemsCreated                        WorkItem[]               @relation("WorkItemCreator")
+  workItemsAssigned                       WorkItem[]               @relation("WorkItemAssignee")
+  workItemsStakeholder                    WorkItem[]               @relation("WorkItemStakeholder")
+  workItemsReviewed                       WorkItem[]               @relation("WorkItemReviewedBy")
+  skillEndorsementsGiven                  SkillEndorsement[]       @relation("SkillEndorsementEndorsedBy")
+  skillEndorsementsReceived               SkillEndorsement[]       @relation("SkillEndorsementVolunteer")
   skills                                  VolunteerSkill[]
-  localGroupSuggestions                   LocalGroupSuggestion[] @relation("LocalGroupSuggestionSuggestedBy")
-  localGroupSuggestionsReviewed           LocalGroupSuggestion[] @relation("LocalGroupSuggestionReviewedBy")
+  localGroupSuggestions                   LocalGroupSuggestion[]   @relation("LocalGroupSuggestionSuggestedBy")
+  localGroupSuggestionsReviewed           LocalGroupSuggestion[]   @relation("LocalGroupSuggestionReviewedBy")
 
   @@index([localGroup], map: "idx_volunteers_local_group")
   @@index([country], map: "idx_volunteers_country")

--- a/scripts/seed-migration-test-state.ts
+++ b/scripts/seed-migration-test-state.ts
@@ -1,0 +1,115 @@
+// TEMPORARY: seeds db/anonymised_prod.db with comment-source data in every
+// state the WorkItem migration backfill must handle. Delete after #96 lands.
+//
+// Run: NODE_OPTIONS=--experimental-sqlite npx tsx scripts/seed-migration-test-state.ts
+//
+// Idempotent: UPDATEs key off fixed ids; inserted rows are tagged with the
+// SENTINEL marker and cleared before re-insert.
+import { DatabaseSync } from 'node:sqlite'
+import { join } from 'path'
+
+const DB_PATH = join(process.cwd(), 'db', 'anonymised_prod.db')
+const ADMIN = 60 // admin@example.com
+const VOL = 59 // volunteer@example.com
+const SENTINEL = '[seed:migration-test]'
+
+const db = new DatabaseSync(DB_PATH)
+
+function run(label: string, sql: string, ...params: (string | number | null)[]) {
+  const info = db.prepare(sql).run(...params)
+  console.log(`  ${label}: ${info.changes} row(s)`)
+}
+
+console.log(`Seeding ${DB_PATH}`)
+db.exec('BEGIN')
+try {
+  // ── feedback_to_proposer → WorkItemComment ──────────────────────────────
+  // Normal: reviewer + reviewed_at present (author + date resolvable).
+  run(
+    'proposer feedback (normal, project 20)',
+    `UPDATE projects SET proposed_by_id=?, reviewed_by_id=?, reviewed_at=datetime('now'),
+       feedback_to_proposer='Please clarify scope before we approve.'
+     WHERE id=20`,
+    VOL,
+    ADMIN,
+  )
+  run(
+    'proposer feedback (normal, project 10)',
+    `UPDATE projects SET proposed_by_id=?, reviewed_by_id=?, reviewed_at=datetime('now'),
+       feedback_to_proposer='Looks good, approving with minor notes.'
+     WHERE id=10`,
+    VOL,
+    ADMIN,
+  )
+  // Edge: feedback present but reviewer + reviewed_at NULL (comment author/date must fall back).
+  run(
+    'proposer feedback (null reviewer/date, project 12)',
+    `UPDATE projects SET proposed_by_id=?, reviewed_by_id=NULL, reviewed_at=NULL,
+       feedback_to_proposer='Orphaned feedback with no reviewer recorded.'
+     WHERE id=12`,
+    VOL,
+  )
+
+  // ── feedback_to_volunteer → WorkItemComment ─────────────────────────────
+  // Normal: reviewer + reviewed_at present.
+  run(
+    'volunteer feedback (normal, starter 1)',
+    `UPDATE starter_tasks SET assigned_to_id=?, reviewed_by_id=?, reviewed_at=datetime('now'),
+       feedback_to_volunteer='Great first task, well done.'
+     WHERE id=1`,
+    VOL,
+    ADMIN,
+  )
+  // Edge: feedback present, reviewer NULL.
+  run(
+    'volunteer feedback (null reviewer, starter 2)',
+    `UPDATE starter_tasks SET assigned_to_id=?, reviewed_by_id=NULL, reviewed_at=NULL,
+       feedback_to_volunteer='Feedback left without a recorded reviewer.'
+     WHERE id=2`,
+    VOL,
+  )
+
+  // ── project_updates → WorkItemComment ───────────────────────────────────
+  // Ensure project 1 is visible to the test volunteer.
+  run(
+    'project 1 → volunteer',
+    `UPDATE projects SET proposed_by_id=?, owner_id=? WHERE id=1`,
+    VOL,
+    VOL,
+  )
+  // Clear prior seeded updates, then insert author-present + author-null cases.
+  run('clear seeded updates', `DELETE FROM project_updates WHERE content LIKE ?`, `${SENTINEL}%`)
+  run(
+    'project_update (author present)',
+    `INSERT INTO project_updates (project_id, author_id, content, created_at)
+     VALUES (1, ?, ?, datetime('now','-2 days'))`,
+    VOL,
+    `${SENTINEL} progress update from the owner`,
+  )
+  run(
+    'project_update (author null)',
+    `INSERT INTO project_updates (project_id, author_id, content, created_at)
+     VALUES (1, NULL, ?, datetime('now','-1 days'))`,
+    `${SENTINEL} system-generated update, no author`,
+  )
+
+  // ── admin_notes / contact_messages FK remap (related_project_id) ─────────
+  run('admin_note related_project_id', `UPDATE admin_notes SET related_project_id=1 WHERE id=1`)
+  run(
+    'contact_message related_project_id (msg 1 → proj 1)',
+    `UPDATE contact_messages SET related_project_id=1 WHERE id=1`,
+  )
+  run(
+    'contact_message related_project_id (msg 2 → proj 20)',
+    `UPDATE contact_messages SET related_project_id=20 WHERE id=2`,
+  )
+
+  db.exec('COMMIT')
+  console.log('Done.')
+} catch (err) {
+  db.exec('ROLLBACK')
+  console.error('Failed, rolled back:', err)
+  process.exit(1)
+} finally {
+  db.close()
+}

--- a/server/router.ts
+++ b/server/router.ts
@@ -9,6 +9,7 @@ import { bugReportsRouter } from './routers/bugReports'
 import { localGroupsRouter } from './routers/localGroups'
 import { localGroupSuggestionsRouter } from './routers/localGroupSuggestions'
 import { starterTasksRouter } from './routers/starterTasks'
+import { workItemCommentsRouter } from './routers/workItemComments'
 import { myRouter } from './routers/my'
 import { privacyRouter } from './routers/privacy'
 import { contactRouter } from './routers/contact'
@@ -41,6 +42,7 @@ export const appRouter = {
   localGroups: localGroupsRouter,
   localGroupSuggestions: localGroupSuggestionsRouter,
   starterTasks: starterTasksRouter,
+  workItemComments: workItemCommentsRouter,
   my: myRouter,
   privacy: privacyRouter,
   contact: contactRouter,

--- a/server/routers/admin/interests.ts
+++ b/server/routers/admin/interests.ts
@@ -7,14 +7,14 @@ export const adminInterestsRouter = {
   list: adminProcedure
     .input(z.object({ status: z.nativeEnum(InterestStatus).optional() }))
     .handler(async ({ input }) => {
-      const interests = await prisma.projectInterest.findMany({
+      const interests = await prisma.workItemInterest.findMany({
         where: input.status ? { status: input.status } : {},
         include: {
-          project: {
+          workItem: {
             select: {
               title: true,
               status: true,
-              owner: { select: { name: true } },
+              assignee: { select: { name: true } },
             },
           },
           volunteer: {
@@ -33,18 +33,18 @@ export const adminInterestsRouter = {
       return interests.map((i) => ({
         id: i.id,
         volunteerId: i.volunteerId,
-        projectId: i.projectId,
+        projectId: i.workItemId,
         interestType: i.interestType,
         message: i.message,
         status: i.status,
         responseMessage: i.responseMessage,
         createdAt: i.createdAt,
         respondedAt: i.respondedAt,
-        projectTitle: i.project.title,
-        projectStatus: i.project.status,
+        projectTitle: i.workItem.title,
+        projectStatus: i.workItem.status,
         volunteerName: i.volunteer.name,
         volunteerEmail: i.volunteer.email,
-        ownerName: i.project.owner?.name ?? null,
+        ownerName: i.workItem.assignee?.name ?? null,
         volunteerSkills: i.volunteer.skills.map((vs) => ({
           id: vs.skill.id,
           categoryId: vs.skill.categoryId,

--- a/server/routers/admin/localGroups.ts
+++ b/server/routers/admin/localGroups.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { sendLocalGroupSuggestionEmail } from '@/lib/email'
 import { BASE_LOCATION_OPTIONS } from '@/lib/filter-options'
-import { createNotification } from '@/lib/project'
+import { createNotification } from '@/lib/notify'
 import { LocalGroupBodySchema, ReviewSuggestionSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
 import { LocalGroupSuggestionStatus } from '@/generated/prisma/enums'
@@ -67,7 +67,7 @@ export const adminLocalGroupsRouter = {
         where: { mergedIntoId: input.id },
         data: { mergedIntoId: null },
       }),
-      prisma.project.updateMany({
+      prisma.workItem.updateMany({
         where: { localGroup: existing.name },
         data: { localGroup: null },
       }),

--- a/server/routers/admin/notes.ts
+++ b/server/routers/admin/notes.ts
@@ -19,7 +19,7 @@ export const adminNotesRouter = {
         authorId: n.authorId,
         content: n.content,
         category: n.category,
-        relatedProjectId: n.relatedProjectId,
+        relatedProjectId: n.relatedWorkItemId,
         createdAt: n.createdAt,
         updatedAt: n.updatedAt,
         authorName: n.author.name,
@@ -41,7 +41,7 @@ export const adminNotesRouter = {
           authorId: context.volunteer.id,
           content: input.content.trim(),
           category: input.category ?? 'general',
-          relatedProjectId: input.relatedProjectId ?? null,
+          relatedWorkItemId: input.relatedWorkItemId ?? null,
         },
       })
       return { id: note.id, message: 'Note added' }

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
-import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
+import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
 import { notifyUser } from '@/lib/notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
-import { ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
+import { ProjectStatus, TaskStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const adminProjectsRouter = {
   create: adminProcedure.input(AdminCreateProjectSchema).handler(async ({ input, context }) => {
@@ -13,13 +13,14 @@ export const adminProjectsRouter = {
     const { wantToOwn, skillIds, skillRequiredMap, tasks } = input
 
     const project = await prisma.$transaction(async (tx) => {
-      const newProject = await tx.project.create({
+      const newProject = await tx.workItem.create({
         data: {
+          type: WorkItemType.PROJECT,
           title: input.title,
           description: input.description,
           status: tasks.length > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks,
-          ownerId: wantToOwn ? admin.id : null,
-          proposedById: admin.id,
+          assigneeId: wantToOwn ? admin.id : null,
+          creatorId: admin.id,
           isOrgProposed: true,
           projectType: input.projectType ?? null,
           estimatedDuration: input.estimatedDuration ?? null,
@@ -34,9 +35,9 @@ export const adminProjectsRouter = {
       })
 
       if (skillIds.length > 0) {
-        await tx.projectSkill.createMany({
+        await tx.workItemSkill.createMany({
           data: skillIds.map((skillId) => ({
-            projectId: newProject.id,
+            workItemId: newProject.id,
             skillId,
             isRequired: skillRequiredMap[skillId] !== false,
           })),
@@ -44,12 +45,14 @@ export const adminProjectsRouter = {
       }
 
       if (tasks.length > 0) {
-        await tx.projectTask.createMany({
+        await tx.workItem.createMany({
           data: tasks.map((t) => ({
-            projectId: newProject.id,
+            type: WorkItemType.TASK,
+            status: TaskStatus.open,
+            parentId: newProject.id,
             title: t.title,
             description: t.description ?? null,
-            createdById: admin.id,
+            creatorId: admin.id,
           })),
         })
       }
@@ -64,15 +67,21 @@ export const adminProjectsRouter = {
     .input(z.object({ id: z.number().int() }).merge(ReviewProjectSchema))
     .handler(async ({ input, context }) => {
       const admin = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.id } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      const { status, reviewNotes = null, feedbackToProposer = null, targetStatus } = input
+      const { status, reviewNotes = null, comment = null, targetStatus } = input
 
       if (status === 'approved') {
-        const hasOwner = project.ownerId !== null
-        const openTaskCount = await prisma.projectTask.count({
-          where: { projectId: input.id, status: { not: TaskStatus.done } },
+        const hasOwner = project.assigneeId !== null
+        const openTaskCount = await prisma.workItem.count({
+          where: {
+            parentId: input.id,
+            type: WorkItemType.TASK,
+            status: { not: TaskStatus.completed },
+          },
         })
         const newStatus = openTaskCount > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks
         const isSeekingHelp =
@@ -80,22 +89,29 @@ export const adminProjectsRouter = {
           targetStatus === ProjectStatus.seeking_owner
         const isSeekingOwner = targetStatus === ProjectStatus.seeking_owner && !hasOwner
 
-        await prisma.project.update({
+        await prisma.workItem.update({
           where: { id: input.id },
           data: {
             status: newStatus,
             isSeekingHelp,
             isSeekingOwner,
             reviewNotes,
+            stakeholderId: admin.id,
             reviewedById: admin.id,
             reviewedAt: new Date(),
             updatedAt: new Date(),
           },
         })
 
-        if (project.proposedById) {
+        if (comment && comment.trim()) {
+          await prisma.workItemComment.create({
+            data: { workItemId: input.id, authorId: admin.id, content: comment.trim() },
+          })
+        }
+
+        if (project.creatorId) {
           await notifyUser(
-            project.proposedById,
+            project.creatorId,
             'project_approved',
             `Your project '${project.title}' has been approved!`,
             "It's now visible to other volunteers.",
@@ -109,22 +125,28 @@ export const adminProjectsRouter = {
           )
         }
       } else {
-        await prisma.project.update({
+        await prisma.workItem.update({
           where: { id: input.id },
           data: {
             status: ProjectStatus.needs_discussion,
             reviewNotes,
-            feedbackToProposer,
+            stakeholderId: admin.id,
             reviewedById: admin.id,
             reviewedAt: new Date(),
             updatedAt: new Date(),
           },
         })
 
-        if (project.proposedById) {
-          const feedback = feedbackToProposer || 'A team lead wants to chat about your proposal.'
+        if (comment && comment.trim()) {
+          await prisma.workItemComment.create({
+            data: { workItemId: input.id, authorId: admin.id, content: comment.trim() },
+          })
+        }
+
+        if (project.creatorId) {
+          const feedback = comment || 'A team lead wants to chat about your proposal.'
           await notifyUser(
-            project.proposedById,
+            project.creatorId,
             'project_needs_discussion',
             `Let's discuss your project '${project.title}'`,
             feedback,
@@ -147,13 +169,15 @@ export const adminProjectsRouter = {
     .input(z.object({ id: z.number().int() }).merge(OutcomeProjectSchema))
     .handler(async ({ input, context }) => {
       const admin = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.id } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
       const { outcome, outcomeNotes = null } = input
       const isCompleted = ['successful', 'partial', 'not_completed'].includes(outcome)
 
-      await prisma.project.update({
+      await prisma.workItem.update({
         where: { id: input.id },
         data: {
           outcome,
@@ -164,21 +188,22 @@ export const adminProjectsRouter = {
         },
       })
 
-      if (project.ownerId && outcomeNotes) {
+      if (project.assigneeId && outcomeNotes) {
         await prisma.adminNote.create({
           data: {
-            volunteerId: project.ownerId,
+            volunteerId: project.assigneeId,
             authorId: admin.id,
             content: `Project '${project.title}' outcome: ${outcome}. ${outcomeNotes}`,
             category: 'reliability',
-            relatedProjectId: input.id,
+            relatedWorkItemId: input.id,
           },
         })
       }
 
-      if (outcome === 'successful' && project.ownerId) {
-        const projectSkills = await prisma.projectSkill.findMany({
-          where: { projectId: input.id, isRequired: true },
+      if (outcome === 'successful' && project.assigneeId) {
+        const assigneeId = project.assigneeId
+        const projectSkills = await prisma.workItemSkill.findMany({
+          where: { workItemId: input.id, isRequired: true },
           select: { skillId: true },
         })
         await Promise.all(
@@ -186,7 +211,7 @@ export const adminProjectsRouter = {
             prisma.skillEndorsement.upsert({
               where: {
                 volunteerId_skillId_endorsedById: {
-                  volunteerId: project.ownerId!,
+                  volunteerId: assigneeId,
                   skillId: ps.skillId,
                   endorsedById: admin.id,
                 },
@@ -198,7 +223,7 @@ export const adminProjectsRouter = {
                 notes: `Successfully delivered: ${project.title}`,
               },
               create: {
-                volunteerId: project.ownerId!,
+                volunteerId: assigneeId,
                 skillId: ps.skillId,
                 endorsedById: admin.id,
                 source: 'project_outcome',
@@ -215,8 +240,11 @@ export const adminProjectsRouter = {
     }),
 
   triage: adminProcedure.handler(async () => {
-    const projects = await prisma.project.findMany({
-      where: { status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] } },
+    const projects = await prisma.workItem.findMany({
+      where: {
+        type: WorkItemType.PROJECT,
+        status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] },
+      },
       include: projectInclude,
       orderBy: { createdAt: 'asc' },
     })

--- a/server/routers/admin/skills.ts
+++ b/server/routers/admin/skills.ts
@@ -63,7 +63,7 @@ export const adminSkillsRouter = {
     const skill = await prisma.skill.findUnique({ where: { id: input.id } })
     if (!skill) throw new ORPCError('NOT_FOUND', { message: 'Skill not found' })
 
-    await prisma.starterTask.updateMany({ where: { skillId: input.id }, data: { skillId: null } })
+    await prisma.workItem.updateMany({ where: { skillId: input.id }, data: { skillId: null } })
     await prisma.skill.delete({ where: { id: input.id } })
 
     return { success: true, deletedSkill: { id: skill.id, name: skill.name } }

--- a/server/routers/admin/stats.ts
+++ b/server/routers/admin/stats.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { adminProcedure } from '../../procedures'
-import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
+import { InterestStatus, ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const adminStatsRouter = {
   get: adminProcedure.handler(async () => {
@@ -20,15 +20,24 @@ export const adminStatsRouter = {
         SELECT COUNT(*) as count FROM volunteers
         WHERE deleted_at IS NULL AND created_at >= date('now', '-30 days')
       `,
-      prisma.project.count(),
-      prisma.project.count({ where: { status: ProjectStatus.pending_review } }),
-      prisma.project.count({
-        where: { OR: [{ isSeekingHelp: true }, { isSeekingOwner: true }] },
+      prisma.workItem.count({ where: { type: WorkItemType.PROJECT } }),
+      prisma.workItem.count({
+        where: { type: WorkItemType.PROJECT, status: ProjectStatus.pending_review },
       }),
-      prisma.project.count({ where: { status: ProjectStatus.in_progress } }),
-      prisma.project.count({ where: { status: ProjectStatus.completed } }),
-      prisma.projectInterest.count(),
-      prisma.projectInterest.count({ where: { status: InterestStatus.pending } }),
+      prisma.workItem.count({
+        where: {
+          type: WorkItemType.PROJECT,
+          OR: [{ isSeekingHelp: true }, { isSeekingOwner: true }],
+        },
+      }),
+      prisma.workItem.count({
+        where: { type: WorkItemType.PROJECT, status: ProjectStatus.in_progress },
+      }),
+      prisma.workItem.count({
+        where: { type: WorkItemType.PROJECT, status: ProjectStatus.completed },
+      }),
+      prisma.workItemInterest.count(),
+      prisma.workItemInterest.count({ where: { status: InterestStatus.pending } }),
     ])
 
     return {

--- a/server/routers/admin/triage.ts
+++ b/server/routers/admin/triage.ts
@@ -1,8 +1,5 @@
-import { z } from 'zod'
-import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
-import { notifyUser } from '@/lib/notify'
 import { adminProcedure } from '../../procedures'
 import { ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
 
@@ -13,56 +10,9 @@ export const adminTriageRouter = {
         type: WorkItemType.PROJECT,
         status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] },
       },
-      include: {
-        ...projectInclude,
-        comments: {
-          include: { author: { select: { name: true } } },
-          orderBy: { createdAt: 'asc' },
-        },
-      },
+      include: projectInclude,
       orderBy: { createdAt: 'asc' },
     })
-    return projects.map((p) => ({
-      ...withProjectExtras(p as EnrichedProject),
-      comments: p.comments.map((c) => ({
-        id: c.id,
-        authorId: c.authorId,
-        authorName: c.author?.name ?? null,
-        content: c.content,
-        createdAt: c.createdAt,
-      })),
-    }))
+    return projects.map((p) => withProjectExtras(p as EnrichedProject))
   }),
-
-  addComment: adminProcedure
-    .input(z.object({ projectId: z.number().int(), content: z.string().min(1) }))
-    .handler(async ({ input, context }) => {
-      const admin = context.volunteer
-      const project = await prisma.workItem.findFirst({
-        where: { id: input.projectId, type: WorkItemType.PROJECT },
-      })
-      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
-
-      const comment = await prisma.workItemComment.create({
-        data: { workItemId: input.projectId, authorId: admin.id, content: input.content.trim() },
-      })
-
-      if (project.creatorId && project.creatorId !== admin.id) {
-        await notifyUser(
-          project.creatorId,
-          'project_needs_discussion',
-          `New message on your project '${project.title}'`,
-          input.content.slice(0, 200),
-          `/projects/${input.projectId}`,
-          {
-            message: `A team lead added a message to the discussion on <strong>${project.title}</strong>.`,
-            projectTitle: project.title,
-            projectId: input.projectId,
-            extraHtml: `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;">${input.content}</div>`,
-          },
-        )
-      }
-
-      return { id: comment.id, message: 'Comment added' }
-    }),
 }

--- a/server/routers/admin/triage.ts
+++ b/server/routers/admin/triage.ts
@@ -1,15 +1,68 @@
+import { z } from 'zod'
+import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
-import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
+import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
+import { notifyUser } from '@/lib/notify'
 import { adminProcedure } from '../../procedures'
-import { ProjectStatus } from '@/generated/prisma/enums'
+import { ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const adminTriageRouter = {
   list: adminProcedure.handler(async () => {
-    const projects = await prisma.project.findMany({
-      where: { status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] } },
-      include: projectInclude,
+    const projects = await prisma.workItem.findMany({
+      where: {
+        type: WorkItemType.PROJECT,
+        status: { in: [ProjectStatus.pending_review, ProjectStatus.needs_discussion] },
+      },
+      include: {
+        ...projectInclude,
+        comments: {
+          include: { author: { select: { name: true } } },
+          orderBy: { createdAt: 'asc' },
+        },
+      },
       orderBy: { createdAt: 'asc' },
     })
-    return projects.map((p) => withProjectExtras(p as EnrichedProject))
+    return projects.map((p) => ({
+      ...withProjectExtras(p as EnrichedProject),
+      comments: p.comments.map((c) => ({
+        id: c.id,
+        authorId: c.authorId,
+        authorName: c.author?.name ?? null,
+        content: c.content,
+        createdAt: c.createdAt,
+      })),
+    }))
   }),
+
+  addComment: adminProcedure
+    .input(z.object({ projectId: z.number().int(), content: z.string().min(1) }))
+    .handler(async ({ input, context }) => {
+      const admin = context.volunteer
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
+      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
+
+      const comment = await prisma.workItemComment.create({
+        data: { workItemId: input.projectId, authorId: admin.id, content: input.content.trim() },
+      })
+
+      if (project.creatorId && project.creatorId !== admin.id) {
+        await notifyUser(
+          project.creatorId,
+          'project_needs_discussion',
+          `New message on your project '${project.title}'`,
+          input.content.slice(0, 200),
+          `/projects/${input.projectId}`,
+          {
+            message: `A team lead added a message to the discussion on <strong>${project.title}</strong>.`,
+            projectTitle: project.title,
+            projectId: input.projectId,
+            extraHtml: `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;">${input.content}</div>`,
+          },
+        )
+      }
+
+      return { id: comment.id, message: 'Comment added' }
+    }),
 }

--- a/server/routers/admin/volunteers.ts
+++ b/server/routers/admin/volunteers.ts
@@ -3,6 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { redactVolunteer } from '@/lib/auth'
 import { adminProcedure } from '../../procedures'
+import { WorkItemType } from '@/generated/prisma/enums'
 
 const EndorsementInputSchema = z.object({
   skillId: z.number().int({ message: 'skillId is required' }),
@@ -43,13 +44,16 @@ export const adminVolunteersRouter = {
         },
         orderBy: { createdAt: 'desc' },
       }),
-      prisma.starterTask.findMany({
-        where: { assignedToId: input.id },
+      prisma.workItem.findMany({
+        where: { type: WorkItemType.STARTER_TASK, assigneeId: input.id },
         include: { skill: { select: { name: true } } },
         orderBy: { createdAt: 'desc' },
       }),
-      prisma.project.findMany({
-        where: { OR: [{ ownerId: input.id }, { proposedById: input.id }] },
+      prisma.workItem.findMany({
+        where: {
+          type: WorkItemType.PROJECT,
+          OR: [{ assigneeId: input.id }, { creatorId: input.id }],
+        },
         orderBy: { createdAt: 'desc' },
       }),
     ])
@@ -82,7 +86,7 @@ export const adminVolunteersRouter = {
         authorId: n.authorId,
         content: n.content,
         category: n.category,
-        relatedProjectId: n.relatedProjectId,
+        relatedProjectId: n.relatedWorkItemId,
         createdAt: n.createdAt,
         updatedAt: n.updatedAt,
         authorName: n.author.name,
@@ -103,16 +107,15 @@ export const adminVolunteersRouter = {
       })),
       starterTasks: starterTasks.map((t) => ({
         id: t.id,
-        projectId: t.projectId,
+        projectId: t.contextProjectId,
         title: t.title,
         description: t.description,
         skillId: t.skillId,
-        assignedToId: t.assignedToId,
-        assignedById: t.assignedById,
+        assignedToId: t.assigneeId,
+        assignedById: t.creatorId,
         status: t.status,
         reviewRating: t.reviewRating,
         reviewNotes: t.reviewNotes,
-        feedbackToVolunteer: t.feedbackToVolunteer,
         reviewedById: t.reviewedById,
         reviewedAt: t.reviewedAt,
         estimatedHours: t.estimatedHours,
@@ -125,8 +128,8 @@ export const adminVolunteersRouter = {
         title: p.title,
         description: p.description,
         status: p.status,
-        ownerId: p.ownerId,
-        proposedById: p.proposedById,
+        ownerId: p.assigneeId,
+        proposedById: p.creatorId,
         outcome: p.outcome,
         outcomeNotes: p.outcomeNotes,
         completedAt: p.completedAt,

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -26,7 +26,7 @@ import {
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
 import { env } from '@/lib/env'
-import { ApprovalStatus, ProjectStatus } from '@/generated/prisma/enums'
+import { ApprovalStatus, ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
 
 const STUB_EMAIL = env.STUB_EMAIL
 const GOOGLE_CLIENT_ID = env.GOOGLE_CLIENT_ID
@@ -57,21 +57,23 @@ async function sendAccountDeletionNotifications(deletedId: number, deletedName: 
       task_count: number
     }>
   >`
-    SELECT p.owner_id, v.name AS owner_name, v.email AS owner_email,
+    SELECT p.assignee_id AS owner_id, v.name AS owner_name, v.email AS owner_email,
            p.id AS project_id, p.title AS project_title,
            COUNT(st.id) AS task_count
-    FROM starter_tasks st
-    JOIN projects p ON st.project_id = p.id
-    JOIN volunteers v ON p.owner_id = v.id
-    WHERE st.assigned_to_id = ${deletedId}
-      AND st.status NOT IN ('completed', 'reviewed')
-      AND p.owner_id != ${deletedId}
+    FROM work_items st
+    JOIN work_items p ON st.context_project_id = p.id AND p.type = 'PROJECT'
+    JOIN volunteers v ON p.assignee_id = v.id
+    WHERE st.type = 'STARTER_TASK'
+      AND st.assignee_id = ${deletedId}
+      AND st.status NOT IN ('completed')
+      AND p.assignee_id != ${deletedId}
       AND v.deleted_at IS NULL
     GROUP BY p.id
   `
-  const ownedProjects = await prisma.project.findMany({
+  const ownedProjects = await prisma.workItem.findMany({
     where: {
-      ownerId: deletedId,
+      type: WorkItemType.PROJECT,
+      assigneeId: deletedId,
       status: { notIn: [ProjectStatus.completed, ProjectStatus.archived] },
     },
     select: { id: true, title: true },

--- a/server/routers/bugReports.ts
+++ b/server/routers/bugReports.ts
@@ -1,6 +1,6 @@
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
-import { createNotification } from '@/lib/project'
+import { createNotification } from '@/lib/notify'
 import { checkRateLimit } from '@/lib/rate-limit'
 import { CreateBugReportSchema } from '@/lib/schemas'
 import { publicProcedure } from '../procedures'

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma'
-import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
+import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
 import { authedProcedure } from '../procedures'
-import { ProjectStatus } from '@/generated/prisma/enums'
+import { ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const dashboardRouter = {
   get: authedProcedure.handler(async ({ context }) => {
@@ -13,47 +13,49 @@ export const dashboardRouter = {
     })
     const volunteerSkillIds = new Set((volunteerWithSkills?.skills ?? []).map((s) => s.skillId))
 
-    const alreadyInterestedProjects = await prisma.projectInterest.findMany({
+    const alreadyInterestedProjects = await prisma.workItemInterest.findMany({
       where: { volunteerId: volunteer.id },
-      select: { projectId: true },
+      select: { workItemId: true },
     })
-    const interestedProjectIds = alreadyInterestedProjects.map((i) => i.projectId)
+    const interestedProjectIds = alreadyInterestedProjects.map((i) => i.workItemId)
 
     const [ownedProjects, proposedProjects, myInterests, suggestedProjects, unreadCount] =
       await Promise.all([
-        prisma.project.findMany({
-          where: { ownerId: volunteer.id },
+        prisma.workItem.findMany({
+          where: { type: WorkItemType.PROJECT, assigneeId: volunteer.id },
           orderBy: { updatedAt: 'desc' },
           include: projectInclude,
         }),
 
-        prisma.project.findMany({
+        prisma.workItem.findMany({
           where: {
-            proposedById: volunteer.id,
-            OR: [{ ownerId: null }, { ownerId: { not: volunteer.id } }],
+            type: WorkItemType.PROJECT,
+            creatorId: volunteer.id,
+            OR: [{ assigneeId: null }, { assigneeId: { not: volunteer.id } }],
           },
           orderBy: { createdAt: 'desc' },
           include: projectInclude,
         }),
 
-        prisma.projectInterest.findMany({
+        prisma.workItemInterest.findMany({
           where: { volunteerId: volunteer.id },
           orderBy: { createdAt: 'desc' },
           include: {
-            project: { include: projectInclude },
+            workItem: { include: projectInclude },
           },
         }),
 
         volunteerSkillIds.size > 0
-          ? prisma.project.findMany({
+          ? prisma.workItem.findMany({
               where: {
+                type: WorkItemType.PROJECT,
                 skills: { some: { skillId: { in: [...volunteerSkillIds] } } },
                 OR: [
                   { isSeekingHelp: true },
                   { isSeekingOwner: true },
                   { status: { in: [ProjectStatus.seeking_owner, ProjectStatus.seeking_help] } },
                 ],
-                ownerId: { not: volunteer.id },
+                assigneeId: { not: volunteer.id },
                 id: { notIn: interestedProjectIds.length > 0 ? interestedProjectIds : [-1] },
               },
               orderBy: { createdAt: 'desc' },
@@ -78,7 +80,7 @@ export const dashboardRouter = {
         interestCreatedAt: i.createdAt,
         interestResponseMessage: i.responseMessage,
         interestRespondedAt: i.respondedAt,
-        ...withProjectExtras(i.project as EnrichedProject, volunteerSkillIds),
+        ...withProjectExtras(i.workItem as EnrichedProject, volunteerSkillIds),
       })),
       suggestedProjects: suggestedProjects.map((p) =>
         withProjectExtras(p as EnrichedProject, volunteerSkillIds),

--- a/server/routers/messages.ts
+++ b/server/routers/messages.ts
@@ -3,6 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { sendRelayMessage, isEmailConfigured } from '@/lib/email'
 import { authedProcedure } from '../procedures'
+import { WorkItemType } from '@/generated/prisma/enums'
 
 const ContactSchema = z.object({
   recipientId: z.number().int(),
@@ -36,7 +37,7 @@ export const messagesRouter = {
         toVolunteerId: m.toVolunteerId,
         subject: m.subject,
         message: m.message,
-        relatedProjectId: m.relatedProjectId,
+        relatedProjectId: m.relatedWorkItemId,
         readAt: m.readAt,
         createdAt: m.createdAt,
         fromName: m.from.name,
@@ -47,7 +48,7 @@ export const messagesRouter = {
         toVolunteerId: m.toVolunteerId,
         subject: m.subject,
         message: m.message,
-        relatedProjectId: m.relatedProjectId,
+        relatedProjectId: m.relatedWorkItemId,
         readAt: m.readAt,
         createdAt: m.createdAt,
         toName: m.to.name,
@@ -87,8 +88,8 @@ export const messagesRouter = {
 
     let projectTitle: string | null = null
     if (input.relatedProjectId) {
-      const project = await prisma.project.findUnique({
-        where: { id: input.relatedProjectId },
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.relatedProjectId, type: WorkItemType.PROJECT },
         select: { title: true },
       })
       if (project) projectTitle = project.title
@@ -101,7 +102,7 @@ export const messagesRouter = {
           toVolunteerId: input.recipientId,
           subject: input.subject,
           message: input.message,
-          relatedProjectId: input.relatedProjectId ?? null,
+          relatedWorkItemId: input.relatedProjectId ?? null,
         },
       })
       await tx.notification.create({

--- a/server/routers/my.ts
+++ b/server/routers/my.ts
@@ -1,31 +1,31 @@
 import { prisma } from '@/lib/prisma'
 import { authedProcedure } from '../procedures'
+import { WorkItemType } from '@/generated/prisma/enums'
 
 export const myRouter = {
   starterTasks: authedProcedure.handler(async ({ context }) => {
-    const tasks = await prisma.starterTask.findMany({
-      where: { assignedToId: context.volunteer.id },
+    const tasks = await prisma.workItem.findMany({
+      where: { type: WorkItemType.STARTER_TASK, assigneeId: context.volunteer.id },
       include: {
         skill: true,
-        project: { select: { title: true } },
+        contextProject: { select: { title: true } },
       },
       orderBy: { createdAt: 'desc' },
     })
 
     return tasks.map((t) => ({
       id: t.id,
-      projectId: t.projectId,
+      projectId: t.contextProjectId,
       title: t.title,
       description: t.description,
       skillId: t.skillId,
       skillName: t.skill?.name ?? null,
-      projectTitle: t.project?.title ?? null,
-      assignedToId: t.assignedToId,
-      assignedById: t.assignedById,
+      projectTitle: t.contextProject?.title ?? null,
+      assignedToId: t.assigneeId,
+      assignedById: t.creatorId,
       status: t.status,
       reviewRating: t.reviewRating,
       reviewNotes: t.reviewNotes,
-      feedbackToVolunteer: t.feedbackToVolunteer,
       reviewedById: t.reviewedById,
       reviewedAt: t.reviewedAt,
       estimatedHours: t.estimatedHours,

--- a/server/routers/privacy.ts
+++ b/server/routers/privacy.ts
@@ -2,6 +2,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { redactVolunteer } from '@/lib/auth'
 import { authedProcedure } from '../procedures'
+import { WorkItemType } from '@/generated/prisma/enums'
 
 export const privacyRouter = {
   export: authedProcedure.handler(async ({ context }) => {
@@ -12,11 +13,14 @@ export const privacyRouter = {
           skills: { include: { skill: { include: { category: true } } } },
         },
       }),
-      prisma.projectInterest.findMany({ where: { volunteerId: context.volunteer.id } }),
+      prisma.workItemInterest.findMany({ where: { volunteerId: context.volunteer.id } }),
       prisma.message.findMany({ where: { fromVolunteerId: context.volunteer.id } }),
       prisma.message.findMany({ where: { toVolunteerId: context.volunteer.id } }),
-      prisma.project.findMany({
-        where: { OR: [{ ownerId: context.volunteer.id }, { proposedById: context.volunteer.id }] },
+      prisma.workItem.findMany({
+        where: {
+          type: WorkItemType.PROJECT,
+          OR: [{ assigneeId: context.volunteer.id }, { creatorId: context.volunteer.id }],
+        },
       }),
     ])
 
@@ -47,8 +51,8 @@ export const privacyRouter = {
         title: p.title,
         description: p.description,
         status: p.status,
-        ownerId: p.ownerId,
-        proposedById: p.proposedById,
+        ownerId: p.assigneeId,
+        proposedById: p.creatorId,
         outcome: p.outcome,
         outcomeNotes: p.outcomeNotes,
         createdAt: p.createdAt,
@@ -56,7 +60,7 @@ export const privacyRouter = {
       })),
       interests: interests.map((i) => ({
         id: i.id,
-        projectId: i.projectId,
+        projectId: i.workItemId,
         interestType: i.interestType,
         message: i.message,
         status: i.status,
@@ -68,7 +72,7 @@ export const privacyRouter = {
         toVolunteerId: m.toVolunteerId,
         subject: m.subject,
         message: m.message,
-        relatedProjectId: m.relatedProjectId,
+        relatedProjectId: m.relatedWorkItemId,
         createdAt: m.createdAt,
       })),
       messagesReceived: messagesReceived.map((m) => ({
@@ -76,7 +80,7 @@ export const privacyRouter = {
         fromVolunteerId: m.fromVolunteerId,
         subject: m.subject,
         message: m.message,
-        relatedProjectId: m.relatedProjectId,
+        relatedProjectId: m.relatedWorkItemId,
         readAt: m.readAt,
         createdAt: m.createdAt,
       })),

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -10,7 +10,6 @@ import {
   ProjectInterestBodySchema,
   CreateProjectTaskSchema,
   UpdateProjectTaskSchema,
-  CreateProjectUpdateSchema,
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure, adminProcedure } from '../procedures'
 import {
@@ -303,34 +302,18 @@ export const projectsRouter = {
 
       const base = withProjectExtras(project as EnrichedProject, volunteerSkillIds)
 
-      const [comments, tasks] = await Promise.all([
-        prisma.workItemComment.findMany({
-          where: { workItemId: input.id },
-          include: { author: { select: { name: true } } },
-          orderBy: { createdAt: 'asc' },
-        }),
-        prisma.workItem.findMany({
-          where: { parentId: input.id, type: WorkItemType.TASK },
-          include: {
-            assignee: { select: { name: true } },
-            creator: { select: { name: true } },
-          },
-          orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
-        }),
-      ])
+      const tasks = await prisma.workItem.findMany({
+        where: { parentId: input.id, type: WorkItemType.TASK },
+        include: {
+          assignee: { select: { name: true } },
+          creator: { select: { name: true } },
+        },
+        orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+      })
 
       const sortedTasks = tasks.sort(
         (a, b) => (TASK_ORDER[a.status] ?? 0) - (TASK_ORDER[b.status] ?? 0),
       )
-
-      const mappedComments = comments.map((c) => ({
-        id: c.id,
-        workItemId: c.workItemId,
-        authorId: c.authorId,
-        content: c.content,
-        createdAt: c.createdAt,
-        authorName: c.author?.name ?? null,
-      }))
 
       const mappedTasks = sortedTasks.map((t) => ({
         id: t.id,
@@ -446,7 +429,6 @@ export const projectsRouter = {
       return {
         ...base,
         ...(isPending && { owner: null, ownerId: null, proposedBy: null, proposedById: null }),
-        comments: mappedComments,
         tasks: mappedTasks,
         interests,
         myInterest,
@@ -988,25 +970,5 @@ export const projectsRouter = {
       })
       if (deleted.count === 0) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
       return { message: 'Task deleted' }
-    }),
-
-  createUpdate: authedProcedure
-    .input(z.object({ projectId: z.number().int() }).merge(CreateProjectUpdateSchema))
-    .handler(async ({ input, context }) => {
-      const volunteer = context.volunteer
-      const project = await prisma.workItem.findFirst({
-        where: { id: input.projectId, type: WorkItemType.PROJECT },
-      })
-      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
-
-      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
-        throw new ORPCError('FORBIDDEN', { message: 'Only project owner can add updates' })
-      }
-
-      const comment = await prisma.workItemComment.create({
-        data: { workItemId: input.projectId, authorId: volunteer.id, content: input.content },
-      })
-
-      return { id: comment.id, message: 'Update added' }
     }),
 }

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { Prisma } from '@/generated/prisma/client'
 import { prisma } from '@/lib/prisma'
-import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/project'
+import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
 import { notifyUser } from '@/lib/notify'
 import {
   CreateProjectSchema,
@@ -13,7 +13,13 @@ import {
   CreateProjectUpdateSchema,
 } from '@/lib/schemas'
 import { publicProcedure, authedProcedure, adminProcedure } from '../procedures'
-import { ApprovalStatus, InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
+import {
+  ApprovalStatus,
+  InterestStatus,
+  ProjectStatus,
+  TaskStatus,
+  WorkItemType,
+} from '@/generated/prisma/enums'
 
 const STATUS_LABELS: Record<string, string> = {
   seeking_owner: 'Seeking Owner',
@@ -33,6 +39,12 @@ const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
   ProjectStatus.on_hold,
   ProjectStatus.completed,
 ]
+
+const TASK_ORDER: Record<string, number> = {
+  [TaskStatus.open]: 0,
+  [TaskStatus.in_progress]: 1,
+  [TaskStatus.completed]: 2,
+}
 
 export const projectsRouter = {
   list: publicProcedure
@@ -76,7 +88,7 @@ export const projectsRouter = {
         volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
       }
 
-      const conditions: Prisma.Sql[] = []
+      const conditions: Prisma.Sql[] = [Prisma.sql`type = ${WorkItemType.PROJECT}`]
 
       if (input.status) {
         conditions.push(Prisma.sql`status = ${input.status}`)
@@ -90,7 +102,7 @@ export const projectsRouter = {
 
       if (input.skillIds && input.skillIds.length > 0) {
         conditions.push(
-          Prisma.sql`id IN (SELECT project_id FROM project_skills WHERE skill_id IN (${Prisma.join(input.skillIds)}))`,
+          Prisma.sql`id IN (SELECT work_item_id FROM work_item_skills WHERE skill_id IN (${Prisma.join(input.skillIds)}))`,
         )
       }
 
@@ -128,20 +140,20 @@ export const projectsRouter = {
       const [countResult, idRows] = await Promise.all([
         prisma.$queryRaw<
           [{ count: bigint }]
-        >`SELECT COUNT(*) as count FROM projects ${whereClause}`,
+        >`SELECT COUNT(*) as count FROM work_items ${whereClause}`,
         input.sortBy === 'match'
           ? prisma.$queryRaw<
               { id: number }[]
-            >`SELECT id FROM projects ${whereClause} ${orderClause}`
+            >`SELECT id FROM work_items ${whereClause} ${orderClause}`
           : prisma.$queryRaw<
               { id: number }[]
-            >`SELECT id FROM projects ${whereClause} ${orderClause} LIMIT ${input.limit} OFFSET ${input.offset}`,
+            >`SELECT id FROM work_items ${whereClause} ${orderClause} LIMIT ${input.limit} OFFSET ${input.offset}`,
       ])
 
       const total = Number(countResult[0].count)
       const ids = idRows.map((r) => r.id)
 
-      const rawProjects = await prisma.project.findMany({
+      const rawProjects = await prisma.workItem.findMany({
         where: { id: { in: ids } },
         include: projectInclude,
       })
@@ -186,13 +198,14 @@ export const projectsRouter = {
     }
 
     const project = await prisma.$transaction(async (tx) => {
-      const newProject = await tx.project.create({
+      const newProject = await tx.workItem.create({
         data: {
+          type: WorkItemType.PROJECT,
           title: input.title,
           description: input.description,
           status: ProjectStatus.pending_review,
-          ownerId: wantToOwn ? volunteer.id : null,
-          proposedById: volunteer.id,
+          assigneeId: wantToOwn ? volunteer.id : null,
+          creatorId: volunteer.id,
           isOrgProposed: false,
           projectType: input.projectType ?? null,
           estimatedDuration: input.estimatedDuration ?? null,
@@ -207,21 +220,23 @@ export const projectsRouter = {
       })
 
       if (skillIds.length > 0) {
-        await tx.projectSkill.createMany({
+        await tx.workItemSkill.createMany({
           data: skillIds.map((skillId) => ({
-            projectId: newProject.id,
+            workItemId: newProject.id,
             skillId,
             isRequired: skillRequiredMap[skillId] !== false,
           })),
         })
       }
 
-      await tx.projectTask.createMany({
+      await tx.workItem.createMany({
         data: tasks.map((t) => ({
-          projectId: newProject.id,
+          type: WorkItemType.TASK,
+          status: TaskStatus.open,
+          parentId: newProject.id,
           title: t.title,
           description: t.description ?? null,
-          createdById: volunteer.id,
+          creatorId: volunteer.id,
         })),
       })
 
@@ -259,21 +274,21 @@ export const projectsRouter = {
         volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
       )
 
-      const project = await prisma.project.findUnique({
-        where: { id: input.id },
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.PROJECT },
         include: projectInclude,
       })
 
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      const hiddenStatuses: ProjectStatus[] = [
+      const hiddenStatuses: string[] = [
         ProjectStatus.pending_review,
         ProjectStatus.needs_discussion,
       ]
       if (hiddenStatuses.includes(project.status)) {
         if (!volunteer) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
-        const isProposer = project.proposedById === volunteer.id
-        if (!isProposer && !volunteer.isAdmin)
+        const isCreator = project.creatorId === volunteer.id
+        if (!isCreator && !volunteer.isAdmin)
           throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
       }
 
@@ -288,45 +303,44 @@ export const projectsRouter = {
 
       const base = withProjectExtras(project as EnrichedProject, volunteerSkillIds)
 
-      const [updates, tasks] = await Promise.all([
-        prisma.projectUpdate.findMany({
-          where: { projectId: input.id },
+      const [comments, tasks] = await Promise.all([
+        prisma.workItemComment.findMany({
+          where: { workItemId: input.id },
           include: { author: { select: { name: true } } },
-          orderBy: { createdAt: 'desc' },
+          orderBy: { createdAt: 'asc' },
         }),
-        prisma.projectTask.findMany({
-          where: { projectId: input.id },
+        prisma.workItem.findMany({
+          where: { parentId: input.id, type: WorkItemType.TASK },
           include: {
-            assignedTo: { select: { name: true } },
-            createdBy: { select: { name: true } },
+            assignee: { select: { name: true } },
+            creator: { select: { name: true } },
           },
           orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
         }),
       ])
 
-      const taskOrder: Record<string, number> = { open: 0, assigned: 1, done: 2 }
       const sortedTasks = tasks.sort(
-        (a, b) => (taskOrder[a.status] ?? 0) - (taskOrder[b.status] ?? 0),
+        (a, b) => (TASK_ORDER[a.status] ?? 0) - (TASK_ORDER[b.status] ?? 0),
       )
 
-      const mappedUpdates = updates.map((u) => ({
-        id: u.id,
-        projectId: u.projectId,
-        authorId: u.authorId,
-        content: u.content,
-        createdAt: u.createdAt,
-        authorName: u.author?.name ?? null,
+      const mappedComments = comments.map((c) => ({
+        id: c.id,
+        workItemId: c.workItemId,
+        authorId: c.authorId,
+        content: c.content,
+        createdAt: c.createdAt,
+        authorName: c.author?.name ?? null,
       }))
 
       const mappedTasks = sortedTasks.map((t) => ({
         id: t.id,
-        projectId: t.projectId,
+        projectId: t.parentId,
         title: t.title,
         description: t.description,
-        assignedToId: isPending ? null : t.assignedToId,
-        assignedToName: isPending ? null : (t.assignedTo?.name ?? null),
-        createdById: isPending ? null : t.createdById,
-        createdByName: isPending ? null : (t.createdBy?.name ?? null),
+        assignedToId: isPending ? null : t.assigneeId,
+        assignedToName: isPending ? null : (t.assignee?.name ?? null),
+        createdById: isPending ? null : t.creatorId,
+        createdByName: isPending ? null : (t.creator?.name ?? null),
         status: t.status,
         completedAt: t.completedAt,
         createdAt: t.createdAt,
@@ -370,10 +384,10 @@ export const projectsRouter = {
         | undefined
 
       if (volunteer) {
-        const isOwner = project.ownerId === volunteer.id
-        if (isOwner || volunteer.isAdmin) {
-          const rawInterests = await prisma.projectInterest.findMany({
-            where: { projectId: input.id },
+        const isAssignee = project.assigneeId === volunteer.id
+        if (isAssignee || volunteer.isAdmin) {
+          const rawInterests = await prisma.workItemInterest.findMany({
+            where: { workItemId: input.id },
             include: {
               volunteer: {
                 select: {
@@ -389,7 +403,7 @@ export const projectsRouter = {
           interests = rawInterests.map((i) => ({
             id: i.id,
             volunteerId: i.volunteerId,
-            projectId: i.projectId,
+            projectId: i.workItemId,
             interestType: i.interestType,
             message: i.message,
             status: i.status,
@@ -407,9 +421,9 @@ export const projectsRouter = {
           }))
         }
 
-        const rawMyInterest = await prisma.projectInterest.findFirst({
+        const rawMyInterest = await prisma.workItemInterest.findFirst({
           where: {
-            projectId: input.id,
+            workItemId: input.id,
             volunteerId: volunteer.id,
             status: { not: InterestStatus.withdrawn },
           },
@@ -418,7 +432,7 @@ export const projectsRouter = {
           ? {
               id: rawMyInterest.id,
               volunteerId: rawMyInterest.volunteerId,
-              projectId: rawMyInterest.projectId,
+              projectId: rawMyInterest.workItemId,
               interestType: rawMyInterest.interestType,
               message: rawMyInterest.message,
               status: rawMyInterest.status,
@@ -432,7 +446,7 @@ export const projectsRouter = {
       return {
         ...base,
         ...(isPending && { owner: null, ownerId: null, proposedBy: null, proposedById: null }),
-        updates: mappedUpdates,
+        comments: mappedComments,
         tasks: mappedTasks,
         interests,
         myInterest,
@@ -443,12 +457,14 @@ export const projectsRouter = {
     .input(z.object({ id: z.number().int() }).merge(UpdateProjectSchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.id } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      const isOwner = project.ownerId === volunteer.id
-      const isProposer = project.proposedById === volunteer.id
-      if (!isOwner && !isProposer && !volunteer.isAdmin) {
+      const isAssignee = project.assigneeId === volunteer.id
+      const isCreator = project.creatorId === volunteer.id
+      if (!isAssignee && !isCreator && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized to edit this project' })
       }
 
@@ -460,8 +476,12 @@ export const projectsRouter = {
         newStatus === ProjectStatus.in_progress &&
         project.status !== ProjectStatus.in_progress
       ) {
-        const openTaskCount = await prisma.projectTask.count({
-          where: { projectId: input.id, status: { not: TaskStatus.done } },
+        const openTaskCount = await prisma.workItem.count({
+          where: {
+            parentId: input.id,
+            type: WorkItemType.TASK,
+            status: { not: TaskStatus.completed },
+          },
         })
         if (openTaskCount === 0) {
           throw new ORPCError('BAD_REQUEST', {
@@ -488,12 +508,12 @@ export const projectsRouter = {
       }
       if (body.timeCommitmentHoursPerWeek !== undefined)
         data.timeCommitmentHoursPerWeek = body.timeCommitmentHoursPerWeek
-      if (body.ownerId !== undefined) data.ownerId = body.ownerId
+      if (body.assigneeId !== undefined) data.assigneeId = body.assigneeId
 
       if (newStatus !== undefined) {
         if (volunteer.isAdmin) {
           data.status = newStatus
-        } else if (isOwner && OWNER_ALLOWED_STATUSES.includes(newStatus)) {
+        } else if (isAssignee && OWNER_ALLOWED_STATUSES.includes(newStatus as ProjectStatus)) {
           data.status = newStatus
         }
       }
@@ -507,15 +527,15 @@ export const projectsRouter = {
       }
 
       data.updatedAt = new Date()
-      await prisma.project.update({ where: { id: input.id }, data })
+      await prisma.workItem.update({ where: { id: input.id }, data })
 
       if (body.skillIds !== undefined) {
         const skillRequiredMap = body.skillRequiredMap ?? {}
-        await prisma.projectSkill.deleteMany({ where: { projectId: input.id } })
+        await prisma.workItemSkill.deleteMany({ where: { workItemId: input.id } })
         if (body.skillIds.length > 0) {
-          await prisma.projectSkill.createMany({
+          await prisma.workItemSkill.createMany({
             data: body.skillIds.map((skillId) => ({
-              projectId: input.id,
+              workItemId: input.id,
               skillId,
               isRequired: skillRequiredMap[skillId] !== false,
             })),
@@ -526,12 +546,13 @@ export const projectsRouter = {
       if (newStatus && newStatus !== project.status) {
         const statusLabel = STATUS_LABELS[newStatus] ?? newStatus
         const notifyIds = new Set<number>()
-        if (project.ownerId && project.ownerId !== volunteer.id) notifyIds.add(project.ownerId)
-        if (project.proposedById && project.proposedById !== volunteer.id)
-          notifyIds.add(project.proposedById)
+        if (project.assigneeId && project.assigneeId !== volunteer.id)
+          notifyIds.add(project.assigneeId)
+        if (project.creatorId && project.creatorId !== volunteer.id)
+          notifyIds.add(project.creatorId)
 
-        const accepted = await prisma.projectInterest.findMany({
-          where: { projectId: input.id, status: InterestStatus.accepted },
+        const accepted = await prisma.workItemInterest.findMany({
+          where: { workItemId: input.id, status: InterestStatus.accepted },
           select: { volunteerId: true },
         })
         for (const row of accepted) {
@@ -554,7 +575,7 @@ export const projectsRouter = {
         }
       }
 
-      const updated = await prisma.project.findUnique({
+      const updated = await prisma.workItem.findUnique({
         where: { id: input.id },
         include: projectInclude,
       })
@@ -562,9 +583,11 @@ export const projectsRouter = {
     }),
 
   delete: adminProcedure.input(z.object({ id: z.number().int() })).handler(async ({ input }) => {
-    const project = await prisma.project.findUnique({ where: { id: input.id } })
+    const project = await prisma.workItem.findFirst({
+      where: { id: input.id, type: WorkItemType.PROJECT },
+    })
     if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
-    await prisma.project.delete({ where: { id: input.id } })
+    await prisma.workItem.delete({ where: { id: input.id } })
     return { message: `Project '${project.title}' deleted` }
   }),
 
@@ -576,9 +599,10 @@ export const projectsRouter = {
         throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
       }
 
-      const project = await prisma.project.findFirst({
+      const project = await prisma.workItem.findFirst({
         where: {
           id: input.projectId,
+          type: WorkItemType.PROJECT,
           status: { notIn: [ProjectStatus.completed, ProjectStatus.archived] },
           OR: [
             { isSeekingHelp: true },
@@ -593,8 +617,8 @@ export const projectsRouter = {
         })
       }
 
-      const existing = await prisma.projectInterest.findFirst({
-        where: { projectId: input.projectId, volunteerId: volunteer.id },
+      const existing = await prisma.workItemInterest.findFirst({
+        where: { workItemId: input.projectId, volunteerId: volunteer.id },
       })
       if (existing && existing.status !== InterestStatus.withdrawn) {
         throw new ORPCError('BAD_REQUEST', { message: "You've already expressed interest" })
@@ -603,9 +627,9 @@ export const projectsRouter = {
       const { interestType, message = null } = input
 
       if (existing) {
-        await prisma.projectInterest.update({
+        await prisma.workItemInterest.update({
           where: {
-            volunteerId_projectId: { volunteerId: volunteer.id, projectId: input.projectId },
+            volunteerId_workItemId: { volunteerId: volunteer.id, workItemId: input.projectId },
           },
           data: {
             interestType,
@@ -616,10 +640,10 @@ export const projectsRouter = {
           },
         })
       } else {
-        await prisma.projectInterest.create({
+        await prisma.workItemInterest.create({
           data: {
             volunteerId: volunteer.id,
-            projectId: input.projectId,
+            workItemId: input.projectId,
             interestType,
             message,
             status: InterestStatus.pending,
@@ -629,9 +653,9 @@ export const projectsRouter = {
 
       const interestLabel = interestType === 'want_to_own' ? 'own / lead' : 'contribute to'
 
-      if (project.ownerId) {
+      if (project.assigneeId) {
         await notifyUser(
-          project.ownerId,
+          project.assigneeId,
           'new_interest',
           `Someone's interested in '${project.title}'!`,
           `${volunteer.name} wants to ${interestLabel}`,
@@ -654,9 +678,9 @@ export const projectsRouter = {
   withdrawInterest: authedProcedure
     .input(z.object({ projectId: z.number().int() }))
     .handler(async ({ input, context }) => {
-      const result = await prisma.projectInterest.updateMany({
+      const result = await prisma.workItemInterest.updateMany({
         where: {
-          projectId: input.projectId,
+          workItemId: input.projectId,
           volunteerId: context.volunteer.id,
           status: InterestStatus.pending,
         },
@@ -678,18 +702,20 @@ export const projectsRouter = {
     )
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.projectId } })
-      const isOwner = project && project.ownerId === volunteer.id
-      if (!project || (!isOwner && !volunteer.isAdmin)) {
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
+      const isAssignee = project && project.assigneeId === volunteer.id
+      if (!project || (!isAssignee && !volunteer.isAdmin)) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized' })
       }
 
-      const interest = await prisma.projectInterest.findFirst({
-        where: { id: input.interestId, projectId: input.projectId },
+      const interest = await prisma.workItemInterest.findFirst({
+        where: { id: input.interestId, workItemId: input.projectId },
       })
       if (!interest) throw new ORPCError('NOT_FOUND', { message: 'Interest not found' })
 
-      await prisma.projectInterest.update({
+      await prisma.workItemInterest.update({
         where: { id: input.interestId },
         data: {
           status: input.status,
@@ -699,13 +725,17 @@ export const projectsRouter = {
       })
 
       if (input.status === InterestStatus.accepted && interest.interestType === 'want_to_own') {
-        const openTaskCount = await prisma.projectTask.count({
-          where: { projectId: input.projectId, status: { not: TaskStatus.done } },
+        const openTaskCount = await prisma.workItem.count({
+          where: {
+            parentId: input.projectId,
+            type: WorkItemType.TASK,
+            status: { not: TaskStatus.completed },
+          },
         })
-        await prisma.project.update({
+        await prisma.workItem.update({
           where: { id: input.projectId },
           data: {
-            ownerId: interest.volunteerId,
+            assigneeId: interest.volunteerId,
             status: openTaskCount > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks,
           },
         })
@@ -740,18 +770,20 @@ export const projectsRouter = {
     )
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.projectId } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.ownerId !== volunteer.id && !volunteer.isAdmin) {
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', {
           message: 'Only project owner or admin can assign volunteers',
         })
       }
 
-      const existing = await prisma.projectInterest.findFirst({
+      const existing = await prisma.workItemInterest.findFirst({
         where: {
-          projectId: input.projectId,
+          workItemId: input.projectId,
           volunteerId: input.volunteerId,
           status: { not: InterestStatus.withdrawn },
         },
@@ -759,7 +791,7 @@ export const projectsRouter = {
 
       if (existing) {
         if (existing.status === InterestStatus.pending) {
-          await prisma.projectInterest.update({
+          await prisma.workItemInterest.update({
             where: { id: existing.id },
             data: { status: InterestStatus.accepted, respondedAt: new Date() },
           })
@@ -767,10 +799,10 @@ export const projectsRouter = {
           return { message: 'This volunteer is already assigned to this project' }
         }
       } else {
-        await prisma.projectInterest.create({
+        await prisma.workItemInterest.create({
           data: {
             volunteerId: input.volunteerId,
-            projectId: input.projectId,
+            workItemId: input.projectId,
             interestType: input.interestType,
             message: 'Assigned by admin/owner',
             status: InterestStatus.accepted,
@@ -780,7 +812,7 @@ export const projectsRouter = {
       }
 
       if (input.interestType === 'want_to_own' && project.isSeekingOwner) {
-        await prisma.project.update({
+        await prisma.workItem.update({
           where: { id: input.projectId },
           data: { isSeekingOwner: false },
         })
@@ -810,30 +842,29 @@ export const projectsRouter = {
         volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
       )
 
-      const tasks = await prisma.projectTask.findMany({
-        where: { projectId: input.projectId },
+      const tasks = await prisma.workItem.findMany({
+        where: { parentId: input.projectId, type: WorkItemType.TASK },
         include: {
-          assignedTo: { select: { name: true } },
-          createdBy: { select: { name: true } },
+          assignee: { select: { name: true } },
+          creator: { select: { name: true } },
         },
       })
 
-      const taskOrder: Record<string, number> = { open: 0, assigned: 1, done: 2 }
       tasks.sort((a, b) => {
-        const orderDiff = (taskOrder[a.status] ?? 0) - (taskOrder[b.status] ?? 0)
+        const orderDiff = (TASK_ORDER[a.status] ?? 0) - (TASK_ORDER[b.status] ?? 0)
         if (orderDiff !== 0) return orderDiff
         return (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0)
       })
 
       return tasks.map((t) => ({
         id: t.id,
-        projectId: t.projectId,
+        projectId: t.parentId,
         title: t.title,
         description: t.description,
-        assignedToId: isPending ? null : t.assignedToId,
-        assignedToName: isPending ? null : (t.assignedTo?.name ?? null),
-        createdById: isPending ? null : t.createdById,
-        createdByName: isPending ? null : (t.createdBy?.name ?? null),
+        assignedToId: isPending ? null : t.assigneeId,
+        assignedToName: isPending ? null : (t.assignee?.name ?? null),
+        createdById: isPending ? null : t.creatorId,
+        createdByName: isPending ? null : (t.creator?.name ?? null),
         status: t.status,
         completedAt: t.completedAt,
         createdAt: t.createdAt,
@@ -845,26 +876,30 @@ export const projectsRouter = {
     .input(z.object({ projectId: z.number().int() }).merge(CreateProjectTaskSchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.projectId } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.ownerId !== volunteer.id && !volunteer.isAdmin) {
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', {
           message: 'Only project owner or admin can create tasks',
         })
       }
 
       const task = await prisma.$transaction(async (tx) => {
-        const newTask = await tx.projectTask.create({
+        const newTask = await tx.workItem.create({
           data: {
-            projectId: input.projectId,
+            type: WorkItemType.TASK,
+            status: TaskStatus.open,
+            parentId: input.projectId,
             title: input.title,
             description: input.description ?? null,
-            createdById: volunteer.id,
+            creatorId: volunteer.id,
           },
         })
         if (project.status === ProjectStatus.needs_tasks) {
-          await tx.project.update({
+          await tx.workItem.update({
             where: { id: input.projectId },
             data: { status: ProjectStatus.in_progress },
           })
@@ -887,25 +922,29 @@ export const projectsRouter = {
       const volunteer = context.volunteer
 
       const [project, task] = await Promise.all([
-        prisma.project.findUnique({ where: { id: input.projectId } }),
-        prisma.projectTask.findFirst({ where: { id: input.taskId, projectId: input.projectId } }),
+        prisma.workItem.findFirst({ where: { id: input.projectId, type: WorkItemType.PROJECT } }),
+        prisma.workItem.findFirst({
+          where: { id: input.taskId, parentId: input.projectId, type: WorkItemType.TASK },
+        }),
       ])
 
       if (!project || !task)
         throw new ORPCError('NOT_FOUND', { message: 'Project or task not found' })
 
-      const isOwner = project.ownerId === volunteer.id
-      const isAssignee = task.assignedToId === volunteer.id
+      const isAssignee = project.assigneeId === volunteer.id
+      const isTaskAssignee = task.assigneeId === volunteer.id
 
-      if (!isOwner && !volunteer.isAdmin) {
+      if (!isAssignee && !volunteer.isAdmin) {
         const newStatus = input.data.status
-        const newAssignedToId = input.data.assignedToId
+        const newAssigneeId = input.data.assigneeId
         const isSelfClaim =
-          newStatus === TaskStatus.assigned &&
-          newAssignedToId === volunteer.id &&
+          newStatus === TaskStatus.in_progress &&
+          newAssigneeId === volunteer.id &&
           task.status === TaskStatus.open
         const isMarkingDone =
-          newStatus === TaskStatus.done && isAssignee && task.status === TaskStatus.assigned
+          newStatus === TaskStatus.completed &&
+          isTaskAssignee &&
+          task.status === TaskStatus.in_progress
         if (!isSelfClaim && !isMarkingDone) {
           throw new ORPCError('FORBIDDEN', { message: 'Not authorized to update this task' })
         }
@@ -916,18 +955,18 @@ export const projectsRouter = {
       if (input.data.description !== undefined) data.description = input.data.description
       if (input.data.status !== undefined) {
         data.status = input.data.status
-        if (input.data.status === TaskStatus.done) data.completedAt = new Date()
+        if (input.data.status === TaskStatus.completed) data.completedAt = new Date()
         else if (input.data.status === TaskStatus.open) {
-          data.assignedToId = null
+          data.assigneeId = null
           data.completedAt = null
         }
       }
-      if (input.data.assignedToId !== undefined) data.assignedToId = input.data.assignedToId
+      if (input.data.assigneeId !== undefined) data.assigneeId = input.data.assigneeId
       data.updatedAt = new Date()
       data.nudgeSentAt = null
       data.finalWarningSentAt = null
 
-      await prisma.projectTask.update({ where: { id: input.taskId }, data })
+      await prisma.workItem.update({ where: { id: input.taskId }, data })
       return { message: 'Task updated' }
     }),
 
@@ -935,15 +974,17 @@ export const projectsRouter = {
     .input(z.object({ projectId: z.number().int(), taskId: z.number().int() }))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.projectId } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.ownerId !== volunteer.id && !volunteer.isAdmin) {
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized' })
       }
 
-      const deleted = await prisma.projectTask.deleteMany({
-        where: { id: input.taskId, projectId: input.projectId },
+      const deleted = await prisma.workItem.deleteMany({
+        where: { id: input.taskId, parentId: input.projectId, type: WorkItemType.TASK },
       })
       if (deleted.count === 0) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
       return { message: 'Task deleted' }
@@ -953,17 +994,19 @@ export const projectsRouter = {
     .input(z.object({ projectId: z.number().int() }).merge(CreateProjectUpdateSchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const project = await prisma.project.findUnique({ where: { id: input.projectId } })
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.ownerId !== volunteer.id && !volunteer.isAdmin) {
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', { message: 'Only project owner can add updates' })
       }
 
-      const update = await prisma.projectUpdate.create({
-        data: { projectId: input.projectId, authorId: volunteer.id, content: input.content },
+      const comment = await prisma.workItemComment.create({
+        data: { workItemId: input.projectId, authorId: volunteer.id, content: input.content },
       })
 
-      return { id: update.id, message: 'Update added' }
+      return { id: comment.id, message: 'Update added' }
     }),
 }

--- a/server/routers/starterTasks.ts
+++ b/server/routers/starterTasks.ts
@@ -8,7 +8,7 @@ import {
   ReviewStarterTaskSchema,
 } from '@/lib/schemas'
 import { adminProcedure, authedProcedure, publicProcedure } from '../procedures'
-import { StarterTaskStatus } from '@/generated/prisma/enums'
+import { StarterTaskStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const starterTasksRouter = {
   list: adminProcedure
@@ -19,15 +19,16 @@ export const starterTasksRouter = {
       }),
     )
     .handler(async ({ input }) => {
-      const tasks = await prisma.starterTask.findMany({
+      const tasks = await prisma.workItem.findMany({
         where: {
+          type: WorkItemType.STARTER_TASK,
           ...(input.status ? { status: input.status } : {}),
           ...(input.skillId ? { skillId: input.skillId } : {}),
         },
         include: {
           skill: { include: { category: true } },
-          project: { select: { title: true } },
-          assignedTo: { select: { name: true } },
+          contextProject: { select: { title: true } },
+          assignee: { select: { name: true } },
           reviewedBy: { select: { name: true } },
         },
         orderBy: { createdAt: 'desc' },
@@ -35,20 +36,19 @@ export const starterTasksRouter = {
 
       return tasks.map((t) => ({
         id: t.id,
-        projectId: t.projectId,
+        projectId: t.contextProjectId,
         title: t.title,
         description: t.description,
         skillId: t.skillId,
         skillName: t.skill?.name ?? null,
         skillCategory: t.skill?.category?.name ?? null,
-        projectTitle: t.project?.title ?? null,
-        assignedToId: t.assignedToId,
-        assignedToName: t.assignedTo?.name ?? null,
-        assignedById: t.assignedById,
+        projectTitle: t.contextProject?.title ?? null,
+        assignedToId: t.assigneeId,
+        assignedToName: t.assignee?.name ?? null,
+        assignedById: t.creatorId,
         status: t.status,
         reviewRating: t.reviewRating,
         reviewNotes: t.reviewNotes,
-        feedbackToVolunteer: t.feedbackToVolunteer,
         reviewedById: t.reviewedById,
         reviewedByName: t.reviewedBy?.name ?? null,
         reviewedAt: t.reviewedAt,
@@ -59,36 +59,38 @@ export const starterTasksRouter = {
     }),
 
   available: publicProcedure.handler(async () => {
-    const tasks = await prisma.starterTask.findMany({
-      where: { status: StarterTaskStatus.open, assignedToId: null },
+    const tasks = await prisma.workItem.findMany({
+      where: { type: WorkItemType.STARTER_TASK, status: StarterTaskStatus.open, assigneeId: null },
       include: {
         skill: { include: { category: true } },
-        project: { select: { title: true } },
+        contextProject: { select: { title: true } },
       },
       orderBy: { createdAt: 'desc' },
     })
 
     return tasks.map((t) => ({
       id: t.id,
-      projectId: t.projectId,
+      projectId: t.contextProjectId,
       title: t.title,
       description: t.description,
       skillId: t.skillId,
       skillName: t.skill?.name ?? null,
       skillCategory: t.skill?.category?.name ?? null,
-      projectTitle: t.project?.title ?? null,
+      projectTitle: t.contextProject?.title ?? null,
       estimatedHours: t.estimatedHours,
       createdAt: t.createdAt,
     }))
   }),
 
   create: adminProcedure.input(CreateStarterTaskSchema).handler(async ({ input }) => {
-    const task = await prisma.starterTask.create({
+    const task = await prisma.workItem.create({
       data: {
+        type: WorkItemType.STARTER_TASK,
+        status: StarterTaskStatus.open,
         title: input.title,
         description: input.description,
         skillId: input.skillId ?? null,
-        projectId: input.projectId ?? null,
+        contextProjectId: input.contextProjectId ?? null,
         estimatedHours: input.estimatedHours ?? null,
       },
     })
@@ -106,10 +108,12 @@ export const starterTasksRouter = {
       }),
     )
     .handler(async ({ input }) => {
-      const task = await prisma.starterTask.findUnique({ where: { id: input.id } })
+      const task = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.STARTER_TASK },
+      })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
 
-      const updated = await prisma.starterTask.update({
+      const updated = await prisma.workItem.update({
         where: { id: input.id },
         data: {
           ...(input.title !== undefined && { title: input.title.trim() }),
@@ -122,13 +126,15 @@ export const starterTasksRouter = {
     }),
 
   delete: adminProcedure.input(z.object({ id: z.number().int() })).handler(async ({ input }) => {
-    const task = await prisma.starterTask.findUnique({ where: { id: input.id } })
+    const task = await prisma.workItem.findFirst({
+      where: { id: input.id, type: WorkItemType.STARTER_TASK },
+    })
     if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
 
     await prisma.skillEndorsement.deleteMany({
       where: { source: 'starter_task', sourceId: input.id },
     })
-    await prisma.starterTask.delete({ where: { id: input.id } })
+    await prisma.workItem.delete({ where: { id: input.id } })
     return { message: 'Task deleted' }
   }),
 
@@ -136,15 +142,17 @@ export const starterTasksRouter = {
     .input(z.object({ id: z.number().int() }).merge(AssignStarterTaskSchema))
     .handler(async ({ input, context }) => {
       const admin = context.volunteer
-      const task = await prisma.starterTask.findUnique({ where: { id: input.id } })
+      const task = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.STARTER_TASK },
+      })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
 
-      await prisma.starterTask.update({
+      await prisma.workItem.update({
         where: { id: input.id },
         data: {
-          assignedToId: input.volunteerId,
-          assignedById: admin.id,
-          status: StarterTaskStatus.assigned,
+          assigneeId: input.volunteerId,
+          creatorId: admin.id,
+          status: StarterTaskStatus.in_progress,
           updatedAt: new Date(),
         },
       })
@@ -153,7 +161,7 @@ export const starterTasksRouter = {
         input.volunteerId,
         'starter_task_assigned',
         `You've been assigned a starter task: ${task.title}`,
-        task.description.slice(0, 200),
+        (task.description ?? '').slice(0, 200),
         '/dashboard',
       )
 
@@ -161,14 +169,16 @@ export const starterTasksRouter = {
     }),
 
   unassign: adminProcedure.input(z.object({ id: z.number().int() })).handler(async ({ input }) => {
-    const task = await prisma.starterTask.findUnique({ where: { id: input.id } })
+    const task = await prisma.workItem.findFirst({
+      where: { id: input.id, type: WorkItemType.STARTER_TASK },
+    })
     if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
 
-    await prisma.starterTask.update({
+    await prisma.workItem.update({
       where: { id: input.id },
       data: {
-        assignedToId: null,
-        assignedById: null,
+        assigneeId: null,
+        creatorId: null,
         status: StarterTaskStatus.open,
         updatedAt: new Date(),
       },
@@ -180,20 +190,20 @@ export const starterTasksRouter = {
     .input(z.object({ id: z.number().int() }))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const task = await prisma.starterTask.findFirst({
-        where: { id: input.id, assignedToId: volunteer.id },
+      const task = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.STARTER_TASK, assigneeId: volunteer.id },
       })
       if (!task)
         throw new ORPCError('NOT_FOUND', { message: 'Task not found or not assigned to you' })
 
-      await prisma.starterTask.update({
+      await prisma.workItem.update({
         where: { id: input.id },
-        data: { status: StarterTaskStatus.submitted, updatedAt: new Date() },
+        data: { status: StarterTaskStatus.under_review, updatedAt: new Date() },
       })
 
-      if (task.assignedById) {
+      if (task.creatorId) {
         notifyUser(
-          task.assignedById,
+          task.creatorId,
           'starter_task_submitted',
           `${volunteer.name} submitted: ${task.title}`,
           'Ready for review',
@@ -208,37 +218,40 @@ export const starterTasksRouter = {
     .input(z.object({ id: z.number().int() }).merge(ReviewStarterTaskSchema))
     .handler(async ({ input, context }) => {
       const admin = context.volunteer
-      const task = await prisma.starterTask.findUnique({ where: { id: input.id } })
+      const task = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.STARTER_TASK },
+      })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
-      if (task.status !== StarterTaskStatus.submitted)
-        throw new ORPCError('BAD_REQUEST', { message: 'Task is not in submitted status' })
+      if (task.status !== StarterTaskStatus.under_review)
+        throw new ORPCError('BAD_REQUEST', { message: 'Task is not awaiting review' })
 
-      const newStatus = ['excellent', 'good'].includes(input.reviewRating)
-        ? StarterTaskStatus.completed
-        : StarterTaskStatus.reviewed
-
-      await prisma.starterTask.update({
+      await prisma.workItem.update({
         where: { id: input.id },
         data: {
-          status: newStatus,
+          status: StarterTaskStatus.completed,
           reviewRating: input.reviewRating,
           reviewNotes: input.reviewNotes ?? null,
-          feedbackToVolunteer: input.feedbackToVolunteer ?? null,
           reviewedById: admin.id,
           reviewedAt: new Date(),
           updatedAt: new Date(),
         },
       })
 
-      if (task.assignedToId) {
+      if (input.comment && input.comment.trim()) {
+        await prisma.workItemComment.create({
+          data: { workItemId: input.id, authorId: admin.id, content: input.comment.trim() },
+        })
+      }
+
+      if (task.assigneeId) {
         const noteContent = `Starter task '${task.title}': ${input.reviewRating}${input.reviewNotes ? ` - ${input.reviewNotes}` : ''}`
         await prisma.adminNote.create({
           data: {
-            volunteerId: task.assignedToId,
+            volunteerId: task.assigneeId,
             authorId: admin.id,
             content: noteContent,
             category: 'skill_feedback',
-            relatedProjectId: task.projectId ?? null,
+            relatedWorkItemId: task.contextProjectId ?? null,
           },
         })
 
@@ -247,7 +260,7 @@ export const starterTasksRouter = {
           await prisma.skillEndorsement.upsert({
             where: {
               volunteerId_skillId_endorsedById: {
-                volunteerId: task.assignedToId,
+                volunteerId: task.assigneeId,
                 skillId: task.skillId,
                 endorsedById: admin.id,
               },
@@ -259,7 +272,7 @@ export const starterTasksRouter = {
               sourceId: input.id,
             },
             create: {
-              volunteerId: task.assignedToId,
+              volunteerId: task.assigneeId,
               skillId: task.skillId,
               endorsedById: admin.id,
               source: 'starter_task',
@@ -271,10 +284,10 @@ export const starterTasksRouter = {
         }
 
         notifyUser(
-          task.assignedToId,
+          task.assigneeId,
           'starter_task_reviewed',
           `Your starter task was reviewed: ${task.title}`,
-          `Rating: ${input.reviewRating}${input.feedbackToVolunteer ? ` - ${input.feedbackToVolunteer}` : ''}`,
+          `Rating: ${input.reviewRating}${input.comment ? ` - ${input.comment}` : ''}`,
           '/dashboard',
         )
       }

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -4,7 +4,12 @@ import { prisma } from '@/lib/prisma'
 import { redactVolunteer } from '@/lib/auth'
 import { UpdateVolunteerSchema } from '@/lib/schemas'
 import { publicProcedure, authedProcedure } from '../procedures'
-import { ApprovalStatus, ProjectStatus, StarterTaskStatus } from '@/generated/prisma/enums'
+import {
+  ApprovalStatus,
+  ProjectStatus,
+  StarterTaskStatus,
+  WorkItemType,
+} from '@/generated/prisma/enums'
 
 export const volunteersRouter = {
   list: publicProcedure
@@ -163,9 +168,10 @@ export const volunteersRouter = {
       }))
 
       const [projects, completedTasks] = await Promise.all([
-        prisma.project.findMany({
+        prisma.workItem.findMany({
           where: {
-            OR: [{ ownerId: input.id }, { proposedById: input.id }],
+            type: WorkItemType.PROJECT,
+            OR: [{ assigneeId: input.id }, { creatorId: input.id }],
             status: {
               notIn: [
                 ProjectStatus.archived,
@@ -180,23 +186,23 @@ export const volunteersRouter = {
             title: true,
             description: true,
             status: true,
-            ownerId: true,
-            proposedById: true,
+            assigneeId: true,
+            creatorId: true,
             createdAt: true,
             updatedAt: true,
           },
         }),
-        prisma.starterTask.findMany({
+        prisma.workItem.findMany({
           where: {
-            assignedToId: input.id,
-            status: { in: [StarterTaskStatus.completed, StarterTaskStatus.reviewed] },
+            type: WorkItemType.STARTER_TASK,
+            assigneeId: input.id,
+            status: StarterTaskStatus.completed,
             reviewRating: { in: ['excellent', 'good'] },
           },
           orderBy: { reviewedAt: 'desc' },
           select: {
             title: true,
             reviewRating: true,
-            feedbackToVolunteer: true,
             reviewedAt: true,
             skill: { select: { name: true } },
           },
@@ -210,13 +216,19 @@ export const volunteersRouter = {
           endorsements,
         }),
         projects: projects.map((p) => ({
-          ...p,
-          role: p.ownerId === input.id ? 'owner' : 'proposer',
+          id: p.id,
+          title: p.title,
+          description: p.description,
+          status: p.status,
+          ownerId: p.assigneeId,
+          proposedById: p.creatorId,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+          role: p.assigneeId === input.id ? 'owner' : 'proposer',
         })),
         completedTasks: completedTasks.map((t) => ({
           title: t.title,
           reviewRating: t.reviewRating,
-          feedbackToVolunteer: t.feedbackToVolunteer,
           reviewedAt: t.reviewedAt,
           skillName: t.skill?.name ?? null,
         })),

--- a/server/routers/workItemComments.ts
+++ b/server/routers/workItemComments.ts
@@ -48,6 +48,28 @@ function commentLink(item: LoadedWorkItem): string {
   return '/dashboard'
 }
 
+// Whether `viewer` may post on this item. Resolves the accepted-helper lookup
+// for PROJECT/TASK. Returns false for anonymous viewers.
+async function resolveCanPost(
+  item: LoadedWorkItem,
+  parent: LoadedWorkItem | null,
+  viewer: { id: number; isAdmin: boolean } | null,
+): Promise<boolean> {
+  if (!viewer) return false
+  let isAcceptedHelper = false
+  if (!viewer.isAdmin) {
+    const projectId = item.type === WorkItemType.TASK ? item.parentId : item.id
+    if (projectId) {
+      const interest = await prisma.workItemInterest.findFirst({
+        where: { workItemId: projectId, volunteerId: viewer.id, status: InterestStatus.accepted },
+        select: { id: true },
+      })
+      isAcceptedHelper = Boolean(interest)
+    }
+  }
+  return canPostComment(item, viewer, { parent, isAcceptedHelper })
+}
+
 export const workItemCommentsRouter = {
   list: publicProcedure
     .input(z.object({ workItemId: z.number().int() }))
@@ -67,14 +89,18 @@ export const workItemCommentsRouter = {
         include: { author: { select: { name: true } } },
         orderBy: { createdAt: 'asc' },
       })
-      return comments.map((c) => ({
-        id: c.id,
-        workItemId: c.workItemId,
-        authorId: c.authorId,
-        authorName: c.author?.name ?? null,
-        content: c.content,
-        createdAt: c.createdAt,
-      }))
+      const canPost = await resolveCanPost(loaded.item, loaded.parent, viewer)
+      return {
+        canPost,
+        comments: comments.map((c) => ({
+          id: c.id,
+          workItemId: c.workItemId,
+          authorId: c.authorId,
+          authorName: c.author?.name ?? null,
+          content: c.content,
+          createdAt: c.createdAt,
+        })),
+      }
     }),
 
   add: authedProcedure
@@ -85,26 +111,7 @@ export const workItemCommentsRouter = {
       if (!loaded) throw new ORPCError('NOT_FOUND', { message: 'Work item not found' })
 
       const viewer = { id: volunteer.id, isAdmin: Boolean(volunteer.isAdmin) }
-
-      // Accepted-helper check (project participants) for PROJECT/TASK.
-      let isAcceptedHelper = false
-      if (!viewer.isAdmin) {
-        const projectId =
-          loaded.item.type === WorkItemType.TASK ? loaded.item.parentId : loaded.item.id
-        if (projectId) {
-          const interest = await prisma.workItemInterest.findFirst({
-            where: {
-              workItemId: projectId,
-              volunteerId: volunteer.id,
-              status: InterestStatus.accepted,
-            },
-            select: { id: true },
-          })
-          isAcceptedHelper = Boolean(interest)
-        }
-      }
-
-      if (!canPostComment(loaded.item, viewer, { parent: loaded.parent, isAcceptedHelper })) {
+      if (!(await resolveCanPost(loaded.item, loaded.parent, viewer))) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized to comment here' })
       }
 

--- a/server/routers/workItemComments.ts
+++ b/server/routers/workItemComments.ts
@@ -87,7 +87,7 @@ export const workItemCommentsRouter = {
       const comments = await prisma.workItemComment.findMany({
         where: { workItemId: input.workItemId },
         include: { author: { select: { name: true } } },
-        orderBy: { createdAt: 'asc' },
+        orderBy: { createdAt: 'desc' },
       })
       const canPost = await resolveCanPost(loaded.item, loaded.parent, viewer)
       return {

--- a/server/routers/workItemComments.ts
+++ b/server/routers/workItemComments.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod'
+import { ORPCError } from '@orpc/server'
+import { prisma } from '@/lib/prisma'
+import { notifyUser } from '@/lib/notify'
+import { canViewWorkItem, canPostComment } from '@/lib/work-item'
+import { publicProcedure, authedProcedure } from '../procedures'
+import { InterestStatus, WorkItemType } from '@/generated/prisma/enums'
+
+const WORK_ITEM_SELECT = {
+  id: true,
+  type: true,
+  status: true,
+  title: true,
+  parentId: true,
+  creatorId: true,
+  assigneeId: true,
+} as const
+
+type LoadedWorkItem = {
+  id: number
+  type: string
+  status: string
+  title: string
+  parentId: number | null
+  creatorId: number | null
+  assigneeId: number | null
+}
+
+async function loadWithParent(id: number) {
+  const item = (await prisma.workItem.findUnique({
+    where: { id },
+    select: WORK_ITEM_SELECT,
+  })) as LoadedWorkItem | null
+  if (!item) return null
+  const parent =
+    item.type === WorkItemType.TASK && item.parentId
+      ? ((await prisma.workItem.findUnique({
+          where: { id: item.parentId },
+          select: WORK_ITEM_SELECT,
+        })) as LoadedWorkItem | null)
+      : null
+  return { item, parent }
+}
+
+function commentLink(item: LoadedWorkItem): string {
+  if (item.type === WorkItemType.PROJECT) return `/projects/${item.id}`
+  if (item.type === WorkItemType.TASK && item.parentId) return `/projects/${item.parentId}`
+  return '/dashboard'
+}
+
+export const workItemCommentsRouter = {
+  list: publicProcedure
+    .input(z.object({ workItemId: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      const loaded = await loadWithParent(input.workItemId)
+      if (!loaded) throw new ORPCError('NOT_FOUND', { message: 'Work item not found' })
+
+      const viewer = context.volunteer
+        ? { id: context.volunteer.id, isAdmin: Boolean(context.volunteer.isAdmin) }
+        : null
+      if (!canViewWorkItem(loaded.item, viewer, loaded.parent)) {
+        throw new ORPCError('NOT_FOUND', { message: 'Work item not found' })
+      }
+
+      const comments = await prisma.workItemComment.findMany({
+        where: { workItemId: input.workItemId },
+        include: { author: { select: { name: true } } },
+        orderBy: { createdAt: 'asc' },
+      })
+      return comments.map((c) => ({
+        id: c.id,
+        workItemId: c.workItemId,
+        authorId: c.authorId,
+        authorName: c.author?.name ?? null,
+        content: c.content,
+        createdAt: c.createdAt,
+      }))
+    }),
+
+  add: authedProcedure
+    .input(z.object({ workItemId: z.number().int(), content: z.string().min(1) }))
+    .handler(async ({ input, context }) => {
+      const volunteer = context.volunteer
+      const loaded = await loadWithParent(input.workItemId)
+      if (!loaded) throw new ORPCError('NOT_FOUND', { message: 'Work item not found' })
+
+      const viewer = { id: volunteer.id, isAdmin: Boolean(volunteer.isAdmin) }
+
+      // Accepted-helper check (project participants) for PROJECT/TASK.
+      let isAcceptedHelper = false
+      if (!viewer.isAdmin) {
+        const projectId =
+          loaded.item.type === WorkItemType.TASK ? loaded.item.parentId : loaded.item.id
+        if (projectId) {
+          const interest = await prisma.workItemInterest.findFirst({
+            where: {
+              workItemId: projectId,
+              volunteerId: volunteer.id,
+              status: InterestStatus.accepted,
+            },
+            select: { id: true },
+          })
+          isAcceptedHelper = Boolean(interest)
+        }
+      }
+
+      if (!canPostComment(loaded.item, viewer, { parent: loaded.parent, isAcceptedHelper })) {
+        throw new ORPCError('FORBIDDEN', { message: 'Not authorized to comment here' })
+      }
+
+      const comment = await prisma.workItemComment.create({
+        data: {
+          workItemId: input.workItemId,
+          authorId: volunteer.id,
+          content: input.content.trim(),
+        },
+      })
+
+      // Notify the other participants (in-app only).
+      const recipientIds = new Set<number>()
+      for (const id of [
+        loaded.item.creatorId,
+        loaded.item.assigneeId,
+        loaded.parent?.assigneeId ?? null,
+      ]) {
+        if (id && id !== volunteer.id) recipientIds.add(id)
+      }
+      const link = commentLink(loaded.item)
+      for (const rid of recipientIds) {
+        await notifyUser(
+          rid,
+          'work_item_comment',
+          `New comment on "${loaded.item.title}"`,
+          input.content.slice(0, 200),
+          link,
+        )
+      }
+
+      return { id: comment.id, message: 'Comment added' }
+    }),
+}


### PR DESCRIPTION
## Summary
- Collapse `Project`, `ProjectTask`, `StarterTask` into a single `WorkItem` model with a `type` discriminator and unified `creator`/`assignee`/`stakeholder` roles.
- Replace fragmented feedback (`feedbackToProposer`, `feedbackToVolunteer`, `ProjectUpdate`) with a single `WorkItemComment` thread.
- Triage page shows the comment thread for `needs_discussion` projects and supports admin follow-up replies.
- All routers/jobs query `prisma.workItem` with type filters; public URLs unchanged.

## Migration
- `20260520150004_unified_work_items` hand-written: backfills with preserved project IDs (tasks +1,000,000, starters +2,000,000), converts all feedback/update fields to comments, remaps `admin_notes`/`contact_messages` FKs to `related_work_item_id`.
- Verified on a seeded copy of the anonymised dev DB (row counts, comment authorship/dates, `foreign_key_check` clean).
- `project_task_comments` drop guarded `IF EXISTS` (drift table, prod only).

## Notable decisions
- **Clean break** at the DB/router model layer; the serialized *view* keeps `owner`/`proposedBy`/`ownerId` keys so `ProjectCard` and consuming pages stay stable. No generic serializer reintroduced.
- Starter-task review collapses to `completed` (rating captures quality; old `reviewed`/`rejected`/`submitted`/`assigned` states remapped). Status renames: task `assigned`→`in_progress`, `done`→`completed`; starter `submitted`→`under_review`.
- Unblocks #100 (Postgres migration).

## Temporary (remove before merge if undesired)
- `scripts/seed-migration-test-state.ts` — seeds every backfill path against the anonymised dev DB.

## Test plan
- [x] `npm run check-all` green (typecheck, lint, format, 108 e2e passed / 6 skipped)
- [x] Migration verified against seeded anonymised DB
- [ ] Manual browser pass of golden paths beyond e2e (project detail thread, triage reply, task claim/complete, starter review)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)