### PR TITLE
style: quick styling wins — tokens, registries, page width

### DIFF
--- a/app/accept-invite/page.tsx
+++ b/app/accept-invite/page.tsx
@@ -95,7 +95,7 @@ function AcceptInviteContent() {
 export default function AcceptInvitePage() {
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-[500px] my-15 mx-auto text-center">
           <Suspense fallback={<div className="text-center py-10 text-text-light">Loading…</div>}>
             <AcceptInviteContent />

--- a/app/accept-invite/page.tsx
+++ b/app/accept-invite/page.tsx
@@ -56,12 +56,10 @@ function AcceptInviteContent() {
     return (
       <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word text-center">
         <h2>Admin Invite</h2>
-        <p className="text-text-light" style={{ margin: '16px 0' }}>
+        <p className="text-text-light my-4">
           You&apos;ve been invited to become an admin on Catalyse.
         </p>
-        <p style={{ marginBottom: 24 }}>
-          Please log in or sign up with the invited email address to accept.
-        </p>
+        <p className="mb-6">Please log in or sign up with the invited email address to accept.</p>
         <Button href={`/login?redirect=${redirectUrl}`}>Log In</Button>
         <Button href={`/signup?redirect=${redirectUrl}`} variant="outline" className="ml-2">
           Sign Up
@@ -74,9 +72,7 @@ function AcceptInviteContent() {
     return (
       <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word text-center">
         <h2>Welcome to the Team!</h2>
-        <p className="text-text-light" style={{ margin: '16px 0' }}>
-          You now have admin access to Catalyse. Redirecting…
-        </p>
+        <p className="text-text-light my-4">You now have admin access to Catalyse. Redirecting…</p>
         <Button href="/admin/triage">Go to Admin Dashboard</Button>
       </div>
     )
@@ -88,7 +84,7 @@ function AcceptInviteContent() {
   return (
     <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word text-center">
       <h2>Invite Error</h2>
-      <p style={{ margin: '16px 0', color: 'var(--error)' }}>{errorMsg}</p>
+      <p className="my-4 text-error">{errorMsg}</p>
       <Button href="/" variant="outline">
         Back to Home
       </Button>
@@ -100,7 +96,7 @@ export default function AcceptInvitePage() {
   return (
     <>
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div style={{ maxWidth: 500, margin: '60px auto', textAlign: 'center' }}>
+        <div className="max-w-[500px] my-15 mx-auto text-center">
           <Suspense fallback={<div className="text-center py-10 text-text-light">Loading…</div>}>
             <AcceptInviteContent />
           </Suspense>

--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -77,7 +77,7 @@ export default function ApplicationReviewPage() {
 
   if (loadingData) {
     return (
-      <main className="w-full max-w-350 mx-auto px-6 py-5">
+      <main className="container py-5">
         <p className="text-text-light">Loading…</p>
       </main>
     )
@@ -85,7 +85,7 @@ export default function ApplicationReviewPage() {
 
   if (!app) {
     return (
-      <main className="w-full max-w-350 mx-auto px-6 py-5">
+      <main className="container py-5">
         <p className="text-text-light">Application not found.</p>
       </main>
     )

--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -149,7 +149,7 @@ export default function ApplicationReviewPage() {
             {app.skills.map((s) => (
               <span
                 key={s.id}
-                className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300"
               >
                 {s.name}
               </span>

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -72,7 +72,7 @@ export default function ApplicationsPage() {
   const isEmpty = isAnonymised ? anonymisedApplications.length === 0 : applications.length === 0
 
   return (
-    <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+    <main className="container py-5 pb-15">
       <h1>Applications</h1>
       <p className="text-text-light mb-6">Review new volunteer applications.</p>
 

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -170,7 +170,7 @@ function ApplicationCard({
             {app.skills.map((s) => (
               <span
                 key={s.id}
-                className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300"
               >
                 {s.name}
               </span>

--- a/app/admin/bugs/page.tsx
+++ b/app/admin/bugs/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { Badge, type BadgeVariant } from '@/components/Badge'
 
 const STATUS_OPTIONS = [
   { value: 'all', label: 'All' },
@@ -22,15 +23,11 @@ const CATEGORY_OPTIONS = [
   { value: 'ux', label: 'UX Issue' },
 ] as const
 
-const BUG_STATUS_CLASSES: Record<string, string> = {
-  open: 'bg-orange-200 text-amber-800 dark:bg-amber-900 dark:text-orange-200',
-  in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
-  resolved: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
-  wont_fix: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400',
-}
-
-function bugStatusClasses(status: string) {
-  return `inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${BUG_STATUS_CLASSES[status] ?? 'bg-gray-100 text-gray-700'}`
+const BUG_STATUS_VARIANT: Record<string, BadgeVariant> = {
+  open: 'caution',
+  in_progress: 'info',
+  resolved: 'success',
+  wont_fix: 'neutral',
 }
 
 export default function AdminBugsPage() {
@@ -91,7 +88,7 @@ export default function AdminBugsPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Bug Reports &amp; Feedback</h1>
 
         <div className="mb-6 flex gap-4 flex-wrap">
@@ -158,9 +155,9 @@ export default function AdminBugsPage() {
                       })()}
                   </div>
                 </div>
-                <span className={bugStatusClasses(r.status)}>
+                <Badge variant={BUG_STATUS_VARIANT[r.status] ?? 'neutral'}>
                   {STATUS_OPTIONS.find((s) => s.value === r.status)?.label ?? r.status}
-                </span>
+                </Badge>
               </div>
 
               <p className="text-text-light mt-0 mx-0 mb-3 whitespace-pre-wrap">{r.description}</p>

--- a/app/admin/bugs/page.tsx
+++ b/app/admin/bugs/page.tsx
@@ -23,14 +23,14 @@ const CATEGORY_OPTIONS = [
 ] as const
 
 const BUG_STATUS_CLASSES: Record<string, string> = {
-  open: 'bg-[#FED7AA] text-[#92400E] dark:bg-[#78350F] dark:text-[#FED7AA]',
-  in_progress: 'bg-[#DBEAFE] text-[#1E40AF] dark:bg-[#1E3A5F] dark:text-[#93C5FD]',
-  resolved: 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]',
-  wont_fix: 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]',
+  open: 'bg-orange-200 text-amber-800 dark:bg-amber-900 dark:text-orange-200',
+  in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  resolved: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
+  wont_fix: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400',
 }
 
 function bugStatusClasses(status: string) {
-  return `inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${BUG_STATUS_CLASSES[status] ?? 'bg-[#F3F4F6] text-[#374151]'}`
+  return `inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${BUG_STATUS_CLASSES[status] ?? 'bg-gray-100 text-gray-700'}`
 }
 
 export default function AdminBugsPage() {
@@ -122,24 +122,13 @@ export default function AdminBugsPage() {
           reports.map((r) => (
             <div
               key={r.id}
-              className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word w-full"
-              style={{ cursor: 'pointer' }}
+              className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word w-full cursor-pointer"
               onClick={() => openEdit(r)}
             >
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'flex-start',
-                  marginBottom: 8,
-                }}
-              >
+              <div className="flex justify-between items-start mb-2">
                 <div>
-                  <h3 style={{ margin: '0 0 4px' }}>{r.title}</h3>
-                  <div
-                    className="text-text-light"
-                    style={{ display: 'flex', gap: 8, flexWrap: 'wrap', fontSize: '0.8rem' }}
-                  >
+                  <h3 className="mt-0 mx-0 mb-1">{r.title}</h3>
+                  <div className="text-text-light flex gap-2 flex-wrap text-[0.8rem]">
                     {r.category && <span>{r.category}</span>}
                     {r.severity && <span>· {r.severity}</span>}
                     {r.reporterName && <span>· {r.reporterName}</span>}
@@ -174,14 +163,10 @@ export default function AdminBugsPage() {
                 </span>
               </div>
 
-              <p className="text-text-light" style={{ margin: '0 0 12px', whiteSpace: 'pre-wrap' }}>
-                {r.description}
-              </p>
+              <p className="text-text-light mt-0 mx-0 mb-3 whitespace-pre-wrap">{r.description}</p>
 
               {r.resolutionNotes && (
-                <p style={{ margin: '0 0 12px', fontSize: '0.875rem', fontStyle: 'italic' }}>
-                  Resolution: {r.resolutionNotes}
-                </p>
+                <p className="mt-0 mx-0 mb-3 text-sm italic">Resolution: {r.resolutionNotes}</p>
               )}
             </div>
           ))
@@ -202,7 +187,7 @@ export default function AdminBugsPage() {
             className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto"
           >
             <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
-              <h2 style={{ marginBottom: 4 }}>{editModal.title}</h2>
+              <h2 className="mb-1">{editModal.title}</h2>
             </div>
             <div className="p-6">
               <p className="text-text-light mb-4 text-sm">{editModal.description}</p>
@@ -226,7 +211,7 @@ export default function AdminBugsPage() {
                   value={editNotes}
                   onChange={(e) => setEditNotes(e.target.value)}
                   placeholder="Describe what was fixed…"
-                  style={{ width: '100%' }}
+                  className="w-full"
                 />
               </div>
 

--- a/app/admin/email-preview/page.tsx
+++ b/app/admin/email-preview/page.tsx
@@ -193,54 +193,29 @@ function EmailRow({
   }
 
   return (
-    <section style={{ borderBottom: '1px solid #e2e8f0', padding: '32px 0' }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 16 }}>
-        <h2 style={{ margin: 0, fontSize: 18, color: '#1A202C' }}>{type.label}</h2>
+    <section className="border-b border-brand-border py-8">
+      <div className="flex items-baseline gap-3 mb-4">
+        <h2 className="m-0 text-lg text-brand-text">{type.label}</h2>
         <button
           onClick={openInNewTab}
-          style={{
-            background: 'none',
-            border: 'none',
-            color: '#FF9416',
-            cursor: 'pointer',
-            fontSize: 13,
-            padding: 0,
-          }}
+          className="bg-transparent border-none text-primary cursor-pointer text-[13px] p-0"
         >
           Open in new tab ↗
         </button>
       </div>
-      <div
-        style={{ display: 'grid', gridTemplateColumns: '300px 1fr', gap: 32, alignItems: 'start' }}
-      >
+      <div className="grid grid-cols-[300px_1fr] gap-8 items-start">
         <div>
-          <p
-            style={{
-              fontSize: 11,
-              fontWeight: 600,
-              color: '#718096',
-              textTransform: 'uppercase',
-              letterSpacing: '0.05em',
-              margin: '0 0 8px',
-            }}
-          >
+          <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-[0.05em] mb-2">
             Parameters
           </p>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <table className="w-full border-collapse text-[13px]">
             <tbody>
               {Object.entries(type.params).map(([key, val]) => (
                 <tr key={key}>
-                  <td
-                    style={{
-                      padding: '4px 8px 4px 0',
-                      color: '#718096',
-                      whiteSpace: 'nowrap',
-                      verticalAlign: 'top',
-                    }}
-                  >
+                  <td className="py-1 pr-2 pl-0 text-gray-500 whitespace-nowrap align-top">
                     {key}
                   </td>
-                  <td style={{ padding: '4px 0', color: '#2D3748', wordBreak: 'break-word' }}>
+                  <td className="py-1 text-secondary break-words">
                     {typeof val === 'boolean' ? (val ? 'true' : 'false') : String(val)}
                   </td>
                 </tr>
@@ -250,22 +225,15 @@ function EmailRow({
         </div>
         <div>
           {preview?.subject && (
-            <p style={{ fontSize: 13, color: '#718096', margin: '0 0 8px', fontStyle: 'italic' }}>
-              Subject: <strong style={{ color: '#2D3748' }}>{preview.subject}</strong>
+            <p className="text-[13px] text-gray-500 mb-2 italic">
+              Subject: <strong className="text-secondary">{preview.subject}</strong>
             </p>
           )}
-          <div
-            style={{
-              border: '1px solid #e2e8f0',
-              borderRadius: 8,
-              overflow: 'hidden',
-              background: '#fff',
-            }}
-          >
+          <div className="border border-brand-border rounded-lg overflow-hidden bg-white">
             {preview?.html ? (
               <AutoIframe html={preview.html} />
             ) : (
-              <p style={{ padding: 16, color: '#718096', margin: 0 }}>Loading…</p>
+              <p className="p-4 text-gray-500 m-0">Loading…</p>
             )}
           </div>
         </div>
@@ -288,11 +256,9 @@ export default function EmailPreviewPage() {
 
   return (
     <>
-      <main style={{ width: '100%', maxWidth: 1280, margin: '0 auto', padding: '32px 24px 64px' }}>
-        <h1 style={{ marginBottom: 4 }}>Email Previews</h1>
-        <p style={{ color: '#718096', marginBottom: 0 }}>
-          All transactional emails rendered with sample data.
-        </p>
+      <main className="w-full max-w-[1280px] mx-auto pt-8 px-6 pb-16">
+        <h1 className="mb-1">Email Previews</h1>
+        <p className="text-gray-500 mb-0">All transactional emails rendered with sample data.</p>
         {EMAIL_TYPES.map((t, i) => (
           <EmailRow key={t.value} type={t} preview={results[i].data} />
         ))}

--- a/app/admin/email-preview/page.tsx
+++ b/app/admin/email-preview/page.tsx
@@ -256,7 +256,7 @@ export default function EmailPreviewPage() {
 
   return (
     <>
-      <main className="w-full max-w-[1280px] mx-auto pt-8 px-6 pb-16">
+      <main className="container pt-8 pb-16">
         <h1 className="mb-1">Email Previews</h1>
         <p className="text-gray-500 mb-0">All transactional emails rendered with sample data.</p>
         {EMAIL_TYPES.map((t, i) => (

--- a/app/admin/local-groups/page.tsx
+++ b/app/admin/local-groups/page.tsx
@@ -334,7 +334,7 @@ export default function AdminLocalGroupsPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="flex items-center justify-between mb-2">
           <h1 className="m-0">Local Groups</h1>
           <Button size="sm" onClick={openAdd}>

--- a/app/admin/local-groups/page.tsx
+++ b/app/admin/local-groups/page.tsx
@@ -657,7 +657,7 @@ export default function AdminLocalGroupsPage() {
                             "e.g., Thanks for the suggestion. This area isn't something we're able to support at the moment.",
                         }[reviewAction] ?? ''
                       }
-                      style={{ width: '100%' }}
+                      className="w-full"
                     />
                     <p className="text-sm text-text-light mt-1">
                       This note will be shared with the volunteer.

--- a/app/admin/platform-settings/page.tsx
+++ b/app/admin/platform-settings/page.tsx
@@ -42,7 +42,7 @@ export default function PlatformSettingsPage() {
             }
           />
         </div>
-        <p className="text-[var(--text-light)] text-sm">
+        <p className="text-text-light text-sm">
           When enabled, new volunteers must be reviewed and approved by an admin before gaining
           access. When disabled, volunteers are automatically approved after verifying their email.
         </p>

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -15,7 +15,7 @@ export default function AdminCreateProjectPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1 role="heading">Create Organisation Project</h1>
         <p className="text-text-light mb-6">
           Create a project on behalf of PauseAI UK. This skips the approval process.

--- a/app/admin/skills/page.tsx
+++ b/app/admin/skills/page.tsx
@@ -352,7 +352,7 @@ export default function AdminSkillsPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="flex justify-between items-center mb-3">
           <h1>Manage Skills</h1>
           <Button onClick={() => openModal({ type: 'add-category' })}>+ Add Category</Button>

--- a/app/admin/skills/page.tsx
+++ b/app/admin/skills/page.tsx
@@ -62,44 +62,29 @@ function SortableSkill({
     <div
       ref={setNodeRef}
       role="listitem"
-      className="skill-item"
+      className="skill-item bg-brand-bg rounded-[var(--radius)] px-4 py-3 flex items-start gap-2"
       style={{
+        // dynamic: drag transform/transition/opacity
         transform: CSS.Transform.toString(transform),
         transition,
         opacity: isDragging ? 0.5 : 1,
-        background: 'var(--background)',
-        borderRadius: 'var(--radius)',
-        padding: '12px 16px',
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: 8,
       }}
     >
       <span
         {...attributes}
         {...listeners}
-        style={{
-          cursor: 'grab',
-          color: 'var(--text-light)',
-          flexShrink: 0,
-          marginTop: 2,
-          lineHeight: 1,
-        }}
+        className="cursor-grab text-text-light shrink-0 mt-0.5 leading-none"
         title="Drag to reorder"
       >
         ⠿
       </span>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <h4 role="heading" style={{ margin: '0 0 4px 0', fontSize: '1rem', fontWeight: 700 }}>
+      <div className="flex-1 min-w-0">
+        <h4 role="heading" className="mb-1 text-base font-bold">
           {skill.name}
         </h4>
-        {skill.description && (
-          <p style={{ margin: 0, fontSize: '0.875rem', color: 'var(--text-light)' }}>
-            {skill.description}
-          </p>
-        )}
+        {skill.description && <p className="m-0 text-sm text-text-light">{skill.description}</p>}
       </div>
-      <div className="flex gap-1" style={{ flexShrink: 0 }}>
+      <div className="flex gap-1 shrink-0">
         <Button variant="secondary" size="sm" onClick={onEdit}>
           Edit
         </Button>
@@ -149,34 +134,20 @@ function SortableCategory({
   return (
     <div
       ref={setNodeRef}
-      className="category-card bg-surface rounded-xl shadow p-6 overflow-hidden wrap-break-word"
+      className="category-card bg-surface rounded-xl shadow p-6 overflow-hidden wrap-break-word mb-6"
       style={{
-        marginBottom: 24,
+        // dynamic: drag transform/transition/opacity
         transform: CSS.Transform.toString(transform),
         transition,
         opacity: isDragging ? 0.5 : 1,
       }}
     >
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          marginBottom: 16,
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+      <div className="flex justify-between items-start mb-4">
+        <div className="flex items-start gap-2">
           <span
             {...attributes}
             {...listeners}
-            style={{
-              cursor: 'grab',
-              color: 'var(--text-light)',
-              flexShrink: 0,
-              marginTop: 4,
-              lineHeight: 1,
-              fontSize: '1.25rem',
-            }}
+            className="cursor-grab text-text-light shrink-0 mt-1 leading-none text-xl"
             title="Drag to reorder"
           >
             ⠿
@@ -202,7 +173,7 @@ function SortableCategory({
         onDragEnd={handleSkillDragEnd}
       >
         <SortableContext items={cat.skills.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div className="flex flex-col gap-2">
             {cat.skills.map((skill) => (
               <SortableSkill
                 key={skill.id}
@@ -213,16 +184,7 @@ function SortableCategory({
             ))}
             <button
               onClick={onAddSkill}
-              style={{
-                border: '2px dashed var(--border)',
-                background: 'transparent',
-                borderRadius: 'var(--radius)',
-                padding: '12px 16px',
-                color: 'var(--text-light)',
-                cursor: 'pointer',
-                textAlign: 'center',
-              }}
-              className="hover:border-primary hover:text-primary hover:bg-accent transition-all"
+              className="border-2 border-dashed border-brand-border bg-transparent rounded-[var(--radius)] px-4 py-3 text-text-light cursor-pointer text-center hover:border-primary hover:text-primary hover:bg-accent transition-all"
             >
               + Add Skill
             </button>
@@ -391,14 +353,7 @@ export default function AdminSkillsPage() {
   return (
     <>
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 12,
-          }}
-        >
+        <div className="flex justify-between items-center mb-3">
           <h1>Manage Skills</h1>
           <Button onClick={() => openModal({ type: 'add-category' })}>+ Add Category</Button>
         </div>

--- a/app/admin/skills/page.tsx
+++ b/app/admin/skills/page.tsx
@@ -62,7 +62,7 @@ function SortableSkill({
     <div
       ref={setNodeRef}
       role="listitem"
-      className="skill-item bg-brand-bg rounded-[var(--radius)] px-4 py-3 flex items-start gap-2"
+      className="skill-item bg-brand-bg rounded-lg px-4 py-3 flex items-start gap-2"
       style={{
         // dynamic: drag transform/transition/opacity
         transform: CSS.Transform.toString(transform),
@@ -184,7 +184,7 @@ function SortableCategory({
             ))}
             <button
               onClick={onAddSkill}
-              className="border-2 border-dashed border-brand-border bg-transparent rounded-[var(--radius)] px-4 py-3 text-text-light cursor-pointer text-center hover:border-primary hover:text-primary hover:bg-accent transition-all"
+              className="border-2 border-dashed border-brand-border bg-transparent rounded-lg px-4 py-3 text-text-light cursor-pointer text-center hover:border-primary hover:text-primary hover:bg-accent transition-all"
             >
               + Add Skill
             </button>

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -311,7 +311,7 @@ export default function AdminStarterTasksPage() {
 
   return (
     <>
-      <main className="max-w-350 w-full mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="flex justify-between items-center mb-3">
           <h1>Quick Tasks</h1>
           <Button onClick={() => setShowCreate(true)}>Create Task</Button>

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Badge, type BadgeVariant } from '@/components/Badge'
 import Button from '@/components/Button'
 import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
@@ -38,17 +39,17 @@ interface Volunteer {
   name: string
 }
 
-const STATUS_STYLES: Record<string, { background: string; color: string }> = {
-  open: { background: '#FED7AA', color: '#9A3412' },
-  in_progress: { background: '#DBEAFE', color: '#1E40AF' },
-  under_review: { background: '#FEF3C7', color: '#92400E' },
-  completed: { background: '#D1FAE5', color: '#065F46' },
+const STATUS_VARIANTS: Record<string, BadgeVariant> = {
+  open: 'warning',
+  in_progress: 'info',
+  under_review: 'caution',
+  completed: 'success',
 }
 
-const RATING_COLORS: Record<string, string> = {
-  excellent: 'var(--success, #059669)',
-  good: 'var(--secondary, #1D3557)',
-  needs_improvement: 'var(--error, #DC2626)',
+const RATING_CLASSES: Record<string, string> = {
+  excellent: 'text-success',
+  good: 'text-secondary',
+  needs_improvement: 'text-error',
 }
 
 const RATING_LABELS: Record<string, string> = {
@@ -380,21 +381,20 @@ export default function AdminStarterTasksPage() {
                           </span>
                         )}
                         {task.reviewRating && (
-                          <span style={{ color: RATING_COLORS[task.reviewRating] }}>
+                          <span className={RATING_CLASSES[task.reviewRating]}>
                             {RATING_LABELS[task.reviewRating]}
                           </span>
                         )}
                       </div>
                     </div>
                   </div>
-                  <span
+                  <Badge
                     role="status"
-                    className="status-badge px-2 py-0.5 rounded-xl text-xs font-semibold uppercase tracking-[0.05em] whitespace-nowrap shrink-0"
-                    // dynamic: background/color vary by task.status
-                    style={STATUS_STYLES[task.status]}
+                    variant={STATUS_VARIANTS[task.status] ?? 'neutral'}
+                    className="whitespace-nowrap shrink-0"
                   >
                     {task.status}
-                  </span>
+                  </Badge>
                 </div>
 
                 {expanded && (
@@ -402,11 +402,7 @@ export default function AdminStarterTasksPage() {
                     <p className="whitespace-pre-wrap mb-3 text-[0.9rem]">{task.description}</p>
 
                     {task.reviewRating && (
-                      <p
-                        className="mb-2 font-medium"
-                        // dynamic: color varies by reviewRating
-                        style={{ color: RATING_COLORS[task.reviewRating] }}
-                      >
+                      <p className={`mb-2 font-medium ${RATING_CLASSES[task.reviewRating]}`}>
                         Rating: {RATING_LABELS[task.reviewRating]}
                       </p>
                     )}

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -312,14 +312,7 @@ export default function AdminStarterTasksPage() {
   return (
     <>
       <main className="max-w-350 w-full mx-auto px-6 py-5 pb-15">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 12,
-          }}
-        >
+        <div className="flex justify-between items-center mb-3">
           <h1>Quick Tasks</h1>
           <Button onClick={() => setShowCreate(true)}>Create Task</Button>
         </div>
@@ -328,7 +321,7 @@ export default function AdminStarterTasksPage() {
           Small, scoped tasks to verify volunteer skills before assigning bigger projects.
         </p>
 
-        <div className="mb-6" style={{ maxWidth: 240 }}>
+        <div className="mb-6 max-w-[240px]">
           <FilterDropdown
             id="status-filter"
             label="Status"
@@ -359,30 +352,20 @@ export default function AdminStarterTasksPage() {
                 className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
               >
                 <div
-                  className="card-header flex justify-between items-start gap-3 min-w-0"
-                  style={{ cursor: 'pointer', marginBottom: expanded ? 12 : 0 }}
+                  className={`card-header flex justify-between items-start gap-3 min-w-0 cursor-pointer ${expanded ? 'mb-3' : 'mb-0'}`}
                   onClick={() => toggleCard(task.id)}
                 >
-                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, minWidth: 0 }}>
+                  <div className="flex items-start gap-2 min-w-0">
                     <span
-                      style={{
-                        display: 'inline-block',
-                        transition: 'transform 0.2s',
-                        transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-                        flexShrink: 0,
-                        marginTop: 4,
-                        color: 'var(--text-light)',
-                        fontSize: '0.75rem',
-                      }}
+                      className="inline-block transition-transform shrink-0 mt-1 text-text-light text-xs"
+                      // dynamic: transform rotates based on expanded state
+                      style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
                     >
                       ▶
                     </span>
-                    <div style={{ minWidth: 0 }}>
-                      <h3 style={{ margin: '0 0 4px' }}>{task.title}</h3>
-                      <div
-                        className="text-text-light"
-                        style={{ display: 'flex', gap: 8, flexWrap: 'wrap', fontSize: '0.8rem' }}
-                      >
+                    <div className="min-w-0">
+                      <h3 className="mb-1">{task.title}</h3>
+                      <div className="text-text-light flex gap-2 flex-wrap text-[0.8rem]">
                         {task.skillName && <span>Skill: {task.skillName}</span>}
                         {task.estimatedHours !== null && <span>~{task.estimatedHours}h</span>}
                         {task.assignedToId && task.assignedToName && (
@@ -406,18 +389,9 @@ export default function AdminStarterTasksPage() {
                   </div>
                   <span
                     role="status"
-                    className="status-badge"
-                    style={{
-                      padding: '2px 8px',
-                      borderRadius: 12,
-                      fontSize: '0.75rem',
-                      fontWeight: 600,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.05em',
-                      whiteSpace: 'nowrap',
-                      flexShrink: 0,
-                      ...STATUS_STYLES[task.status],
-                    }}
+                    className="status-badge px-2 py-0.5 rounded-xl text-xs font-semibold uppercase tracking-[0.05em] whitespace-nowrap shrink-0"
+                    // dynamic: background/color vary by task.status
+                    style={STATUS_STYLES[task.status]}
                   >
                     {task.status}
                   </span>
@@ -425,31 +399,19 @@ export default function AdminStarterTasksPage() {
 
                 {expanded && (
                   <>
-                    <p style={{ whiteSpace: 'pre-wrap', margin: '0 0 12px', fontSize: '0.9rem' }}>
-                      {task.description}
-                    </p>
+                    <p className="whitespace-pre-wrap mb-3 text-[0.9rem]">{task.description}</p>
 
                     {task.reviewRating && (
                       <p
-                        style={{
-                          marginBottom: 8,
-                          fontWeight: 500,
-                          color: RATING_COLORS[task.reviewRating],
-                        }}
+                        className="mb-2 font-medium"
+                        // dynamic: color varies by reviewRating
+                        style={{ color: RATING_COLORS[task.reviewRating] }}
                       >
                         Rating: {RATING_LABELS[task.reviewRating]}
                       </p>
                     )}
                     {task.reviewNotes && (
-                      <p
-                        style={{
-                          fontSize: '0.875rem',
-                          color: 'var(--text-light)',
-                          marginBottom: 8,
-                        }}
-                      >
-                        Notes: {task.reviewNotes}
-                      </p>
+                      <p className="text-sm text-text-light mb-2">Notes: {task.reviewNotes}</p>
                     )}
 
                     <div className="mb-3">
@@ -457,17 +419,8 @@ export default function AdminStarterTasksPage() {
                       <CommentThread workItemId={task.id} />
                     </div>
 
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        marginTop: 12,
-                        paddingTop: 12,
-                        borderTop: '1px solid var(--border)',
-                      }}
-                    >
-                      <span style={{ fontSize: '0.875rem', color: 'var(--text-light)' }}>
+                    <div className="flex justify-between items-center mt-3 pt-3 border-t border-brand-border">
+                      <span className="text-sm text-text-light">
                         Created {formatDate(task.createdAt)}
                       </span>
                       <div className="flex gap-2">
@@ -591,10 +544,7 @@ export default function AdminStarterTasksPage() {
                     placeholder="What should the volunteer do? Include any context, examples, or guidelines."
                   />
                 </div>
-                <div
-                  style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}
-                  className="mb-5"
-                >
+                <div className="grid grid-cols-2 gap-4 mb-5">
                   <div>
                     <FilterDropdown
                       id="ct-skill"
@@ -679,10 +629,7 @@ export default function AdminStarterTasksPage() {
                     required
                   />
                 </div>
-                <div
-                  style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}
-                  className="mb-5"
-                >
+                <div className="grid grid-cols-2 gap-4 mb-5">
                   <div>
                     <FilterDropdown
                       id="et-skill"
@@ -791,19 +738,16 @@ export default function AdminStarterTasksPage() {
               <h2 id="review-dialog-title">Review Task</h2>
             </div>
             <div className="p-6">
-              <h3 style={{ marginBottom: 4 }}>{reviewModal.title}</h3>
+              <h3 className="mb-1">{reviewModal.title}</h3>
               {reviewModal.assignedToName && (
                 <p className="text-text-light mb-4">Submitted by: {reviewModal.assignedToName}</p>
               )}
               <form onSubmit={reviewTask}>
                 <div className="mb-5">
                   <label>Rating</label>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+                  <div className="flex flex-col gap-2 mt-2">
                     {(['excellent', 'good', 'needs_improvement'] as const).map((r) => (
-                      <label
-                        key={r}
-                        style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}
-                      >
+                      <label key={r} className="flex items-center gap-2 cursor-pointer">
                         <input
                           type="radio"
                           value={r}

--- a/app/admin/stats/page.tsx
+++ b/app/admin/stats/page.tsx
@@ -28,9 +28,7 @@ export default function AdminStatsPage() {
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="bg-surface rounded-xl shadow p-6 overflow-hidden">
               <h2 className="mt-0">Volunteers</h2>
-              <div
-                style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginTop: 16 }}
-              >
+              <div className="grid grid-cols-2 gap-5 mt-4">
                 <div>
                   <div className="text-4xl font-bold text-primary mb-1">
                     {stats.volunteers.total}
@@ -48,7 +46,7 @@ export default function AdminStatsPage() {
 
             <div className="bg-surface rounded-xl shadow p-6 overflow-hidden">
               <h2 className="mt-0">Projects</h2>
-              <div style={{ marginTop: 16 }}>
+              <div className="mt-4">
                 {[
                   { label: 'Total', value: stats.projects.total, color: undefined },
                   {
@@ -66,13 +64,7 @@ export default function AdminStatsPage() {
                 ].map((row, i, arr) => (
                   <div
                     key={row.label}
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      padding: '8px 0',
-                      borderBottom:
-                        i < arr.length - 1 ? '1px solid var(--color-border)' : undefined,
-                    }}
+                    className={`flex justify-between py-2${i < arr.length - 1 ? ' border-b border-brand-border' : ''}`}
                   >
                     <span className={row.color}>{row.label}</span>
                     <strong>{row.value}</strong>
@@ -83,9 +75,7 @@ export default function AdminStatsPage() {
 
             <div className="bg-surface rounded-xl shadow p-6 overflow-hidden">
               <h2 className="mt-0">Volunteer Interest</h2>
-              <div
-                style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginTop: 16 }}
-              >
+              <div className="grid grid-cols-2 gap-5 mt-4">
                 <div>
                   <div className="text-4xl font-bold text-secondary mb-1">
                     {stats.interests.total}
@@ -103,7 +93,7 @@ export default function AdminStatsPage() {
 
             <div className="bg-surface rounded-xl shadow p-6 overflow-hidden">
               <h2 className="mt-0">Quick Actions</h2>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 16 }}>
+              <div className="flex flex-col gap-3 mt-4">
                 <Button variant="outline" href="/admin/triage">
                   Review Pending Projects ({stats.projects.pendingReview})
                 </Button>

--- a/app/admin/stats/page.tsx
+++ b/app/admin/stats/page.tsx
@@ -17,7 +17,7 @@ export default function AdminStatsPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Platform Statistics</h1>
 
         {loadingData ? (

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -97,7 +97,7 @@ export default function AdminTeamPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="flex justify-between items-center mb-6">
           <h1>Team Management</h1>
           <Button onClick={openInviteDialog}>Invite Admin</Button>

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -98,14 +98,7 @@ export default function AdminTeamPage() {
   return (
     <>
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 24,
-          }}
-        >
+        <div className="flex justify-between items-center mb-6">
           <h1>Team Management</h1>
           <Button onClick={openInviteDialog}>Invite Admin</Button>
         </div>
@@ -132,21 +125,12 @@ export default function AdminTeamPage() {
                   admins.map((a) => (
                     <div
                       key={a.id}
-                      className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
-                      style={{ marginBottom: 12 }}
+                      className="card bg-surface rounded-xl shadow p-6 mb-3 overflow-hidden wrap-break-word"
                     >
-                      <div
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                        }}
-                      >
+                      <div className="flex justify-between items-center">
                         <div>
                           <strong>{a.name}</strong>
-                          <p className="text-text-light text-sm" style={{ margin: 0 }}>
-                            {a.email}
-                          </p>
+                          <p className="text-text-light text-sm m-0">{a.email}</p>
                         </div>
                         {a.id !== user.id && (
                           <Button
@@ -173,19 +157,12 @@ export default function AdminTeamPage() {
                   invites.map((inv) => (
                     <div
                       key={inv.id}
-                      className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
-                      style={{ marginBottom: 12 }}
+                      className="card bg-surface rounded-xl shadow p-6 mb-3 overflow-hidden wrap-break-word"
                     >
-                      <div
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                        }}
-                      >
+                      <div className="flex justify-between items-center">
                         <div>
                           <strong>{inv.email}</strong>
-                          <p className="text-text-light text-sm" style={{ margin: 0 }}>
+                          <p className="text-text-light text-sm m-0">
                             Invited by {inv.invitedByName} · Expires{' '}
                             {new Date(inv.expiresAt).toLocaleDateString()}
                           </p>
@@ -217,11 +194,11 @@ export default function AdminTeamPage() {
               className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto"
             >
               <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
-                <h2 style={{ marginTop: 0 }}>Invite Admin</h2>
+                <h2 className="mt-0">Invite Admin</h2>
               </div>
               <div className="p-6">
                 {inviteSuccess ? (
-                  <p role="status" style={{ color: 'var(--success)' }}>
+                  <p role="status" className="text-success">
                     {inviteSuccess}
                   </p>
                 ) : (

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -128,7 +128,7 @@ export default function TriagePage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Project Triage</h1>
 
         <Tabs

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -261,7 +261,7 @@ export default function TriagePage() {
                         {i.volunteerSkills.map((s: { id: number; name: string }) => (
                           <span
                             key={s.id}
-                            className="inline-flex items-center px-2 py-0.5 bg-accent text-secondary-dark rounded-full text-xs font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                            className="inline-flex items-center px-2 py-0.5 bg-accent text-secondary-dark rounded-full text-xs font-medium dark:bg-gray-700 dark:text-gray-300"
                           >
                             {s.name}
                           </span>
@@ -356,16 +356,8 @@ export default function TriagePage() {
             </div>
 
             <div className="p-6">
-              <h3 style={{ marginBottom: 8 }}>{modal.project.title}</h3>
-              <p
-                className="text-text-light"
-                style={{
-                  whiteSpace: 'pre-wrap',
-                  marginBottom: 16,
-                  maxHeight: 200,
-                  overflow: 'auto',
-                }}
-              >
+              <h3 className="mb-2">{modal.project.title}</h3>
+              <p className="text-text-light whitespace-pre-wrap mb-4 max-h-[200px] overflow-auto">
                 {modal.project.description}
               </p>
 
@@ -382,10 +374,8 @@ export default function TriagePage() {
               <form onSubmit={submitReview}>
                 <div className="mb-5">
                   <label>Decision</label>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
-                    <label
-                      style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}
-                    >
+                  <div className="flex flex-col gap-2 mt-2">
+                    <label className="flex items-center gap-2 cursor-pointer">
                       <input
                         type="radio"
                         name="decision"
@@ -397,9 +387,7 @@ export default function TriagePage() {
                         <strong>Approve</strong> — Make visible to volunteers
                       </span>
                     </label>
-                    <label
-                      style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}
-                    >
+                    <label className="flex items-center gap-2 cursor-pointer">
                       <input
                         type="radio"
                         name="decision"
@@ -424,7 +412,7 @@ export default function TriagePage() {
                       value={feedback}
                       onChange={(e) => setFeedback(e.target.value)}
                       placeholder="Explain what you'd like to discuss…"
-                      style={{ width: '100%' }}
+                      className="w-full"
                     />
                   </div>
                 )}
@@ -437,7 +425,7 @@ export default function TriagePage() {
                     value={reviewNotes}
                     onChange={(e) => setReviewNotes(e.target.value)}
                     placeholder="Notes for other admins…"
-                    style={{ width: '100%' }}
+                    className="w-full"
                   />
                 </div>
 

--- a/app/admin/volunteers/[id]/page.tsx
+++ b/app/admin/volunteers/[id]/page.tsx
@@ -216,7 +216,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
   if (loadingData) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="text-center py-10 text-text-light">Loading…</div>
         </main>
       </>
@@ -226,7 +226,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
   if (!vol) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <p className="text-error">Volunteer not found.</p>
           <Button href="/volunteers" variant="secondary" className="mt-4">
             Back
@@ -238,7 +238,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="mb-4">
           <Link href="/volunteers" className="text-text-light">
             &larr; Back to Volunteers

--- a/app/admin/volunteers/[id]/page.tsx
+++ b/app/admin/volunteers/[id]/page.tsx
@@ -254,18 +254,12 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
             </div>
             <div className="flex gap-2">
               {vol.isAdmin && (
-                <span
-                  className="py-0.5 px-2 rounded-xl text-[0.8rem]"
-                  style={{ background: 'var(--primary-light, #e0f2fe)' }}
-                >
+                <span className="py-0.5 px-2 rounded-xl text-[0.8rem] bg-blue-100 dark:bg-blue-950">
                   Admin
                 </span>
               )}
               {!vol.consentMakeProfileVisibleInDirectory && (
-                <span
-                  className="py-0.5 px-2 rounded-xl text-[0.8rem]"
-                  style={{ background: 'var(--warning-bg, #fffbeb)' }}
-                >
+                <span className="py-0.5 px-2 rounded-xl text-[0.8rem] bg-amber-50 dark:bg-amber-900">
                   Profile Hidden
                 </span>
               )}
@@ -405,10 +399,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                       <div>
                         <div className="flex justify-between items-start">
                           <div>
-                            <span
-                              className="text-[0.8rem] px-1.5 py-px rounded-lg"
-                              style={{ background: 'var(--bg-secondary, #f8fafc)' }}
-                            >
+                            <span className="text-[0.8rem] px-1.5 py-px rounded-lg bg-brand-bg">
                               {n.category.replace(/_/g, ' ')}
                             </span>
                             <span className="text-text-light text-[0.8rem] ml-2">

--- a/app/admin/volunteers/[id]/page.tsx
+++ b/app/admin/volunteers/[id]/page.tsx
@@ -227,8 +227,8 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
     return (
       <>
         <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-          <p style={{ color: 'var(--error)' }}>Volunteer not found.</p>
-          <Button href="/volunteers" variant="secondary" style={{ marginTop: 16 }}>
+          <p className="text-error">Volunteer not found.</p>
+          <Button href="/volunteers" variant="secondary" className="mt-4">
             Back
           </Button>
         </main>
@@ -246,89 +246,57 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
         </div>
 
         {/* Profile header */}
-        <div
-          className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
-          style={{ marginBottom: 24 }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              marginBottom: 12,
-            }}
-          >
+        <div className="bg-surface rounded-xl shadow p-6 mb-6 overflow-hidden wrap-break-word">
+          <div className="flex justify-between items-start mb-3">
             <div>
-              <h1 style={{ margin: '0 0 4px' }}>{vol.name}</h1>
-              <p className="text-text-light" style={{ margin: 0 }}>
-                {vol.email}
-              </p>
+              <h1 className="mb-1">{vol.name}</h1>
+              <p className="text-text-light m-0">{vol.email}</p>
             </div>
             <div className="flex gap-2">
               {vol.isAdmin && (
                 <span
-                  style={{
-                    padding: '2px 8px',
-                    borderRadius: 12,
-                    background: 'var(--primary-light, #e0f2fe)',
-                    fontSize: '0.8rem',
-                  }}
+                  className="py-0.5 px-2 rounded-xl text-[0.8rem]"
+                  style={{ background: 'var(--primary-light, #e0f2fe)' }}
                 >
                   Admin
                 </span>
               )}
               {!vol.consentMakeProfileVisibleInDirectory && (
                 <span
-                  style={{
-                    padding: '2px 8px',
-                    borderRadius: 12,
-                    background: 'var(--warning-bg, #fffbeb)',
-                    fontSize: '0.8rem',
-                  }}
+                  className="py-0.5 px-2 rounded-xl text-[0.8rem]"
+                  style={{ background: 'var(--warning-bg, #fffbeb)' }}
                 >
                   Profile Hidden
                 </span>
               )}
             </div>
           </div>
-          {vol.bio && <p style={{ marginBottom: 0, whiteSpace: 'pre-wrap' }}>{vol.bio}</p>}
+          {vol.bio && <p className="mb-0 whitespace-pre-wrap">{vol.bio}</p>}
         </div>
 
         {/* Skills and contact info */}
-        <div
-          className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
-          style={{ marginBottom: 24 }}
-        >
+        <div className="bg-surface rounded-xl shadow p-6 mb-6 overflow-hidden wrap-break-word">
           <h3>Skills (Self-Assessed)</h3>
           {vol.skills.length > 0 ? (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 16 }}>
+            <div className="flex flex-wrap gap-1.5 mb-4">
               {vol.skills.map((s) => (
                 <span
                   key={s.id}
-                  className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                  className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300"
                 >
                   {s.name}
                 </span>
               ))}
             </div>
           ) : (
-            <p className="text-text-light" style={{ marginBottom: 16 }}>
-              No skills listed.
-            </p>
+            <p className="text-text-light mb-4">No skills listed.</p>
           )}
 
           <h3>Verified Skills (Endorsed)</h3>
-          <div id="endorsements" style={{ marginBottom: 16 }}>
+          <div id="endorsements" className="mb-4">
             {vol.endorsements.length > 0 ? (
               vol.endorsements.map((e) => (
-                <div
-                  key={e.id}
-                  style={{
-                    padding: '6px 0',
-                    borderBottom: '1px solid var(--border)',
-                    fontSize: '0.875rem',
-                  }}
-                >
+                <div key={e.id} className="py-1.5 border-b border-brand-border text-sm">
                   <strong>{e.skillName}</strong> — {e.rating} · by {e.endorsedByName}
                 </div>
               ))
@@ -339,36 +307,36 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
 
           <h3>Contact Info</h3>
           <div id="contactInfo" className="text-sm">
-            <p style={{ margin: '4px 0' }}>
+            <p className="my-1">
               <strong>Email:</strong> {vol.email}
             </p>
             {vol.location && (
-              <p style={{ margin: '4px 0' }}>
+              <p className="my-1">
                 <strong>Location:</strong> {vol.location}
               </p>
             )}
             {vol.localGroup && (
-              <p style={{ margin: '4px 0' }}>
+              <p className="my-1">
                 <strong>Local Group:</strong> {vol.localGroup}
               </p>
             )}
             {vol.availabilityHoursPerWeek && (
-              <p style={{ margin: '4px 0' }}>
+              <p className="my-1">
                 <strong>Availability:</strong> {vol.availabilityHoursPerWeek}h/week
               </p>
             )}
             {vol.discordHandle && (
-              <p style={{ margin: '4px 0' }}>
+              <p className="my-1">
                 <strong>Discord:</strong> {vol.discordHandle}
               </p>
             )}
             {vol.signalNumber && (
-              <p style={{ margin: '4px 0' }}>
+              <p className="my-1">
                 <strong>Signal:</strong> {vol.signalNumber}
               </p>
             )}
             {vol.whatsappNumber && (
-              <p style={{ margin: '4px 0' }}>
+              <p className="my-1">
                 <strong>WhatsApp:</strong> {vol.whatsappNumber}
               </p>
             )}
@@ -396,22 +364,13 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
             <div>
               <div id="notesList">
                 {vol.adminNotes.length === 0 && (
-                  <p className="text-text-light" style={{ marginBottom: 16 }}>
-                    No notes yet.
-                  </p>
+                  <p className="text-text-light mb-4">No notes yet.</p>
                 )}
                 {vol.adminNotes.map((n) => (
-                  <div
-                    key={n.id}
-                    style={{ padding: '12px 0', borderBottom: '1px solid var(--border)' }}
-                  >
+                  <div key={n.id} className="py-3 border-b border-brand-border">
                     {editingNoteId === n.id ? (
                       <div>
-                        <label
-                          htmlFor={`edit-note-${n.id}`}
-                          className="text-sm"
-                          style={{ display: 'block', marginBottom: 4 }}
-                        >
+                        <label htmlFor={`edit-note-${n.id}`} className="text-sm block mb-1">
                           Edit note
                         </label>
                         <textarea
@@ -419,7 +378,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                           rows={3}
                           value={editingNoteContent}
                           onChange={(e) => setEditingNoteContent(e.target.value)}
-                          style={{ width: '100%', marginBottom: 8 }}
+                          className="w-full mb-2"
                         />
                         <div className="flex gap-2">
                           <Button
@@ -444,28 +403,15 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                       </div>
                     ) : (
                       <div>
-                        <div
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'flex-start',
-                          }}
-                        >
+                        <div className="flex justify-between items-start">
                           <div>
                             <span
-                              style={{
-                                fontSize: '0.8rem',
-                                background: 'var(--bg-secondary, #f8fafc)',
-                                padding: '1px 6px',
-                                borderRadius: 8,
-                              }}
+                              className="text-[0.8rem] px-1.5 py-px rounded-lg"
+                              style={{ background: 'var(--bg-secondary, #f8fafc)' }}
                             >
                               {n.category.replace(/_/g, ' ')}
                             </span>
-                            <span
-                              className="text-text-light"
-                              style={{ fontSize: '0.8rem', marginLeft: 8 }}
-                            >
+                            <span className="text-text-light text-[0.8rem] ml-2">
                               by {n.authorName}
                             </span>
                           </div>
@@ -485,16 +431,16 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                             </Button>
                           </div>
                         </div>
-                        <p style={{ margin: '8px 0 0', whiteSpace: 'pre-wrap' }}>{n.content}</p>
+                        <p className="mt-2 whitespace-pre-wrap">{n.content}</p>
                       </div>
                     )}
                   </div>
                 ))}
               </div>
 
-              <form onSubmit={addNote} style={{ marginTop: 16 }}>
-                <div style={{ display: 'flex', gap: 12, marginBottom: 8, flexWrap: 'wrap' }}>
-                  <div className="mb-5" style={{ margin: 0 }}>
+              <form onSubmit={addNote} className="mt-4">
+                <div className="flex gap-3 mb-2 flex-wrap">
+                  <div className="m-0">
                     <FilterDropdown
                       id="note-category"
                       label="Category"
@@ -514,7 +460,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                     onChange={(e) => setNoteContent(e.target.value)}
                     required
                     placeholder="Add an admin note…"
-                    style={{ width: '100%' }}
+                    className="w-full"
                   />
                 </div>
                 <Button type="submit" variant="secondary" disabled={submitting}>
@@ -533,13 +479,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                 vol.starterTasks.map((t) => (
                   <div
                     key={t.id}
-                    className="text-sm"
-                    style={{
-                      padding: '8px 0',
-                      borderBottom: '1px solid var(--border)',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                    }}
+                    className="text-sm py-2 border-b border-brand-border flex justify-between"
                   >
                     <span>
                       {t.title}
@@ -564,14 +504,9 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                 vol.projectHistory.map((p) => (
                   <div
                     key={p.id}
-                    style={{
-                      padding: '8px 0',
-                      borderBottom: '1px solid var(--border)',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                    }}
+                    className="py-2 border-b border-brand-border flex justify-between"
                   >
-                    <Link href={`/projects/${p.id}`} style={{ fontWeight: 500 }}>
+                    <Link href={`/projects/${p.id}`} className="font-medium">
                       {p.title}
                     </Link>
                     <div className="text-sm text-text-light">
@@ -587,11 +522,8 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
           {activeTab === 'endorse_skill' && (
             <div>
               <h3>Endorse a Skill</h3>
-              <form
-                onSubmit={addEndorsement}
-                style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 480 }}
-              >
-                <div className="mb-5" style={{ margin: 0 }}>
+              <form onSubmit={addEndorsement} className="flex flex-col gap-3 max-w-[480px]">
+                <div className="m-0">
                   <FilterDropdown
                     id="endorse-skill"
                     label="Skill"
@@ -608,7 +540,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                     searchable
                   />
                 </div>
-                <div className="mb-5" style={{ margin: 0 }}>
+                <div className="m-0">
                   <FilterDropdown
                     id="endorse-rating"
                     label="Rating"
@@ -618,7 +550,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
                     onChange={(v) => setEndorseRating(v)}
                   />
                 </div>
-                <div className="mb-5" style={{ margin: 0 }}>
+                <div className="m-0">
                   <FilterDropdown
                     id="endorse-based-on"
                     label="Based On"

--- a/app/api/cron/daily/route.ts
+++ b/app/api/cron/daily/route.ts
@@ -5,40 +5,27 @@ import { runDigestJob } from '@/jobs/digest'
 import { runNudgesJob } from '@/jobs/nudges'
 import { runApplicationsSummaryJob, runApplicationsAnonymisationJob } from '@/jobs/applications'
 
+const JOBS: { name: string; run: () => Promise<unknown> }[] = [
+  { name: 'backup', run: runBackupJob },
+  { name: 'digest', run: runDigestJob },
+  { name: 'nudges', run: runNudgesJob },
+  { name: 'applications', run: runApplicationsSummaryJob },
+  { name: 'anonymisation', run: runApplicationsAnonymisationJob },
+]
+
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const [backupResult, digestResult, nudgesResult, applicationsResult, anonymisationResult] =
-    await Promise.allSettled([
-      runBackupJob(),
-      runDigestJob(),
-      runNudgesJob(),
-      runApplicationsSummaryJob(),
-      runApplicationsAnonymisationJob(),
-    ])
+  const results = await Promise.allSettled(JOBS.map((j) => j.run()))
 
-  return NextResponse.json({
-    backup:
-      backupResult.status === 'fulfilled'
-        ? backupResult.value
-        : { error: String(backupResult.reason) },
-    digest:
-      digestResult.status === 'fulfilled'
-        ? digestResult.value
-        : { error: String(digestResult.reason) },
-    nudges:
-      nudgesResult.status === 'fulfilled'
-        ? nudgesResult.value
-        : { error: String(nudgesResult.reason) },
-    applications:
-      applicationsResult.status === 'fulfilled'
-        ? applicationsResult.value
-        : { error: String(applicationsResult.reason) },
-    anonymisation:
-      anonymisationResult.status === 'fulfilled'
-        ? anonymisationResult.value
-        : { error: String(anonymisationResult.reason) },
-  })
+  const body = Object.fromEntries(
+    JOBS.map((job, i) => {
+      const r = results[i]
+      return [job.name, r.status === 'fulfilled' ? r.value : { error: String(r.reason) }]
+    }),
+  )
+
+  return NextResponse.json(body)
 }

--- a/app/component-preview/page.tsx
+++ b/app/component-preview/page.tsx
@@ -29,7 +29,7 @@ export default function ComponentPreviewPage() {
   const [tasks, setTasks] = useState(['Build landing page', 'Write copy'])
 
   return (
-    <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+    <main className="container py-5 pb-15">
       <h1>Component Preview</h1>
       <p className="text-text-light mb-8">All button variants and patterns used across the app.</p>
 

--- a/app/component-preview/page.tsx
+++ b/app/component-preview/page.tsx
@@ -17,9 +17,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3 flex-wrap mb-4 last:mb-0">
-      <span className="text-text-light text-sm" style={{ minWidth: 80 }}>
-        {label}
-      </span>
+      <span className="text-text-light text-sm min-w-[80px]">{label}</span>
       {children}
     </div>
   )
@@ -129,7 +127,7 @@ export default function ComponentPreviewPage() {
 
       <Section title="Button — className overrides">
         <Row label="w-full">
-          <div style={{ width: 320 }}>
+          <div className="w-[320px]">
             <Button className="w-full">Full-width (login / reset-password)</Button>
           </div>
         </Row>
@@ -192,10 +190,7 @@ export default function ComponentPreviewPage() {
           All × buttons now use <code>{'<Button variant="ghost" icon>'}</code>.
         </p>
         <Row label="modal header">
-          <div
-            className="bg-surface border border-brand-border rounded-lg px-4 py-3 flex items-center gap-4"
-            style={{ minWidth: 280 }}
-          >
+          <div className="bg-surface border border-brand-border rounded-lg px-4 py-3 flex items-center gap-4 min-w-[280px]">
             <span className="font-medium flex-1">Modal Header</span>
             <Button variant="ghost" icon aria-label="Close">
               ×
@@ -204,10 +199,7 @@ export default function ComponentPreviewPage() {
         </Row>
         <Row label="banner dismiss">
           {!dismissed ? (
-            <div
-              className="flex items-center justify-between gap-3 p-4 rounded-lg bg-[#DBEAFE] text-[#1E40AF] border border-[#93C5FD] dark:bg-[#1E3A5F] dark:text-[#93C5FD] dark:border-[#2563EB]"
-              style={{ minWidth: 300 }}
-            >
+            <div className="flex items-center justify-between gap-3 p-4 rounded-lg bg-blue-100 text-blue-800 border border-blue-300 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-600 min-w-[300px]">
               <span>Dismissible banner.</span>
               <Button variant="ghost" icon onClick={() => setDismissed(true)} aria-label="Dismiss">
                 ×
@@ -223,7 +215,7 @@ export default function ComponentPreviewPage() {
           )}
         </Row>
         <Row label="remove item">
-          <div className="flex flex-col gap-2" style={{ minWidth: 280 }}>
+          <div className="flex flex-col gap-2 min-w-[280px]">
             {tasks.map((t, i) => (
               <div
                 key={i}
@@ -250,7 +242,7 @@ export default function ComponentPreviewPage() {
         <p className="text-text-light text-sm mb-3">
           Ghost variant with error text colour override — sits inside dropdown menu.
         </p>
-        <div className="bg-surface border border-brand-border rounded-lg" style={{ minWidth: 180 }}>
+        <div className="bg-surface border border-brand-border rounded-lg min-w-[180px]">
           <Button
             variant="ghost"
             className="w-full justify-start px-4 py-3 text-error hover:text-error"

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -158,7 +158,7 @@ export default function DashboardPage() {
 
         {/* Pending approval banner */}
         {user.approvalStatus === ApprovalStatus.pending && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-[#FEF9C3] text-[#854D0E] border border-[#FDE047] dark:bg-[#422006] dark:text-[#FDE047] dark:border-[#854D0E]">
+          <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-yellow-100 text-yellow-800 border border-yellow-300 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-800">
             <span>
               Your account is pending approval. You can browse the platform, but some actions are
               restricted until an admin reviews your application.
@@ -168,7 +168,7 @@ export default function DashboardPage() {
 
         {/* Email notification preference banner */}
         {showEmailBanner && (
-          <div className="flex items-center justify-between gap-3 p-4 rounded-lg mb-5 bg-[#DBEAFE] text-[#1E40AF] border border-[#93C5FD] dark:bg-[#1E3A5F] dark:text-[#93C5FD] dark:border-[#2563EB]">
+          <div className="flex items-center justify-between gap-3 p-4 rounded-lg mb-5 bg-blue-100 text-blue-800 border border-blue-300 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-600">
             <span>
               Stay in the loop — set your email notification preference in your{' '}
               <Link href="/profile" className="underline font-semibold">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -120,7 +120,7 @@ export default function DashboardPage() {
   if (loadingData) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="text-center py-10 text-text-light">Loading dashboard…</div>
         </main>
       </>
@@ -153,7 +153,7 @@ export default function DashboardPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1 role="heading">Welcome back, {user.name}!</h1>
 
         {/* Pending approval banner */}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -25,16 +25,16 @@ export default function ForgotPasswordPage() {
   return (
     <>
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div style={{ maxWidth: 400, margin: '60px auto' }}>
+        <div className="max-w-[400px] my-15 mx-auto">
           <h1 className="text-center">Reset Password</h1>
-          <p className="text-center text-text-light" style={{ marginBottom: 32 }}>
+          <p className="text-center text-text-light mb-8">
             Enter your email and we&apos;ll send you a reset link.
           </p>
 
           {mutation.isError && (
             <div
               role="alert"
-              className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEE2E2] text-[#991B1B] border border-[#FCA5A5] dark:bg-[#7F1D1D] dark:text-[#FCA5A5] dark:border-[#DC2626]"
+              className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-red-100 text-red-800 border border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-600"
             >
               {mutation.error instanceof Error ? mutation.error.message : 'Something went wrong'}
             </div>
@@ -65,32 +65,30 @@ export default function ForgotPasswordPage() {
                 {mutation.isPending ? 'Sending…' : 'Send Reset Link'}
               </Button>
 
-              <p className="text-center text-text-light" style={{ marginTop: 20 }}>
+              <p className="text-center text-text-light mt-5">
                 Remember your password? <Link href="/login">Login</Link>
               </p>
             </form>
           ) : (
             <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word">
               <div className="text-center">
-                <h3 style={{ color: 'var(--success)' }}>Check Your Email</h3>
-                <p className="text-text-light" style={{ margin: '16px 0' }}>
+                <h3 className="text-success">Check Your Email</h3>
+                <p className="text-text-light my-4">
                   If an account exists with that email, you&apos;ll receive a password reset link
                   shortly.
                 </p>
                 <Button href="/login" variant="outline">
                   Back to Login
                 </Button>
-                <p className="text-sm text-text-light" style={{ marginTop: 16 }}>
+                <p className="text-sm text-text-light mt-4">
                   Not receiving the email? Check your spam folder, or{' '}
                   <a href="mailto:matilda@pauseai.info">contact support</a>.
                 </p>
               </div>
               {devUrl && (
-                <div
-                  style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid var(--border)' }}
-                >
-                  <p style={{ fontSize: 12, color: 'var(--text-light)' }}>Dev mode — Reset link:</p>
-                  <a href={devUrl} style={{ wordBreak: 'break-all' }}>
+                <div className="mt-6 pt-4 border-t border-brand-border">
+                  <p className="text-[12px] text-text-light">Dev mode — Reset link:</p>
+                  <a href={devUrl} className="break-all">
                     {devUrl}
                   </a>
                 </div>

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -24,7 +24,7 @@ export default function ForgotPasswordPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-[400px] my-15 mx-auto">
           <h1 className="text-center">Reset Password</h1>
           <p className="text-center text-text-light mb-8">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -97,7 +97,7 @@ export default function LoginPage() {
           onLoad={initGoogleButton}
         />
       )}
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-[400px] my-15 mx-auto">
           <h1 className="text-center">Welcome Back</h1>
           <p className="text-center text-text-light mb-8">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -98,16 +98,16 @@ export default function LoginPage() {
         />
       )}
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div style={{ maxWidth: 400, margin: '60px auto' }}>
+        <div className="max-w-[400px] my-15 mx-auto">
           <h1 className="text-center">Welcome Back</h1>
-          <p className="text-center text-text-light" style={{ marginBottom: 32 }}>
+          <p className="text-center text-text-light mb-8">
             Login to access your dashboard and projects.
           </p>
 
           {error && (
             <div
               role="alert"
-              className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEE2E2] text-[#991B1B] border border-[#FCA5A5] dark:bg-[#7F1D1D] dark:text-[#FCA5A5] dark:border-[#DC2626]"
+              className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-red-100 text-red-800 border border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-600"
             >
               {error}
             </div>
@@ -117,10 +117,10 @@ export default function LoginPage() {
             {googleClientId && (
               <div className="text-center mb-5">
                 <div id="g_signin_btn" className="flex justify-center" />
-                <div style={{ display: 'flex', alignItems: 'center', margin: '20px 0', gap: 16 }}>
-                  <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border)' }} />
+                <div className="flex items-center my-5 gap-4">
+                  <hr className="flex-1 border-none border-t border-brand-border" />
                   <span className="text-text-light text-sm">or use email</span>
-                  <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border)' }} />
+                  <hr className="flex-1 border-none border-t border-brand-border" />
                 </div>
               </div>
             )}
@@ -161,16 +161,16 @@ export default function LoginPage() {
                 {submitting ? 'Logging in…' : 'Login'}
               </Button>
 
-              <p className="text-center" style={{ marginTop: 16 }}>
+              <p className="text-center mt-4">
                 <Link href="/forgot-password">Forgot your password?</Link>
               </p>
-              <p className="text-center text-text-light" style={{ marginTop: 12 }}>
+              <p className="text-center text-text-light mt-3">
                 Don&apos;t have an account? <Link href="/signup">Sign up</Link>
               </p>
             </form>
           </div>
 
-          <p className="text-center text-sm text-text-light" style={{ marginTop: 24 }}>
+          <p className="text-center text-sm text-text-light mt-6">
             <Link href="/privacy" className="text-text-light">
               Privacy Policy
             </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -187,7 +187,7 @@ export default function ProjectsPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1 role="heading">Projects</h1>
 
         {user.isAdmin && pendingCount > 0 && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -191,7 +191,7 @@ export default function ProjectsPage() {
         <h1 role="heading">Projects</h1>
 
         {user.isAdmin && pendingCount > 0 && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEF3C7] text-[#92400E] border border-[#FCD34D] dark:bg-[#78350F] dark:text-[#FDE68A] dark:border-[#D97706]">
+          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-amber-100 text-amber-800 border border-amber-300 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-600">
             <strong>
               {pendingCount} project{pendingCount !== 1 ? 's' : ''} pending review.
             </strong>{' '}
@@ -201,7 +201,7 @@ export default function ProjectsPage() {
           </div>
         )}
         {user.isAdmin && pendingApplicationsCount > 0 && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#EDE9FE] text-[#5B21B6] border border-[#C4B5FD] dark:bg-[#2E1065] dark:text-[#C4B5FD] dark:border-[#7C3AED]">
+          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-violet-100 text-violet-800 border border-violet-300 dark:bg-violet-950 dark:text-violet-300 dark:border-violet-600">
             <strong>
               {pendingApplicationsCount} application{pendingApplicationsCount !== 1 ? 's' : ''}{' '}
               pending review.
@@ -342,7 +342,7 @@ export default function ProjectsPage() {
                           {g.label} — {g.projects.length} project
                           {g.projects.length !== 1 ? 's' : ''}
                           <svg
-                            className="text-text-light shrink-0"
+                            className={`text-text-light shrink-0 transition-transform ${completedOpen ? 'rotate-180' : 'rotate-0'}`}
                             width="32"
                             height="32"
                             viewBox="0 0 24 24"
@@ -351,10 +351,6 @@ export default function ProjectsPage() {
                             strokeWidth="2.5"
                             strokeLinecap="round"
                             strokeLinejoin="round"
-                            style={{
-                              transform: completedOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-                              transition: 'transform 0.2s',
-                            }}
                           >
                             <polyline points="6 9 12 15 18 9" />
                           </svg>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -34,7 +34,7 @@ export default function PrivacyPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-[600px] mx-auto">
           <h1>Privacy &amp; Data</h1>
           <p className="text-text-light mb-6">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -35,7 +35,7 @@ export default function PrivacyPage() {
   return (
     <>
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div style={{ maxWidth: 600, margin: '0 auto' }}>
+        <div className="max-w-[600px] mx-auto">
           <h1>Privacy &amp; Data</h1>
           <p className="text-text-light mb-6">
             Manage your data and privacy settings. We&apos;re committed to respecting your rights
@@ -59,10 +59,7 @@ export default function PrivacyPage() {
                 </Button>
               </div>
 
-              <div
-                className="bg-surface rounded-xl shadow p-6 overflow-hidden wrap-break-word mb-6"
-                style={{ borderColor: 'var(--warning)' }}
-              >
+              <div className="bg-surface rounded-xl shadow p-6 overflow-hidden wrap-break-word mb-6 border-warning">
                 <h2>Delete Your Account</h2>
                 <p className="text-text-light mb-4">
                   Permanently delete your account and all associated data. This action cannot be
@@ -79,7 +76,7 @@ export default function PrivacyPage() {
             <h2>Our Data Practices</h2>
 
             <h4>What we collect</h4>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>Information you provide (name, email, bio, contact details)</li>
               <li>Skills and availability you share</li>
               <li>Projects you propose or express interest in</li>
@@ -89,7 +86,7 @@ export default function PrivacyPage() {
 
             <h4>Legal basis for processing</h4>
             <p className="text-text-light">We process your data based on:</p>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>
                 <strong>Consent</strong> — for sharing your profile with other volunteers and
                 allowing project owners to contact you (you can withdraw consent at any time via
@@ -107,7 +104,7 @@ export default function PrivacyPage() {
             </ul>
 
             <h4>How we use it</h4>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>To match you with relevant projects based on your skills</li>
               <li>To enable project owners to contact you (with your consent)</li>
               <li>
@@ -133,7 +130,7 @@ export default function PrivacyPage() {
             </ul>
 
             <h4>What we don&apos;t do</h4>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>We never sell your data</li>
               <li>We don&apos;t share your contact info without your consent</li>
               <li>
@@ -149,7 +146,7 @@ export default function PrivacyPage() {
               The following services process data on our behalf (as data processors under GDPR
               Article 28). We have assessed each for adequate data protection safeguards:
             </p>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>
                 <strong>Railway</strong> (hosting) — our application and database are hosted on
                 Railway&apos;s cloud infrastructure. Data may be processed in the United States. We
@@ -188,7 +185,7 @@ export default function PrivacyPage() {
             </p>
 
             <h4>Data retention</h4>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>Active accounts: data is kept as long as your account is active</li>
               <li>
                 Deleted accounts: personal data is anonymised immediately upon deletion. Anonymised
@@ -205,7 +202,7 @@ export default function PrivacyPage() {
             </ul>
 
             <h4>Cookies</h4>
-            <ul className="list-disc text-text-light mb-4" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light mb-4 pl-5">
               <li>
                 <strong>Essential cookies</strong> — we use localStorage (not cookies) to store your
                 login session and preferences (dark mode, cookie consent choice). These are
@@ -233,7 +230,7 @@ export default function PrivacyPage() {
             <p className="text-text-light mb-4">
               Under GDPR and the UK Data Protection Act 2018, you have the right to:
             </p>
-            <ul className="list-disc text-text-light" style={{ paddingLeft: 20 }}>
+            <ul className="list-disc text-text-light pl-5">
               <li>
                 <strong>Access</strong> (Article 15) — Download all your data using the export
                 feature above
@@ -260,14 +257,14 @@ export default function PrivacyPage() {
                 delete your account at any time
               </li>
             </ul>
-            <p className="text-text-light" style={{ marginTop: 16 }}>
+            <p className="text-text-light mt-4">
               <strong>Data Controller:</strong> Safe AI Alliance Ltd (trading as PauseAI UK /
               Catalyse)
               <br />
               <strong>Contact:</strong>{' '}
               <a href="mailto:matilda@pauseai.info">matilda@pauseai.info</a>
             </p>
-            <p className="text-text-light" style={{ marginTop: 12 }}>
+            <p className="text-text-light mt-3">
               If you are not satisfied with how we handle your data, you have the right to lodge a
               complaint with the <strong>Information Commissioner&apos;s Office (ICO)</strong> at{' '}
               <a
@@ -289,7 +286,7 @@ export default function PrivacyPage() {
             </div>
           )}
 
-          <p className="text-center" style={{ marginTop: 24 }}>
+          <p className="text-center mt-6">
             <Link href="/profile">&larr; Back to Profile</Link>
           </p>
         </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -129,7 +129,7 @@ export default function ProfilePage() {
   if (loadingProfile) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="text-center py-10 text-text-light">Loading profile…</div>
         </main>
       </>
@@ -138,7 +138,7 @@ export default function ProfilePage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Your Profile</h1>
 
         <form

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -135,7 +135,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   if (loadingProject) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="text-center py-10 text-text-light">Loading project…</div>
         </main>
       </>
@@ -144,7 +144,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1 role="heading">Edit Project</h1>
 
         {permissionChecked && !canEdit && (

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -150,7 +150,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
         {permissionChecked && !canEdit && (
           <div
             role="alert"
-            className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEE2E2] text-[#991B1B] border border-[#FCA5A5] dark:bg-[#7F1D1D] dark:text-[#FCA5A5] dark:border-[#DC2626]"
+            className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-red-100 text-red-800 border border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-600"
           >
             You do not have permission to edit this project.
           </div>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -47,16 +47,16 @@ const card = 'bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-w
 
 function statusBadge(status: string) {
   const colors: Record<string, string> = {
-    seeking_owner: 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]',
-    seeking_help: 'bg-[#DBEAFE] text-[#1E40AF] dark:bg-[#1E3A5F] dark:text-[#93C5FD]',
-    needs_tasks: 'bg-[#FEF9C3] text-[#713F12] dark:bg-[#78350F] dark:text-[#FDE68A]',
-    in_progress: 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]',
-    on_hold: 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]',
-    completed: 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]',
-    pending_review: 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]',
-    needs_discussion: 'bg-[#FCE7F3] text-[#9D174D]',
+    seeking_owner: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+    seeking_help: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+    needs_tasks: 'bg-yellow-100 text-yellow-900 dark:bg-amber-900 dark:text-amber-200',
+    in_progress: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
+    on_hold: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400',
+    completed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
+    pending_review: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+    needs_discussion: 'bg-pink-100 text-pink-800',
   }
-  return `inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${colors[status] ?? 'bg-[#F3F4F6] text-[#374151]'}`
+  return `inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${colors[status] ?? 'bg-gray-100 text-gray-700'}`
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -471,8 +471,8 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                     key={s.id}
                     className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
                       s.isRequired
-                        ? 'bg-secondary text-white dark:bg-[#4B5563]'
-                        : 'bg-accent text-secondary-dark dark:bg-[#374151] dark:text-[#D1D5DB]'
+                        ? 'bg-secondary text-white dark:bg-gray-600'
+                        : 'bg-accent text-secondary-dark dark:bg-gray-700 dark:text-gray-300'
                     }`}
                   >
                     {s.name}
@@ -488,7 +488,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           {!isOwner && project.match && project.match.overallScore > 0 && (
             <div className="mt-3 flex items-center gap-2">
               <span className="text-sm text-text-light">Your skill match:</span>
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]">
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300">
                 {project.match.overallScore}%
               </span>
             </div>
@@ -533,7 +533,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
         {project.outcome && (
           <div
             role="status"
-            className="bg-[#D1FAE5] dark:bg-[#064E3B] border border-[#6EE7B7] dark:border-[#059669] rounded-xl p-6 mb-4"
+            className="bg-emerald-100 dark:bg-emerald-900 border border-emerald-300 dark:border-emerald-600 rounded-xl p-6 mb-4"
           >
             <strong>Outcome: </strong>
             {project.outcome === 'successful'
@@ -556,10 +556,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
             {!project.myInterest ? (
               <form onSubmit={handleExpressInterest}>
                 <div className="mb-5">
-                  <label
-                    className="flex items-center gap-2 cursor-pointer mb-2"
-                    style={{ fontWeight: 400 }}
-                  >
+                  <label className="flex items-center gap-2 cursor-pointer mb-2 font-normal">
                     <input
                       type="radio"
                       name="interest_type"
@@ -569,10 +566,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                     />
                     I want to help out / contribute to this project
                   </label>
-                  <label
-                    className="flex items-center gap-2 cursor-pointer"
-                    style={{ fontWeight: 400 }}
-                  >
+                  <label className="flex items-center gap-2 cursor-pointer font-normal">
                     <input
                       type="radio"
                       name="interest_type"
@@ -621,7 +615,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
         {/* Tasks */}
         <div className={card}>
           <div className="flex justify-between items-center mb-3">
-            <h2 style={{ margin: 0 }}>Tasks</h2>
+            <h2 className="m-0">Tasks</h2>
             {isOwnerOrAdmin && (
               <Button variant="secondary" onClick={() => setShowTaskForm((v) => !v)}>
                 Add Task
@@ -698,7 +692,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           <div className={card}>
             <h2>Manage Project Status</h2>
             <form onSubmit={handleUpdateStatus} className="flex gap-2 items-end flex-wrap">
-              <div className="mb-0 flex-1" style={{ minWidth: 160 }}>
+              <div className="mb-0 flex-1 min-w-[160px]">
                 <FilterDropdown
                   id="change-status"
                   label="Change Status"
@@ -767,7 +761,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
             {volunteers.length > 0 && (
               <form onSubmit={handleAssign} className="flex gap-2 items-end flex-wrap mt-4">
-                <div className="flex-1" style={{ minWidth: 200 }}>
+                <div className="flex-1 min-w-[200px]">
                   <FilterDropdown
                     id="assign-volunteer"
                     label="Assign volunteer directly"
@@ -794,7 +788,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           <div className={card}>
             <h3>Transfer Ownership</h3>
             <form onSubmit={handleTransfer} className="flex gap-2 items-end flex-wrap">
-              <div className="flex-1" style={{ minWidth: 200 }}>
+              <div className="flex-1 min-w-[200px]">
                 <FilterDropdown
                   id="transfer-to"
                   label="Transfer to"
@@ -854,10 +848,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
             <h2>Review Project</h2>
             <form onSubmit={handleSubmitReview}>
               <div className="mb-5">
-                <label
-                  className="flex items-center gap-2 cursor-pointer mb-2"
-                  style={{ fontWeight: 400 }}
-                >
+                <label className="flex items-center gap-2 cursor-pointer mb-2 font-normal">
                   <input
                     type="radio"
                     name="review_status"
@@ -867,10 +858,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                   />
                   Approve
                 </label>
-                <label
-                  className="flex items-center gap-2 cursor-pointer"
-                  style={{ fontWeight: 400 }}
-                >
+                <label className="flex items-center gap-2 cursor-pointer font-normal">
                   <input
                     type="radio"
                     name="review_status"
@@ -927,7 +915,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
             className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto"
           >
             <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
-              <h2 style={{ margin: 0, fontSize: '1.25rem' }}>Contact Owner</h2>
+              <h2 className="m-0 text-xl">Contact Owner</h2>
               <Button
                 variant="ghost"
                 icon

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
+import { Badge } from '@/components/Badge'
+import { STATUS_LABELS, projectStatusVariant } from '@/components/ProjectCard'
 import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
@@ -13,18 +15,6 @@ import { useToast } from '@/lib/toast'
 import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 
 // ── Types ────────────────────────────────────────────────────────────────────
-
-const STATUS_LABELS: Record<string, string> = {
-  seeking_owner: 'Seeking Owner',
-  seeking_help: 'Seeking Help',
-  needs_tasks: 'Needs Tasks',
-  in_progress: 'In Progress',
-  on_hold: 'On Hold',
-  completed: 'Completed',
-  archived: 'Archived',
-  pending_review: 'Pending Review',
-  needs_discussion: 'Needs Discussion',
-}
 
 const OWNER_STATUSES = [
   { value: 'seeking_owner', label: 'Seeking Owner' },
@@ -44,20 +34,6 @@ const ADMIN_EXTRA_STATUSES = [
 // ── Tailwind class constants ──────────────────────────────────────────────────
 
 const card = 'bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word'
-
-function statusBadge(status: string) {
-  const colors: Record<string, string> = {
-    seeking_owner: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
-    seeking_help: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
-    needs_tasks: 'bg-yellow-100 text-yellow-900 dark:bg-amber-900 dark:text-amber-200',
-    in_progress: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
-    on_hold: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400',
-    completed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
-    pending_review: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
-    needs_discussion: 'bg-pink-100 text-pink-800',
-  }
-  return `inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${colors[status] ?? 'bg-gray-100 text-gray-700'}`
-}
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -303,7 +279,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   if (loadingProject) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="text-center py-10 text-text-light">Loading project…</div>
         </main>
       </>
@@ -441,12 +417,12 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         {/* [test hook] projectContent id used by action helpers to confirm page has loaded */}
         <div id="projectContent" className="flex items-center gap-3 flex-wrap mb-2">
-          <span aria-label="project status" className={statusBadge(project.status)}>
+          <Badge variant={projectStatusVariant(project.status)} aria-label="project status">
             {STATUS_LABELS[project.status] ?? project.status}
-          </span>
+          </Badge>
           {isOwnerOrAdmin && (
             <Button href={`/projects/${idParam}/edit`} variant="secondary" size="sm">
               Edit
@@ -488,9 +464,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           {!isOwner && project.match && project.match.overallScore > 0 && (
             <div className="mt-3 flex items-center gap-2">
               <span className="text-sm text-text-light">Your skill match:</span>
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300">
+              <Badge variant="success" className="text-sm">
                 {project.match.overallScore}%
-              </span>
+              </Badge>
             </div>
           )}
 
@@ -732,9 +708,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                             ? 'wants to own'
                             : 'wants to help'}
                         </span>
-                        <span className={`ml-2 ${statusBadge(interest.status)}`}>
+                        <Badge variant={projectStatusVariant(interest.status)} className="ml-2">
                           {interest.status}
-                        </span>
+                        </Badge>
                         {interest.message && (
                           <p className="text-sm mt-1 mb-0">{interest.message}</p>
                         )}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -116,7 +116,7 @@ function ResetPasswordForm() {
 export default function ResetPasswordPage() {
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-[400px] my-15 mx-auto">
           <h1 className="text-center">Set New Password</h1>
           <Suspense fallback={<div className="text-center py-10 text-text-light">Loading…</div>}>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -24,8 +24,8 @@ function ResetPasswordForm() {
   if (!token) {
     return (
       <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word text-center">
-        <h3 style={{ color: 'var(--error)' }}>Invalid Link</h3>
-        <p className="text-text-light" style={{ margin: '16px 0' }}>
+        <h3 className="text-error">Invalid Link</h3>
+        <p className="text-text-light my-4">
           This reset link is invalid or has expired. Please request a new one.
         </p>
         <Button href="/forgot-password" variant="outline">
@@ -67,7 +67,7 @@ function ResetPasswordForm() {
       {error && (
         <div
           role="alert"
-          className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEE2E2] text-[#991B1B] border border-[#FCA5A5] dark:bg-[#7F1D1D] dark:text-[#FCA5A5] dark:border-[#DC2626]"
+          className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-red-100 text-red-800 border border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-600"
         >
           {error}
         </div>
@@ -117,7 +117,7 @@ export default function ResetPasswordPage() {
   return (
     <>
       <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
-        <div style={{ maxWidth: 400, margin: '60px auto' }}>
+        <div className="max-w-[400px] my-15 mx-auto">
           <h1 className="text-center">Set New Password</h1>
           <Suspense fallback={<div className="text-center py-10 text-text-light">Loading…</div>}>
             <ResetPasswordForm />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -193,7 +193,7 @@ export default function SettingsPage() {
           >
             <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto">
               <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
-                <h2 style={{ margin: 0, fontSize: '1.25rem' }}>Delete Your Account</h2>
+                <h2 className="m-0 text-xl">Delete Your Account</h2>
               </div>
               <div className="p-6">
                 {user.hasPassword && (

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -94,7 +94,7 @@ export default function SettingsPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Settings</h1>
 
         {/* Change Email */}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -303,7 +303,7 @@ export default function SignupPage() {
             onLoad={initGoogleButton}
           />
         )}
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="max-w-2xl mx-auto">
             <h1>Complete your application</h1>
             <p className="text-text-light mb-6">
@@ -566,7 +566,7 @@ export default function SignupPage() {
   if (applicationPending) {
     const isGoogleSignup = !!googlePendingToken
     return (
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-2xl mx-auto">
           <div className="bg-surface rounded-xl shadow p-8 text-center">
             {isGoogleSignup ? (
@@ -631,7 +631,7 @@ export default function SignupPage() {
           onLoad={initGoogleButton}
         />
       )}
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="max-w-2xl mx-auto">
           <h1>Join Catalyse</h1>
           <p className="text-text-light mb-6">

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -312,7 +312,7 @@ export default function SignupPage() {
             {error && (
               <div
                 role="alert"
-                className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEE2E2] text-[#991B1B] border border-[#FCA5A5] dark:bg-[#7F1D1D] dark:text-[#FCA5A5] dark:border-[#DC2626]"
+                className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-red-100 text-red-800 border border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-600"
               >
                 {error}
               </div>
@@ -368,7 +368,7 @@ export default function SignupPage() {
                 />
               </div>
 
-              <h3 style={{ marginTop: 24 }}>Contact Preferences</h3>
+              <h3 className="mt-6">Contact Preferences</h3>
               <p className="text-sm text-text-light mt-1 mb-4">
                 Add ways for project owners to reach you. All optional.
               </p>
@@ -427,7 +427,7 @@ export default function SignupPage() {
                 />
               </div>
 
-              <h3 style={{ marginTop: 24 }}>Availability</h3>
+              <h3 className="mt-6">Availability</h3>
               <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-5">
                 <div className="mb-5">
                   <label htmlFor="g_availability">Hours per Week</label>
@@ -473,13 +473,13 @@ export default function SignupPage() {
                 </div>
               </div>
 
-              <h3 style={{ marginTop: 24 }}>Your Skills</h3>
-              <p className="text-sm text-text-light mt-1" style={{ marginBottom: 12 }}>
+              <h3 className="mt-6">Your Skills</h3>
+              <p className="text-sm text-text-light mt-1 mb-3">
                 Select skills you can contribute. This helps match you with projects.
               </p>
               <SkillPicker value={skills} onChange={setSkills} />
 
-              <div className="mb-5" style={{ marginTop: 16 }}>
+              <div className="mb-5 mt-4">
                 <label htmlFor="g_otherSkills">Other Skills</label>
                 <input
                   type="text"
@@ -490,10 +490,10 @@ export default function SignupPage() {
                 />
               </div>
 
-              <div style={{ marginTop: 24 }}>
+              <div className="mt-6">
                 <h3>Privacy &amp; Consent</h3>
                 <div className="flex flex-col gap-2">
-                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 400 }}>
+                  <label className="flex items-center gap-2 font-normal">
                     <input
                       type="checkbox"
                       checked={consentVisible}
@@ -501,7 +501,7 @@ export default function SignupPage() {
                     />
                     Make my profile visible in the volunteer directory
                   </label>
-                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 400 }}>
+                  <label className="flex items-center gap-2 font-normal">
                     <input
                       type="checkbox"
                       checked={consentContact}
@@ -510,14 +510,7 @@ export default function SignupPage() {
                     Allow project owners to contact me about opportunities
                   </label>
                   <label
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                      fontWeight: 400,
-                      marginLeft: 24,
-                      opacity: consentContact ? 1 : 0.5,
-                    }}
+                    className={`flex items-center gap-2 font-normal ml-6 ${consentContact ? 'opacity-100' : 'opacity-50'}`}
                   >
                     <input
                       type="checkbox"
@@ -528,7 +521,7 @@ export default function SignupPage() {
                     Share my contact info directly with project owners
                   </label>
                 </div>
-                <p className="text-sm text-text-light mt-1" style={{ marginTop: 12 }}>
+                <p className="text-sm text-text-light mt-3">
                   You can change these settings or delete your account at any time.{' '}
                   <Link href="/privacy" target="_blank">
                     Read our privacy policy
@@ -536,7 +529,7 @@ export default function SignupPage() {
                 </p>
               </div>
 
-              <h3 style={{ marginTop: 24 }}>Email Notifications</h3>
+              <h3 className="mt-6">Email Notifications</h3>
               <div className="mb-5">
                 <FilterDropdown
                   id="g_emailDigest"
@@ -548,14 +541,14 @@ export default function SignupPage() {
                 />
               </div>
 
-              <div style={{ marginTop: 12 }}>
+              <div className="mt-3">
                 <Button type="submit" className="w-full" disabled={googleApplicationSubmitting}>
                   {googleApplicationSubmitting ? 'Submitting…' : 'Submit Application'}
                 </Button>
               </div>
             </form>
 
-            <p className="text-center text-sm text-text-light" style={{ marginTop: 24 }}>
+            <p className="text-center text-sm text-text-light mt-6">
               <Link href="/privacy" className="text-text-light">
                 Privacy Policy
               </Link>
@@ -648,7 +641,7 @@ export default function SignupPage() {
           {error && (
             <div
               role="alert"
-              className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-[#FEE2E2] text-[#991B1B] border border-[#FCA5A5] dark:bg-[#7F1D1D] dark:text-[#FCA5A5] dark:border-[#DC2626]"
+              className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-red-100 text-red-800 border border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-600"
             >
               {error}
             </div>
@@ -669,10 +662,10 @@ export default function SignupPage() {
                   </button>
                 )}
               </div>
-              <div style={{ display: 'flex', alignItems: 'center', margin: '16px 0', gap: 16 }}>
-                <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border)' }} />
+              <div className="flex items-center my-4 gap-4">
+                <hr className="flex-1 border-none border-t border-brand-border" />
                 <span className="text-text-light text-sm">or sign up with email</span>
-                <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border)' }} />
+                <hr className="flex-1 border-none border-t border-brand-border" />
               </div>
             </>
           )}
@@ -781,7 +774,7 @@ export default function SignupPage() {
               />
             </div>
 
-            <h3 style={{ marginTop: 24 }}>Contact Preferences</h3>
+            <h3 className="mt-6">Contact Preferences</h3>
             <p className="text-sm text-text-light mt-1 mb-4">
               Add ways for project owners to reach you. All optional.
             </p>
@@ -844,7 +837,7 @@ export default function SignupPage() {
               />
             </div>
 
-            <h3 style={{ marginTop: 24 }}>Availability</h3>
+            <h3 className="mt-6">Availability</h3>
             <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-5">
               <div className="mb-5">
                 <label htmlFor="availability">Hours per Week</label>
@@ -894,13 +887,13 @@ export default function SignupPage() {
               </div>
             </div>
 
-            <h3 style={{ marginTop: 24 }}>Your Skills</h3>
-            <p className="text-sm text-text-light mt-1" style={{ marginBottom: 12 }}>
+            <h3 className="mt-6">Your Skills</h3>
+            <p className="text-sm text-text-light mt-1 mb-3">
               Select skills you can contribute. This helps match you with projects.
             </p>
             <SkillPicker value={skills} onChange={setSkills} />
 
-            <div className="mb-5" style={{ marginTop: 16 }}>
+            <div className="mb-5 mt-4">
               <label htmlFor="otherSkills">Other Skills</label>
               <input
                 type="text"
@@ -912,10 +905,10 @@ export default function SignupPage() {
               />
             </div>
 
-            <div style={{ marginTop: 24 }}>
+            <div className="mt-6">
               <h3>Privacy &amp; Consent</h3>
               <div className="flex flex-col gap-2">
-                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 400 }}>
+                <label className="flex items-center gap-2 font-normal">
                   <input
                     type="checkbox"
                     checked={consentVisible}
@@ -923,7 +916,7 @@ export default function SignupPage() {
                   />
                   Make my profile visible in the volunteer directory
                 </label>
-                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 400 }}>
+                <label className="flex items-center gap-2 font-normal">
                   <input
                     type="checkbox"
                     checked={consentContact}
@@ -932,14 +925,7 @@ export default function SignupPage() {
                   Allow project owners to contact me about opportunities
                 </label>
                 <label
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    fontWeight: 400,
-                    marginLeft: 24,
-                    opacity: consentContact ? 1 : 0.5,
-                  }}
+                  className={`flex items-center gap-2 font-normal ml-6 ${consentContact ? 'opacity-100' : 'opacity-50'}`}
                 >
                   <input
                     type="checkbox"
@@ -950,7 +936,7 @@ export default function SignupPage() {
                   Share my contact info directly with project owners
                 </label>
               </div>
-              <p className="text-sm text-text-light mt-1" style={{ marginTop: 12 }}>
+              <p className="text-sm text-text-light mt-3">
                 You can change these settings or delete your account at any time.{' '}
                 <Link href="/privacy" target="_blank">
                   Read our privacy policy
@@ -958,7 +944,7 @@ export default function SignupPage() {
               </p>
             </div>
 
-            <h3 style={{ marginTop: 24 }}>Email Notifications</h3>
+            <h3 className="mt-6">Email Notifications</h3>
             <div className="mb-5">
               <FilterDropdown
                 id="emailDigest"
@@ -970,18 +956,18 @@ export default function SignupPage() {
               />
             </div>
 
-            <div style={{ marginTop: 12 }}>
+            <div className="mt-3">
               <Button type="submit" className="w-full" disabled={submitting}>
                 {submitting ? 'Creating account…' : 'Create Account'}
               </Button>
             </div>
 
-            <p className="text-center text-text-light" style={{ marginTop: 16 }}>
+            <p className="text-center text-text-light mt-4">
               Already have an account? <Link href="/login">Login</Link>
             </p>
           </form>
 
-          <p className="text-center text-sm text-text-light" style={{ marginTop: 24 }}>
+          <p className="text-center text-sm text-text-light mt-6">
             <Link href="/privacy" className="text-text-light">
               Privacy Policy
             </Link>

--- a/app/starter-tasks/page.tsx
+++ b/app/starter-tasks/page.tsx
@@ -66,7 +66,7 @@ export default function StarterTasksPage() {
               <div className="flex justify-between items-start mb-2">
                 <h3 className="m-0">{task.title}</h3>
                 <span
-                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === StarterTaskStatus.completed ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
+                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === StarterTaskStatus.completed ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300' : 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'}`}
                 >
                   {STATUS_LABELS[task.status] ?? task.status}
                 </span>
@@ -74,7 +74,7 @@ export default function StarterTasksPage() {
 
               <div className="flex gap-2 mb-3 flex-wrap">
                 {task.skillName && (
-                  <span className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB]">
+                  <span className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300">
                     {task.skillName}
                   </span>
                 )}

--- a/app/starter-tasks/page.tsx
+++ b/app/starter-tasks/page.tsx
@@ -4,6 +4,7 @@ import { useRequireAuth } from '@/lib/hooks/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Link from 'next/link'
 import Button from '@/components/Button'
+import { Badge } from '@/components/Badge'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { StarterTaskStatus } from '@/generated/prisma/enums'
@@ -40,7 +41,7 @@ export default function StarterTasksPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>My Quick Tasks</h1>
         <p className="text-text-light mb-6">
           Small, self-contained tasks to help you get started and demonstrate your skills.
@@ -65,11 +66,11 @@ export default function StarterTasksPage() {
             >
               <div className="flex justify-between items-start mb-2">
                 <h3 className="m-0">{task.title}</h3>
-                <span
-                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${task.status === StarterTaskStatus.completed ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300' : 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'}`}
+                <Badge
+                  variant={task.status === StarterTaskStatus.completed ? 'success' : 'warning'}
                 >
                   {STATUS_LABELS[task.status] ?? task.status}
-                </span>
+                </Badge>
               </div>
 
               <div className="flex gap-2 mb-3 flex-wrap">

--- a/app/suggest-local-group/page.tsx
+++ b/app/suggest-local-group/page.tsx
@@ -66,7 +66,7 @@ export default function SuggestLocalGroupPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Suggest a Local Group</h1>
         <p className="text-text-light mb-6">
           Don&apos;t see your local group listed? Suggest it here and an admin will review it.

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -17,7 +17,7 @@ export default function SuggestPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1 role="heading">Suggest a Project</h1>
         <p>
           Have an idea for something PauseAI UK should do? Propose it here! Our team will review it

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -125,7 +125,7 @@ function VerifyEmailContent() {
 
 export default function VerifyEmailPage() {
   return (
-    <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+    <main className="container py-5 pb-15">
       <div className="max-w-lg mx-auto">
         <Suspense
           fallback={

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -76,7 +76,7 @@ function VerifyEmailContent() {
 
   return (
     <div className="bg-surface rounded-xl shadow p-8 text-center">
-      <h1 style={token ? { color: 'var(--error)' } : undefined}>
+      <h1 className={token ? 'text-error' : undefined}>
         {token ? 'Confirmation failed' : 'Confirm your email'}
       </h1>
       <p className="text-text-light mt-4 mb-6">{errorMessage}</p>

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useRequireAuth } from '@/lib/hooks/auth'
 import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import Button from '@/components/Button'
+import { Badge } from '@/components/Badge'
+import { STATUS_LABELS, projectStatusVariant } from '@/components/ProjectCard'
 import { orpc } from '@/lib/orpc'
 
 export default function VolunteerDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -25,7 +27,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
   if (loadingProfile) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <div className="text-center py-10 text-text-light">Loading profile…</div>
         </main>
       </>
@@ -35,7 +37,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
   if (isError || !volunteer) {
     return (
       <>
-        <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+        <main className="container py-5 pb-15">
           <p className="text-[color:var(--error)]">Volunteer not found.</p>
           <Button href="/volunteers" variant="secondary" className="mt-4">
             Back to Volunteers
@@ -53,7 +55,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <div className="mb-5">
           <Link href="/volunteers" className="text-text-light">
             &larr; Back to Volunteers
@@ -189,11 +191,9 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                     <Link href={`/projects/${p.id}`} className="font-semibold text-primary-dark">
                       {p.title}
                     </Link>
-                    <span
-                      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${p.status === 'in_progress' || p.status === 'completed' ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300' : p.status === 'on_hold' ? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400' : p.status === 'seeking_help' ? 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300' : 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'}`}
-                    >
-                      {p.status.replace(/_/g, ' ')}
-                    </span>
+                    <Badge variant={projectStatusVariant(p.status)}>
+                      {STATUS_LABELS[p.status] ?? p.status.replace(/_/g, ' ')}
+                    </Badge>
                   </div>
                   <p className="text-sm text-text-light mt-1">
                     {p.role === 'owner' ? 'Project owner' : 'Proposer'}

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -38,7 +38,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
     return (
       <>
         <main className="container py-5 pb-15">
-          <p className="text-[color:var(--error)]">Volunteer not found.</p>
+          <p className="text-error">Volunteer not found.</p>
           <Button href="/volunteers" variant="secondary" className="mt-4">
             Back to Volunteers
           </Button>
@@ -160,7 +160,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                   <div className="flex justify-between items-center">
                     <strong>{t.title}</strong>
                     <span
-                      className={`text-sm font-medium ${t.reviewRating === 'excellent' ? 'text-[color:var(--success)]' : 'text-secondary'}`}
+                      className={`text-sm font-medium ${t.reviewRating === 'excellent' ? 'text-success' : 'text-secondary'}`}
                     >
                       {t.reviewRating}
                     </span>

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -82,7 +82,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                 skills.map((s) => (
                   <span
                     key={s.id}
-                    className={`inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB]${endorsedSkillIds.has(s.id) ? ' matched' : ''}`}
+                    className={`inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300${endorsedSkillIds.has(s.id) ? ' matched' : ''}`}
                   >
                     {s.name}
                     {endorsedSkillIds.has(s.id) ? ' ✓' : ''}
@@ -108,7 +108,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                 </div>
               )}
 
-              <div id="contactInfo" style={{ display: hasContact ? 'block' : 'none' }}>
+              <div id="contactInfo" className={hasContact ? 'block' : 'hidden'}>
                 <h4 className="text-text-light">Contact</h4>
                 <div>
                   {volunteer.email && <div>Email: {volunteer.email}</div>}
@@ -138,7 +138,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                 {endorsements.map((e) => (
                   <span
                     key={e.skillId}
-                    className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                    className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300"
                     style={{
                       borderLeft: `3px solid ${e.rating === 'strong' ? 'var(--success)' : 'var(--secondary)'}`,
                     }}
@@ -171,7 +171,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                     </span>
                   </div>
                   {t.skillName && (
-                    <span className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-[#374151] dark:text-[#D1D5DB] mt-1">
+                    <span className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300 mt-1">
                       {t.skillName}
                     </span>
                   )}
@@ -190,7 +190,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                       {p.title}
                     </Link>
                     <span
-                      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${p.status === 'in_progress' || p.status === 'completed' ? 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]' : p.status === 'on_hold' ? 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]' : p.status === 'seeking_help' ? 'bg-[#DBEAFE] text-[#1E40AF] dark:bg-[#1E3A5F] dark:text-[#93C5FD]' : 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]'}`}
+                      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${p.status === 'in_progress' || p.status === 'completed' ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300' : p.status === 'on_hold' ? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400' : p.status === 'seeking_help' ? 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300' : 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'}`}
                     >
                       {p.status.replace(/_/g, ' ')}
                     </span>

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -140,17 +140,10 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
                 {endorsements.map((e) => (
                   <span
                     key={e.skillId}
-                    className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300"
-                    style={{
-                      borderLeft: `3px solid ${e.rating === 'strong' ? 'var(--success)' : 'var(--secondary)'}`,
-                    }}
+                    className={`inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300 border-l-[3px] ${e.rating === 'strong' ? 'border-l-success' : 'border-l-secondary'}`}
                   >
                     {e.skillName}{' '}
-                    <small
-                      style={{
-                        color: e.rating === 'strong' ? 'var(--success)' : 'var(--secondary)',
-                      }}
-                    >
+                    <small className={e.rating === 'strong' ? 'text-success' : 'text-secondary'}>
                       {e.rating}
                     </small>
                   </span>

--- a/app/volunteers/page.tsx
+++ b/app/volunteers/page.tsx
@@ -175,13 +175,13 @@ export default function VolunteersPage() {
                           {shown.map((s) => (
                             <span
                               key={s.id}
-                              className="inline-flex items-center px-2 py-0.5 bg-accent text-secondary-dark rounded-full text-xs font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                              className="inline-flex items-center px-2 py-0.5 bg-accent text-secondary-dark rounded-full text-xs font-medium dark:bg-gray-700 dark:text-gray-300"
                             >
                               {s.name}
                             </span>
                           ))}
                           {overflow > 0 && (
-                            <span className="inline-flex items-center px-2 py-0.5 bg-[#F3F4F6] text-text-light rounded-full text-xs font-medium dark:bg-[#374151] dark:text-[#9CA3AF]">
+                            <span className="inline-flex items-center px-2 py-0.5 bg-gray-100 text-text-light rounded-full text-xs font-medium dark:bg-gray-700 dark:text-gray-400">
                               and {overflow} more
                             </span>
                           )}

--- a/app/volunteers/page.tsx
+++ b/app/volunteers/page.tsx
@@ -77,7 +77,7 @@ export default function VolunteersPage() {
 
   return (
     <>
-      <main className="w-full max-w-350 mx-auto px-6 py-5 pb-15">
+      <main className="container py-5 pb-15">
         <h1>Volunteer Directory</h1>
 
         <div className="mb-5">

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+const BADGE_VARIANTS = {
+  success: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
+  warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  caution: 'bg-orange-200 text-amber-800 dark:bg-amber-900 dark:text-orange-200',
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  neutral: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400',
+  danger: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300',
+} as const
+
+export type BadgeVariant = keyof typeof BADGE_VARIANTS
+
+export function badgeClasses(variant: BadgeVariant, className = '') {
+  // `status-badge` is a documented e2e test selector — keep it.
+  return `status-badge inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${BADGE_VARIANTS[variant]} ${className}`.trim()
+}
+
+export function Badge({
+  variant = 'neutral',
+  className = '',
+  role,
+  'aria-label': ariaLabel,
+  children,
+}: {
+  variant?: BadgeVariant
+  className?: string
+  role?: string
+  'aria-label'?: string
+  children: React.ReactNode
+}) {
+  return (
+    <span role={role} aria-label={ariaLabel} className={badgeClasses(variant, className)}>
+      {children}
+    </span>
+  )
+}

--- a/components/BugReportDialog.tsx
+++ b/components/BugReportDialog.tsx
@@ -106,7 +106,7 @@ export default function BugReportDialog({ isOpen, onClose }: BugReportDialogProp
         </div>
         <div className="p-6">
           {success ? (
-            <div style={{ textAlign: 'center', padding: '20px 0' }}>
+            <div className="text-center py-5">
               <h3 role="heading">Thank you!</h3>
               <p>Your feedback has been submitted.</p>
               <Button onClick={handleClose}>Close</Button>

--- a/components/Checkbox.tsx
+++ b/components/Checkbox.tsx
@@ -6,10 +6,7 @@ type CheckboxProps = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 
 export default function Checkbox({ children, ...props }: CheckboxProps) {
   return (
-    <label
-      className="items-center gap-2 cursor-pointer"
-      style={{ display: 'flex', fontWeight: 400, marginBottom: 0 }}
-    >
+    <label className="flex items-center gap-2 cursor-pointer font-normal mb-0">
       <span className="relative flex-shrink-0">
         <input type="checkbox" className="sr-only peer" {...props} />
         <span className="block w-5 h-5 rounded border-2 border-brand-border dark:border-secondary bg-surface peer-checked:bg-primary peer-checked:border-primary dark:peer-checked:border-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 transition-colors" />

--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -72,9 +72,9 @@ export default function CookieConsentBanner() {
       )}
 
       {resolved && consent === null && (
-        <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-[var(--border)] bg-[var(--surface)] shadow-lg xl:h-16">
+        <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-brand-border bg-surface shadow-lg xl:h-16">
           <div className="container flex flex-wrap items-center justify-between gap-4 py-4 xl:h-full xl:py-0">
-            <p className="text-sm text-[var(--text-light)]">
+            <p className="text-sm text-text-light">
               We use Google Analytics to understand how the site is used. You can decline and it
               won&apos;t load.{' '}
               <a href="/privacy" className="underline">

--- a/components/FilterDropdown.tsx
+++ b/components/FilterDropdown.tsx
@@ -160,7 +160,7 @@ export default function FilterDropdown<T extends string>({
   }
 
   const triggerClass =
-    'w-full flex items-center justify-between p-3 bg-[var(--surface)] text-[var(--text)] border-2 border-[var(--border)] rounded-[var(--radius)] text-base font-[var(--font-body)] cursor-pointer focus:outline-none focus:border-[var(--secondary)] transition-colors'
+    'w-full flex items-center justify-between p-3 bg-surface text-brand-text border-2 border-brand-border rounded-lg text-base font-body cursor-pointer focus:outline-none focus:border-secondary transition-colors'
 
   // min-w-[200px]: deliberate minimum to prevent dropdown from collapsing on short labels
   return (
@@ -188,7 +188,7 @@ export default function FilterDropdown<T extends string>({
           tabIndex={searchable && open ? -1 : 0}
         >
           <span className="flex-1 text-left">{selectedLabel}</span>
-          <span className="ml-2 text-[var(--text-light)]">▾</span>
+          <span className="ml-2 text-text-light">▾</span>
         </button>
         {searchable && open && (
           <input

--- a/components/FilterDropdown.tsx
+++ b/components/FilterDropdown.tsx
@@ -162,8 +162,9 @@ export default function FilterDropdown<T extends string>({
   const triggerClass =
     'w-full flex items-center justify-between p-3 bg-[var(--surface)] text-[var(--text)] border-2 border-[var(--border)] rounded-[var(--radius)] text-base font-[var(--font-body)] cursor-pointer focus:outline-none focus:border-[var(--secondary)] transition-colors'
 
+  // min-w-[200px]: deliberate minimum to prevent dropdown from collapsing on short labels
   return (
-    <div ref={ref} style={{ minWidth: 200 }}>
+    <div ref={ref} className="min-w-[200px]">
       <label htmlFor={id}>{label}</label>
       <div className="relative">
         <button

--- a/components/FloatingActions.tsx
+++ b/components/FloatingActions.tsx
@@ -16,7 +16,7 @@ export default function FloatingActions() {
     <>
       {/* bottom-4 centers the group in the xl:h-16 footer; bottom-20 clears the same h-16 banner + the 16px gap */}
       <div
-        className={`fixed right-6 z-[200] hidden xl:flex items-center bg-surface border border-brand-border rounded-[var(--radius)] shadow-lg overflow-hidden ${bannerVisible ? 'bottom-20' : 'bottom-4'}`}
+        className={`fixed right-6 z-[200] hidden xl:flex items-center bg-surface border border-brand-border rounded-lg shadow-lg overflow-hidden ${bannerVisible ? 'bottom-20' : 'bottom-4'}`}
       >
         <ThemeToggle icon={false} className="rounded-none self-stretch" />
         {process.env.NODE_ENV === 'development' && (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -109,6 +109,19 @@ function DashboardNavButtons({ unreadCount }: { unreadCount: number }) {
   )
 }
 
+const ADMIN_NAV_ITEMS: { href: string; label: string; superAdminOnly?: boolean }[] = [
+  { href: '/admin/triage', label: 'Triage Queue' },
+  { href: '/admin/projects/new', label: 'Create Org Project' },
+  { href: '/admin/starter-tasks', label: 'Manage Quick Tasks' },
+  { href: '/admin/skills', label: 'Manage Skills' },
+  { href: '/admin/bugs', label: 'Bug Reports' },
+  { href: '/admin/team', label: 'Admin Team' },
+  { href: '/admin/stats', label: 'Platform Stats' },
+  { href: '/admin/applications', label: 'Manage Applications', superAdminOnly: true },
+  { href: '/admin/platform-settings', label: 'Platform Settings', superAdminOnly: true },
+  { href: '/admin/local-groups', label: 'Manage Local Groups' },
+]
+
 export default function Header() {
   const { user, loading, logout } = useAuth()
   const pathname = usePathname()
@@ -235,70 +248,17 @@ export default function Header() {
                           <div className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-light)] border-t border-brand-border mt-1">
                             Admin
                           </div>
-                          <Link
-                            href="/admin/triage"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Triage Queue
-                          </Link>
-                          <Link
-                            href="/admin/projects/new"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Create Org Project
-                          </Link>
-                          <Link
-                            href="/admin/starter-tasks"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Manage Quick Tasks
-                          </Link>
-                          <Link
-                            href="/admin/skills"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Manage Skills
-                          </Link>
-                          <Link
-                            href="/admin/bugs"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Bug Reports
-                          </Link>
-                          <Link
-                            href="/admin/team"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Admin Team
-                          </Link>
-                          <Link
-                            href="/admin/stats"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Platform Stats
-                          </Link>
-                          {user.isSuperAdmin && (
-                            <>
-                              <Link
-                                href="/admin/applications"
-                                className="block px-4 py-3 text-[var(--text)] no-underline"
-                              >
-                                Manage Applications
-                              </Link>
-                              <Link
-                                href="/admin/platform-settings"
-                                className="block px-4 py-3 text-[var(--text)] no-underline"
-                              >
-                                Platform Settings
-                              </Link>
-                            </>
-                          )}
-                          <Link
-                            href="/admin/local-groups"
-                            className="block px-4 py-3 text-[var(--text)] no-underline"
-                          >
-                            Manage Local Groups
-                          </Link>
+                          {ADMIN_NAV_ITEMS.filter(
+                            (i) => !i.superAdminOnly || user.isSuperAdmin,
+                          ).map((i) => (
+                            <Link
+                              key={i.href}
+                              href={i.href}
+                              className="block px-4 py-3 text-[var(--text)] no-underline"
+                            >
+                              {i.label}
+                            </Link>
+                          ))}
                         </>
                       )}
                       <div className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-light)] border-t border-brand-border mt-1">
@@ -439,24 +399,13 @@ export default function Header() {
                   {user.isAdmin && (
                     <>
                       <MobileNavSection admin>Admin</MobileNavSection>
-                      <MobileNavLink href="/admin/triage">Triage Queue</MobileNavLink>
-                      <MobileNavLink href="/admin/projects/new">Create Org Project</MobileNavLink>
-                      <MobileNavLink href="/admin/starter-tasks">Manage Quick Tasks</MobileNavLink>
-                      <MobileNavLink href="/admin/skills">Manage Skills</MobileNavLink>
-                      <MobileNavLink href="/admin/bugs">Bug Reports</MobileNavLink>
-                      <MobileNavLink href="/admin/team">Admin Team</MobileNavLink>
-                      <MobileNavLink href="/admin/stats">Platform Stats</MobileNavLink>
-                      {user.isSuperAdmin && (
-                        <>
-                          <MobileNavLink href="/admin/applications">
-                            Manage Applications
+                      {ADMIN_NAV_ITEMS.filter((i) => !i.superAdminOnly || user.isSuperAdmin).map(
+                        (i) => (
+                          <MobileNavLink key={i.href} href={i.href}>
+                            {i.label}
                           </MobileNavLink>
-                          <MobileNavLink href="/admin/platform-settings">
-                            Platform Settings
-                          </MobileNavLink>
-                        </>
+                        ),
                       )}
-                      <MobileNavLink href="/admin/local-groups">Manage Local Groups</MobileNavLink>
                     </>
                   )}
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -22,7 +22,7 @@ function MobileNavLink({
   return (
     <Link
       href={href}
-      className={`block px-5 py-4 text-[var(--text)] no-underline font-medium text-base border-b border-brand-border transition-colors hover:bg-[var(--background)] ${active ? 'text-primary bg-accent' : ''}`}
+      className={`block px-5 py-4 text-brand-text no-underline font-medium text-base border-b border-brand-border transition-colors hover:bg-brand-bg ${active ? 'text-primary bg-accent' : ''}`}
     >
       {children}
     </Link>
@@ -32,7 +32,7 @@ function MobileNavLink({
 function MobileNavSection({ children, admin }: { children: React.ReactNode; admin?: boolean }) {
   return (
     <div
-      className={`px-5 py-2 text-[0.65rem] font-bold uppercase tracking-widest bg-[var(--background)] border-b border-brand-border ${admin ? 'text-primary' : 'text-[var(--text-light)]'}`}
+      className={`px-5 py-2 text-[0.65rem] font-bold uppercase tracking-widest bg-brand-bg border-b border-brand-border ${admin ? 'text-primary' : 'text-text-light'}`}
     >
       {children}
     </div>
@@ -179,7 +179,7 @@ export default function Header() {
         <div className="container flex justify-between items-center gap-2 flex-nowrap xl:gap-4">
           <Link
             href="/"
-            className="font-[var(--font-display)] text-2xl font-black text-primary no-underline flex items-center gap-2"
+            className="font-display text-2xl font-black text-primary no-underline flex items-center gap-2"
           >
             Catalyse
           </Link>
@@ -222,30 +222,30 @@ export default function Header() {
                   </Button>
                   {userMenuOpen && (
                     <div
-                      className="absolute top-full right-0 mt-2 bg-surface rounded-[var(--radius)] border border-brand-border shadow-lg w-max z-[101]"
+                      className="absolute top-full right-0 mt-2 bg-surface rounded-lg border border-brand-border shadow-lg w-max z-[101]"
                       onClick={() => setUserMenuOpen(false)}
                     >
                       <Link
                         href="/profile"
-                        className="block px-4 py-3 text-[var(--text)] no-underline"
+                        className="block px-4 py-3 text-brand-text no-underline"
                       >
                         My Profile
                       </Link>
                       <Link
                         href="/settings"
-                        className="block px-4 py-3 text-[var(--text)] no-underline"
+                        className="block px-4 py-3 text-brand-text no-underline"
                       >
                         Account Settings
                       </Link>
                       <Link
                         href="/privacy"
-                        className="block px-4 py-3 text-[var(--text)] no-underline"
+                        className="block px-4 py-3 text-brand-text no-underline"
                       >
                         Privacy &amp; Data
                       </Link>
                       {user.isAdmin && (
                         <>
-                          <div className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-light)] border-t border-brand-border mt-1">
+                          <div className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-text-light border-t border-brand-border mt-1">
                             Admin
                           </div>
                           {ADMIN_NAV_ITEMS.filter(
@@ -254,14 +254,14 @@ export default function Header() {
                             <Link
                               key={i.href}
                               href={i.href}
-                              className="block px-4 py-3 text-[var(--text)] no-underline"
+                              className="block px-4 py-3 text-brand-text no-underline"
                             >
                               {i.label}
                             </Link>
                           ))}
                         </>
                       )}
-                      <div className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-light)] border-t border-brand-border mt-1">
+                      <div className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-text-light border-t border-brand-border mt-1">
                         Session
                       </div>
                       <Button
@@ -342,10 +342,7 @@ export default function Header() {
           {/* Panel header */}
           <div className="border-b border-brand-border bg-surface shrink-0">
             <div className="container flex items-center justify-between py-4">
-              <Link
-                href="/"
-                className="font-[var(--font-display)] text-2xl font-black text-primary no-underline"
-              >
+              <Link href="/" className="font-display text-2xl font-black text-primary no-underline">
                 Catalyse
               </Link>
               <Button
@@ -415,7 +412,7 @@ export default function Header() {
                       logout()
                       setMobileMenuOpen(false)
                     }}
-                    className="block w-full text-left px-5 py-4 text-[var(--text)] font-medium text-base border-b border-brand-border hover:bg-[var(--background)] cursor-pointer bg-transparent"
+                    className="block w-full text-left px-5 py-4 text-brand-text font-medium text-base border-b border-brand-border hover:bg-brand-bg cursor-pointer bg-transparent"
                   >
                     Sign Out
                   </button>
@@ -442,7 +439,7 @@ export default function Header() {
                   setBugDialogOpen(true)
                   setMobileMenuOpen(false)
                 }}
-                className="flex items-center justify-center gap-2 flex-1 px-4 py-2 text-[var(--text)] font-medium text-base border-l border-brand-border hover:bg-[var(--background)] cursor-pointer bg-transparent whitespace-nowrap"
+                className="flex items-center justify-center gap-2 flex-1 px-4 py-2 text-brand-text font-medium text-base border-l border-brand-border hover:bg-brand-bg cursor-pointer bg-transparent whitespace-nowrap"
               >
                 <svg
                   width="15"

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import Button from '@/components/Button'
+import { Badge, badgeClasses, type BadgeVariant } from '@/components/Badge'
 import { matchGradeLabel } from '@/lib/matching'
 
 export interface Project {
@@ -29,18 +30,24 @@ export interface Project {
   } | null
 }
 
-export const STATUS_LABELS: Record<string, string> = {
-  seeking_owner: 'Seeking Owner',
-  seeking_help: 'Seeking Help',
-  needs_tasks: 'Needs Tasks',
-  in_progress: 'In Progress',
-  on_hold: 'On Hold',
-  completed: 'Completed',
-  pending_review: 'Pending Review',
-  accepted: 'Accepted',
-  declined: 'Declined',
-  withdrawn: 'Withdrawn',
+export const PROJECT_STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
+  seeking_owner: { label: 'Seeking Owner', variant: 'caution' },
+  seeking_help: { label: 'Seeking Help', variant: 'caution' },
+  needs_tasks: { label: 'Needs Tasks', variant: 'warning' },
+  in_progress: { label: 'In Progress', variant: 'info' },
+  on_hold: { label: 'On Hold', variant: 'neutral' },
+  completed: { label: 'Completed', variant: 'success' },
+  archived: { label: 'Archived', variant: 'neutral' },
+  needs_discussion: { label: 'Needs Discussion', variant: 'neutral' },
+  pending_review: { label: 'Pending Review', variant: 'warning' },
+  accepted: { label: 'Accepted', variant: 'success' },
+  declined: { label: 'Declined', variant: 'neutral' },
+  withdrawn: { label: 'Withdrawn', variant: 'neutral' },
 }
+
+export const STATUS_LABELS: Record<string, string> = Object.fromEntries(
+  Object.entries(PROJECT_STATUS_CONFIG).map(([k, v]) => [k, v.label]),
+)
 
 const PROJECT_TYPE_LABELS: Record<string, string> = {
   sprint: 'Sprint',
@@ -49,21 +56,12 @@ const PROJECT_TYPE_LABELS: Record<string, string> = {
   one_off: 'One-off',
 }
 
+export function projectStatusVariant(status: string): BadgeVariant {
+  return PROJECT_STATUS_CONFIG[status]?.variant ?? 'neutral'
+}
+
 export function statusBadgeClasses(status: string) {
-  const map: Record<string, string> = {
-    seeking_owner: 'bg-[#FED7AA] text-[#92400E] dark:bg-[#78350F] dark:text-[#FED7AA]',
-    seeking_help: 'bg-[#FED7AA] text-[#92400E] dark:bg-[#78350F] dark:text-[#FED7AA]',
-    needs_tasks: 'bg-[#FEF9C3] text-[#713F12] dark:bg-[#78350F] dark:text-[#FDE68A]',
-    in_progress: 'bg-[#DBEAFE] text-[#1E40AF] dark:bg-[#1E3A5F] dark:text-[#93C5FD]',
-    on_hold: 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]',
-    completed: 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]',
-    pending_review: 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]',
-    accepted: 'bg-[#D1FAE5] text-[#065F46] dark:bg-[#064E3B] dark:text-[#6EE7B7]',
-    declined: 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]',
-    withdrawn: 'bg-[#F3F4F6] text-[#374151] dark:bg-[#374151] dark:text-[#9CA3AF]',
-  }
-  // [test hook] status-badge class used as test selector
-  return `status-badge inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${map[status] ?? 'bg-[#F3F4F6] text-[#374151]'}`
+  return badgeClasses(projectStatusVariant(status))
 }
 
 export function ProjectCard({
@@ -88,16 +86,12 @@ export function ProjectCard({
       </div>
       <div className="row-start-2 flex gap-1 flex-wrap self-start">
         {!['seeking_owner', 'seeking_help'].includes(p.status) && (
-          <span className={statusBadgeClasses(p.status)}>
+          <Badge variant={projectStatusVariant(p.status)}>
             {STATUS_LABELS[p.status] ?? p.status.replace(/_/g, ' ')}
-          </span>
+          </Badge>
         )}
-        {p.isSeekingHelp && (
-          <span className={statusBadgeClasses('seeking_help')}>Seeking Help</span>
-        )}
-        {p.isSeekingOwner && (
-          <span className={statusBadgeClasses('seeking_owner')}>Seeking Owner</span>
-        )}
+        {p.isSeekingHelp && <Badge variant="caution">Seeking Help</Badge>}
+        {p.isSeekingOwner && <Badge variant="caution">Seeking Owner</Badge>}
       </div>
       <div className="row-start-3 flex items-center gap-3 flex-wrap text-xs text-text-light self-start">
         <span>👤 {p.owner ? p.owner.name : 'No owner yet'}</span>
@@ -125,13 +119,13 @@ export function ProjectCard({
             {shown.map((s) => (
               <span
                 key={s.id}
-                className="inline-flex items-center px-2 py-0.5 bg-accent text-secondary-dark rounded-full text-xs font-medium dark:bg-[#374151] dark:text-[#D1D5DB]"
+                className="inline-flex items-center px-2 py-0.5 bg-accent text-secondary-dark rounded-full text-xs font-medium dark:bg-gray-700 dark:text-gray-300"
               >
                 {s.name}
               </span>
             ))}
             {overflow > 0 && (
-              <span className="inline-flex items-center px-2 py-0.5 bg-[#F3F4F6] text-text-light rounded-full text-xs font-medium dark:bg-[#374151] dark:text-[#9CA3AF]">
+              <span className="inline-flex items-center px-2 py-0.5 bg-gray-100 text-text-light rounded-full text-xs font-medium dark:bg-gray-700 dark:text-gray-400">
                 and {overflow} more
               </span>
             )}

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -160,11 +160,7 @@ export default function ProjectForm({
           placeholder="A clear, descriptive name for the project"
           aria-invalid={!!fe('title') || undefined}
         />
-        {fe('title') && (
-          <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-            {fe('title')}
-          </p>
-        )}
+        {fe('title') && <p className="text-sm mt-1 text-error">{fe('title')}</p>}
       </div>
 
       <div className="mb-5">
@@ -185,9 +181,7 @@ export default function ProjectForm({
           aria-invalid={!!fe('description') || undefined}
         />
         {fe('description') ? (
-          <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-            {fe('description')}
-          </p>
+          <p className="text-sm mt-1 text-error">{fe('description')}</p>
         ) : (
           <p className="text-sm text-text-light mt-1">
             The more detail you provide, the easier it is to find the right contributors and get
@@ -209,9 +203,7 @@ export default function ProjectForm({
           }}
         />
         {fe('project_type') ? (
-          <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-            {fe('project_type')}
-          </p>
+          <p className="text-sm mt-1 text-error">{fe('project_type')}</p>
         ) : (
           <p className="text-sm text-text-light mt-1">
             This helps contributors understand the commitment involved
@@ -236,9 +228,7 @@ export default function ProjectForm({
             aria-invalid={!!fe('time_commitment_hours_per_week') || undefined}
           />
           {fe('time_commitment_hours_per_week') ? (
-            <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-              {fe('time_commitment_hours_per_week')}
-            </p>
+            <p className="text-sm mt-1 text-error">{fe('time_commitment_hours_per_week')}</p>
           ) : (
             <p className="text-sm text-text-light mt-1">
               Estimated weekly time from each contributor
@@ -258,11 +248,7 @@ export default function ProjectForm({
               clearFieldError('urgency')
             }}
           />
-          {fe('urgency') && (
-            <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-              {fe('urgency')}
-            </p>
-          )}
+          {fe('urgency') && <p className="text-sm mt-1 text-error">{fe('urgency')}</p>}
         </div>
       </div>
 
@@ -281,9 +267,7 @@ export default function ProjectForm({
             aria-invalid={!!fe('estimated_duration') || undefined}
           />
           {fe('estimated_duration') ? (
-            <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-              {fe('estimated_duration')}
-            </p>
+            <p className="text-sm mt-1 text-error">{fe('estimated_duration')}</p>
           ) : (
             <p className="text-sm text-text-light mt-1">
               Roughly how long do you expect this to take?
@@ -307,9 +291,7 @@ export default function ProjectForm({
           searchable
         />
         {fe('country') || fe('local_group') ? (
-          <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-            {fe('country') ?? fe('local_group')}
-          </p>
+          <p className="text-sm mt-1 text-error">{fe('country') ?? fe('local_group')}</p>
         ) : (
           <p className="text-sm text-text-light mt-1">
             Where is this project based? Local groups appear indented under their country.{' '}
@@ -334,9 +316,7 @@ export default function ProjectForm({
           aria-invalid={!!fe('collaboration_link') || undefined}
         />
         {fe('collaboration_link') ? (
-          <p className="text-sm mt-1" style={{ color: 'var(--error)' }}>
-            {fe('collaboration_link')}
-          </p>
+          <p className="text-sm mt-1 text-error">{fe('collaboration_link')}</p>
         ) : (
           <p className="text-sm text-text-light mt-1">
             A URL to a planning doc or workspace, or just describe your plans for collaboration
@@ -409,7 +389,7 @@ export default function ProjectForm({
                 placeholder="More detail about what needs doing…"
                 value={task.description}
                 onChange={(e) => updateTask(i, 'description', e.target.value)}
-                style={{ minHeight: 60 }}
+                className="min-h-14"
               />
             </div>
             {tasks.length > 1 && (

--- a/components/Radio.tsx
+++ b/components/Radio.tsx
@@ -6,10 +6,7 @@ type RadioProps = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 
 export default function Radio({ children, ...props }: RadioProps) {
   return (
-    <label
-      className="items-center gap-2 cursor-pointer"
-      style={{ display: 'flex', fontWeight: 400, marginBottom: 0 }}
-    >
+    <label className="flex items-center gap-2 cursor-pointer font-normal mb-0">
       <span className="relative flex-shrink-0">
         <input type="radio" className="sr-only peer" {...props} />
         <span className="block w-5 h-5 rounded-full border-2 border-brand-border dark:border-secondary bg-surface peer-checked:border-primary dark:peer-checked:border-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 transition-colors" />

--- a/components/SkillPicker.tsx
+++ b/components/SkillPicker.tsx
@@ -41,9 +41,7 @@ export default function SkillPicker({
     <div>
       {categories.map((cat) => (
         <div key={cat.id} className="mb-4">
-          <div style={{ fontWeight: 600, marginBottom: 8, color: 'var(--secondary-dark)' }}>
-            {cat.name}
-          </div>
+          <div className="font-semibold mb-2 text-secondary-dark">{cat.name}</div>
           <div className="flex flex-wrap gap-2">
             {cat.skills.map((skill) => {
               const selected = value.find((s) => s.skillId === skill.id)

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -13,7 +13,7 @@ export function ThemeToggle({
 }) {
   const { resolvedTheme, setTheme } = useTheme()
 
-  if (!resolvedTheme) return <div style={{ width: 32, height: 32 }} />
+  if (!resolvedTheme) return <div className="w-8 h-8" />
 
   const isDark = resolvedTheme === 'dark'
 

--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -9,7 +9,7 @@ export default function Toggle({ children, ...props }: ToggleProps) {
     <label className="flex items-center gap-3 cursor-pointer font-normal mb-0">
       <span className="relative flex-shrink-0">
         <input type="checkbox" className="sr-only peer" {...props} />
-        <span className="block w-11 h-6 rounded-full bg-[var(--border)] peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-disabled:opacity-50 transition-colors" />
+        <span className="block w-11 h-6 rounded-full bg-brand-border peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-disabled:opacity-50 transition-colors" />
         <span className="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow-sm peer-checked:translate-x-5 transition-transform pointer-events-none" />
       </span>
       {children !== null && <span>{children}</span>}

--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -6,10 +6,7 @@ type ToggleProps = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 
 export default function Toggle({ children, ...props }: ToggleProps) {
   return (
-    <label
-      className="flex items-center gap-3 cursor-pointer"
-      style={{ fontWeight: 400, marginBottom: 0 }}
-    >
+    <label className="flex items-center gap-3 cursor-pointer font-normal mb-0">
       <span className="relative flex-shrink-0">
         <input type="checkbox" className="sr-only peer" {...props} />
         <span className="block w-11 h-6 rounded-full bg-[var(--border)] peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-disabled:opacity-50 transition-colors" />

--- a/e2e/tests/08-project-tasks.spec.ts
+++ b/e2e/tests/08-project-tasks.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, getAlert, readAdminToken, confirmVolunteerEmail, approveVolunteer } from '../fixtures'
+import {
+  test,
+  expect,
+  getAlert,
+  readAdminToken,
+  confirmVolunteerEmail,
+  approveVolunteer,
+} from '../fixtures'
 import { fake } from '../fake'
 import { proposeProject, adminCreateProject, adminApproveProject } from '../actions/projects'
 import { Page } from '@playwright/test'
@@ -92,7 +99,19 @@ test.describe('Project Tasks', () => {
 
     // Admin creates a project and a task
     const projectCreated = await adminApi.admin.projects.create({
-      body: { title: fake.projectTitle(), description: 'Task comment back-and-forth test' },
+      body: {
+        title: fake.projectTitle(),
+        description: 'Task comment back-and-forth test',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: false,
+        isSeekingOwner: false,
+      },
     })
     expect(projectCreated.status).toBe(200)
     const projectId = (projectCreated.body as { id: number }).id

--- a/e2e/tests/09-project-interests-assignment.spec.ts
+++ b/e2e/tests/09-project-interests-assignment.spec.ts
@@ -242,14 +242,16 @@ test.describe('Project Interests and Assignment', () => {
 
     // Admin (the project creator) receives a comment notification
     await goToDashboardNotifications(baseUrl, adminPage)
-    await expect(adminPage.locator('strong').filter({ hasText: 'New comment on' })).toBeVisible({
+    await expect(
+      adminPage.locator('strong').filter({ hasText: `New comment on "${title}"` }),
+    ).toBeVisible({
       timeout: 10_000,
     })
 
     // The author (volunteer) is NOT notified of their own comment
     await goToDashboardNotifications(baseUrl, volunteer.page)
     await expect(
-      volunteer.page.locator('strong').filter({ hasText: 'New comment on' }),
+      volunteer.page.locator('strong').filter({ hasText: `New comment on "${title}"` }),
     ).not.toBeVisible({ timeout: 5_000 })
   })
 

--- a/scripts/fetch-prod-db.ts
+++ b/scripts/fetch-prod-db.ts
@@ -242,7 +242,7 @@ function anonymise(dbPath: string): void {
   }
 
   db.exec('UPDATE notifications SET body = NULL')
-  db.exec("UPDATE project_updates SET content = '[redacted]'")
+  db.exec("UPDATE work_item_comments SET content = '[redacted]'")
 
   db.exec('PRAGMA journal_mode=DELETE')
   db.close()

--- a/server/routers/admin/emailPreview.ts
+++ b/server/routers/admin/emailPreview.ts
@@ -49,200 +49,163 @@ const SAMPLE_PROJECTS = [
   },
 ]
 
-const EMAIL_TYPES = [
-  'welcome-google',
-  'welcome-and-confirm',
-  'application-received',
-  'application-approved',
-  'application-rejected',
-  'pending-applications-summary',
-  'password-reset',
-  'admin-invite',
-  'project-notification',
-  'local-group-suggestion-accepted',
-  'local-group-suggestion-merge',
-  'local-group-suggestion-on-hold',
-  'local-group-suggestion-declined',
-  'relay-message',
-  'digest-match',
-  'digest-general',
-  'task-nudge',
-  'task-final-warning',
-  'task-surrendered-owner',
-  'task-surrendered-assignee',
-]
-
-function buildPreview(type: string): { subject: string; html: string } | null {
-  switch (type) {
-    case 'welcome-google':
-      return { subject: 'Welcome to Catalyse!', html: buildWelcomeHtml('Alex', APP_URL) }
-    case 'welcome-and-confirm':
-      return {
-        subject: 'Welcome to Catalyse — please confirm your email',
-        html: buildWelcomeAndConfirmHtml(
-          'Alex',
-          `${APP_URL}/verify-email?token=sample-token-abc123`,
-        ),
-      }
-    case 'application-received':
-      return {
-        subject: 'Your Catalyse application has been received',
-        html: buildApplicationReceivedHtml('Alex'),
-      }
-    case 'application-approved':
-      return {
-        subject: 'Your Catalyse application has been approved',
-        html: buildApplicationApprovedHtml('Alex', APP_URL),
-      }
-    case 'application-rejected':
-      return {
-        subject: 'Update on your Catalyse application',
-        html: buildApplicationRejectedHtml(
-          'Alex',
-          'Unfortunately your application did not meet our current requirements.',
-        ),
-      }
-    case 'pending-applications-summary':
-      return {
-        subject: '3 pending applications on Catalyse',
-        html: buildPendingApplicationsSummaryHtml(3, APP_URL),
-      }
-    case 'password-reset':
-      return {
-        subject: 'Reset your Catalyse password',
-        html: buildPasswordResetHtml(`${APP_URL}/reset-password?token=sample-token-abc123`, 'Alex'),
-      }
-    case 'admin-invite':
-      return {
-        subject: 'Jamie Smith invited you to be a Catalyse admin',
-        html: buildAdminInviteHtml(
-          `${APP_URL}/accept-invite?token=sample-token-abc123`,
-          'Jamie Smith',
-        ),
-      }
-    case 'project-notification':
-      return {
-        subject: 'Your project has been approved',
-        html: buildProjectNotificationHtml(
-          'Alex',
-          'Your project has been approved',
-          'Great news — your project AI Safety Explainer Series has been reviewed and approved.',
-          1,
-          APP_URL,
-        ),
-      }
-    case 'local-group-suggestion-accepted':
-      return {
-        subject: 'Your local group suggestion "London" was accepted',
-        html: buildLocalGroupSuggestionHtml('Alex', 'accepted', 'London'),
-      }
-    case 'local-group-suggestion-merge':
-      return {
-        subject: 'Your local group suggestion "London" has been merged',
-        html: buildLocalGroupSuggestionHtml('Alex', 'merge', 'London', 'Merged with South London.'),
-      }
-    case 'local-group-suggestion-on-hold':
-      return {
-        subject: 'Your local group suggestion "London" is under review',
-        html: buildLocalGroupSuggestionHtml(
-          'Alex',
-          'on_hold',
-          'London',
-          'We need a bit more time to assess this one.',
-        ),
-      }
-    case 'local-group-suggestion-declined':
-      return {
-        subject: 'Update on your local group suggestion "London"',
-        html: buildLocalGroupSuggestionHtml(
-          'Alex',
-          'declined',
-          'London',
-          'We already have good coverage in this area.',
-        ),
-      }
-    case 'relay-message':
-      return {
-        subject: '[Catalyse] Collaboration on AI Safety Explainer Series',
-        html: buildRelayMessageHtml(
-          'Alex',
-          'Jamie Smith',
-          'Collaboration on AI Safety Explainer Series',
-          'Hi Alex,\n\nI came across your profile and think your writing skills would be a great fit.\n\nThanks,\nJamie',
-          'AI Safety Explainer Series',
-        ),
-      }
-    case 'digest-match':
-      return {
-        subject: 'New projects matching your skills',
-        html: buildDigestHtml('Alex', APP_URL, SAMPLE_PROJECTS, true),
-      }
-    case 'digest-general':
-      return {
-        subject: "What's new on Catalyse",
-        html: buildDigestHtml('Alex', APP_URL, SAMPLE_PROJECTS, false),
-      }
-    case 'task-nudge':
-      return {
-        subject: "How's it going with Write fundraising copy?",
-        html: buildTaskNudgeHtml(
-          'Alex',
-          'Write fundraising copy',
-          'Climate Action Newsletter',
-          1,
-          42,
-          14,
-          'you were assigned this task',
-          '16 April 2026',
-        ),
-      }
-    case 'task-final-warning':
-      return {
-        subject: 'A quick nudge about Write fundraising copy',
-        html: buildTaskFinalWarningHtml(
-          'Alex',
-          'Write fundraising copy',
-          'Climate Action Newsletter',
-          1,
-          42,
-          21,
-          'you last updated this task',
-          '9 April 2026',
-          '7 May 2026',
-        ),
-      }
-    case 'task-surrendered-owner':
-      return {
-        subject: 'Task unassigned due to inactivity: Write fundraising copy',
-        html: buildTaskSurrenderedOwnerHtml(
-          'Jordan',
-          'Alex Johnson',
-          'Write fundraising copy',
-          'Climate Action Newsletter',
-          1,
-        ),
-      }
-    case 'task-surrendered-assignee':
-      return {
-        subject: 'Update on your task: Write fundraising copy',
-        html: buildTaskSurrenderedAssigneeHtml(
-          'Alex',
-          'Write fundraising copy',
-          'Climate Action Newsletter',
-          1,
-        ),
-      }
-    default:
-      return null
-  }
+const EMAIL_PREVIEW_REGISTRY: Record<string, { subject: string; build: () => string }> = {
+  'welcome-google': {
+    subject: 'Welcome to Catalyse!',
+    build: () => buildWelcomeHtml('Alex', APP_URL),
+  },
+  'welcome-and-confirm': {
+    subject: 'Welcome to Catalyse — please confirm your email',
+    build: () =>
+      buildWelcomeAndConfirmHtml('Alex', `${APP_URL}/verify-email?token=sample-token-abc123`),
+  },
+  'application-received': {
+    subject: 'Your Catalyse application has been received',
+    build: () => buildApplicationReceivedHtml('Alex'),
+  },
+  'application-approved': {
+    subject: 'Your Catalyse application has been approved',
+    build: () => buildApplicationApprovedHtml('Alex', APP_URL),
+  },
+  'application-rejected': {
+    subject: 'Update on your Catalyse application',
+    build: () =>
+      buildApplicationRejectedHtml(
+        'Alex',
+        'Unfortunately your application did not meet our current requirements.',
+      ),
+  },
+  'pending-applications-summary': {
+    subject: '3 pending applications on Catalyse',
+    build: () => buildPendingApplicationsSummaryHtml(3, APP_URL),
+  },
+  'password-reset': {
+    subject: 'Reset your Catalyse password',
+    build: () =>
+      buildPasswordResetHtml(`${APP_URL}/reset-password?token=sample-token-abc123`, 'Alex'),
+  },
+  'admin-invite': {
+    subject: 'Jamie Smith invited you to be a Catalyse admin',
+    build: () =>
+      buildAdminInviteHtml(`${APP_URL}/accept-invite?token=sample-token-abc123`, 'Jamie Smith'),
+  },
+  'project-notification': {
+    subject: 'Your project has been approved',
+    build: () =>
+      buildProjectNotificationHtml(
+        'Alex',
+        'Your project has been approved',
+        'Great news — your project AI Safety Explainer Series has been reviewed and approved.',
+        1,
+        APP_URL,
+      ),
+  },
+  'local-group-suggestion-accepted': {
+    subject: 'Your local group suggestion "London" was accepted',
+    build: () => buildLocalGroupSuggestionHtml('Alex', 'accepted', 'London'),
+  },
+  'local-group-suggestion-merge': {
+    subject: 'Your local group suggestion "London" has been merged',
+    build: () =>
+      buildLocalGroupSuggestionHtml('Alex', 'merge', 'London', 'Merged with South London.'),
+  },
+  'local-group-suggestion-on-hold': {
+    subject: 'Your local group suggestion "London" is under review',
+    build: () =>
+      buildLocalGroupSuggestionHtml(
+        'Alex',
+        'on_hold',
+        'London',
+        'We need a bit more time to assess this one.',
+      ),
+  },
+  'local-group-suggestion-declined': {
+    subject: 'Update on your local group suggestion "London"',
+    build: () =>
+      buildLocalGroupSuggestionHtml(
+        'Alex',
+        'declined',
+        'London',
+        'We already have good coverage in this area.',
+      ),
+  },
+  'relay-message': {
+    subject: '[Catalyse] Collaboration on AI Safety Explainer Series',
+    build: () =>
+      buildRelayMessageHtml(
+        'Alex',
+        'Jamie Smith',
+        'Collaboration on AI Safety Explainer Series',
+        'Hi Alex,\n\nI came across your profile and think your writing skills would be a great fit.\n\nThanks,\nJamie',
+        'AI Safety Explainer Series',
+      ),
+  },
+  'digest-match': {
+    subject: 'New projects matching your skills',
+    build: () => buildDigestHtml('Alex', APP_URL, SAMPLE_PROJECTS, true),
+  },
+  'digest-general': {
+    subject: "What's new on Catalyse",
+    build: () => buildDigestHtml('Alex', APP_URL, SAMPLE_PROJECTS, false),
+  },
+  'task-nudge': {
+    subject: "How's it going with Write fundraising copy?",
+    build: () =>
+      buildTaskNudgeHtml(
+        'Alex',
+        'Write fundraising copy',
+        'Climate Action Newsletter',
+        1,
+        42,
+        14,
+        'you were assigned this task',
+        '16 April 2026',
+      ),
+  },
+  'task-final-warning': {
+    subject: 'A quick nudge about Write fundraising copy',
+    build: () =>
+      buildTaskFinalWarningHtml(
+        'Alex',
+        'Write fundraising copy',
+        'Climate Action Newsletter',
+        1,
+        42,
+        21,
+        'you last updated this task',
+        '9 April 2026',
+        '7 May 2026',
+      ),
+  },
+  'task-surrendered-owner': {
+    subject: 'Task unassigned due to inactivity: Write fundraising copy',
+    build: () =>
+      buildTaskSurrenderedOwnerHtml(
+        'Jordan',
+        'Alex Johnson',
+        'Write fundraising copy',
+        'Climate Action Newsletter',
+        1,
+      ),
+  },
+  'task-surrendered-assignee': {
+    subject: 'Update on your task: Write fundraising copy',
+    build: () =>
+      buildTaskSurrenderedAssigneeHtml(
+        'Alex',
+        'Write fundraising copy',
+        'Climate Action Newsletter',
+        1,
+      ),
+  },
 }
 
 export const adminEmailPreviewRouter = {
-  types: adminProcedure.handler(async () => ({ types: EMAIL_TYPES })),
+  types: adminProcedure.handler(async () => ({ types: Object.keys(EMAIL_PREVIEW_REGISTRY) })),
 
   preview: adminProcedure.input(z.object({ type: z.string() })).handler(async ({ input }) => {
-    const preview = buildPreview(input.type)
-    if (!preview) throw new ORPCError('NOT_FOUND', { message: 'Unknown email type' })
-    return { subject: preview.subject, html: preview.html }
+    const entry = EMAIL_PREVIEW_REGISTRY[input.type]
+    if (!entry) throw new ORPCError('NOT_FOUND', { message: 'Unknown email type' })
+    return { subject: entry.subject, html: entry.build() }
   }),
 }


### PR DESCRIPTION
## Summary

- Replace inline `style={{}}` props, hardcoded hex codes, and CSS `var()` arbitrary values with Tailwind design tokens across all pages
- Standardise page content widths to a consistent max-width token
- Extract `Badge` component with single-source status badge config
- Single-source admin nav items (`ADMIN_NAV_ITEMS` registry in `Header.tsx`)
- Single-source email preview types (`EMAIL_TYPES` registry in `emailPreview.ts`)
- Single-source cron jobs (`JOBS` registry in `cron/daily/route.ts`)
- Fix pre-existing e2e test failure: send all required fields in admin project create API call

## Closes

Closes #85
Closes #86
Closes #87
Closes #107
Closes #120
Closes #121
Closes #122
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)