### PR TITLE
fix: save Google signup application message after oRPC migration

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -183,6 +183,9 @@ export default function SignupPage() {
     e.preventDefault()
     if (!googlePendingToken) return
     setGoogleApplicationSubmitting(true)
+    // Write directly to localStorage (not setToken) so the orpc client sends
+    // the auth header without triggering auth state and the dashboard redirect.
+    localStorage.setItem('authToken', googlePendingToken)
     try {
       await updateMeMutation.mutateAsync({
         name,

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -60,6 +60,7 @@ function startWorkerNextJs(parallelIndex: number): number {
       ADMIN_EMAILS: ADMIN_EMAIL,
       RESEND_API_KEY: '',
       STUB_EMAIL: 'true',
+      STUB_GOOGLE: 'true',
       DISABLE_RATE_LIMIT: 'true',
     },
     cwd: PROJECT_ROOT,

--- a/e2e/tests/01-auth-signup-login.spec.ts
+++ b/e2e/tests/01-auth-signup-login.spec.ts
@@ -379,6 +379,49 @@ test.describe('Authentication: Signup & Login', () => {
     expect(verifyResult.status).toBe(200)
   })
 
+  test('Google signup: application message and profile fields saved and visible to admin', async ({
+    adminPage,
+    browser,
+    baseUrl,
+  }) => {
+    const person = fake.person()
+    const applicationMessage = 'I want to help pause AI development because of safety concerns'
+
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/signup`)
+
+      // Stub button only appears in dev/test (no GOOGLE_CLIENT_ID configured)
+      await expect(
+        page.getByRole('button', { name: /Sign up with Google/ }),
+      ).toBeVisible({ timeout: 10_000 })
+      await page.getByRole('button', { name: /Sign up with Google/ }).click()
+
+      // Google account created; application form appears
+      await expect(page.getByLabel('Your Application')).toBeVisible({ timeout: 10_000 })
+
+      await page.getByLabel('Your Name').fill(person.name)
+      await page.getByLabel('Your Application').fill(applicationMessage)
+      await page.getByRole('button', { name: 'Submit Application' }).click()
+
+      await expect(page.getByRole('heading', { name: 'Application submitted' })).toBeVisible({
+        timeout: 10_000,
+      })
+    } finally {
+      await context.close()
+    }
+
+    // Admin can see the application message on the applications list
+    await adminPage.goto(`${baseUrl}/admin/applications`)
+    await expect(adminPage.getByRole('heading', { name: 'Applications' })).toBeVisible({
+      timeout: 10_000,
+    })
+    const card = adminPage.getByRole('article').filter({ hasText: person.name })
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    await expect(card.getByText(applicationMessage)).toBeVisible()
+  })
+
   test.skip('Re-applicant shows full prior rejection history on admin card', async () => {
     // Scenario:
     // 1. Person signs up with email A, admin rejects them with notes + applicant message.

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -17,6 +17,7 @@ export const env = {
     (process.env.DISABLE_RATE_LIMIT ?? '').toLowerCase(),
   ),
   GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  STUB_GOOGLE: ['1', 'true', 'yes'].includes((process.env.STUB_GOOGLE ?? '').toLowerCase()),
   RAILWAY_GIT_COMMIT_SHA: process.env.RAILWAY_GIT_COMMIT_SHA,
   RAILWAY_ENVIRONMENT_NAME: process.env.RAILWAY_ENVIRONMENT_NAME,
 } as const

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -30,7 +30,7 @@ import { ApprovalStatus, ProjectStatus, WorkItemType } from '@/generated/prisma/
 
 const STUB_EMAIL = env.STUB_EMAIL
 const GOOGLE_CLIENT_ID = env.GOOGLE_CLIENT_ID
-const STUB_GOOGLE = !GOOGLE_CLIENT_ID && env.NODE_ENV !== 'production'
+const STUB_GOOGLE = env.STUB_GOOGLE || (!GOOGLE_CLIENT_ID && env.NODE_ENV !== 'production')
 
 async function verifyGoogleToken(credential: string) {
   if (!GOOGLE_CLIENT_ID) return null


### PR DESCRIPTION
## Summary

- Google users signing up had their application message (and all other profile fields) silently lost — admin saw only name and email
- Root cause: oRPC migration (#157) replaced `fetch(..., { headers: { Authorization: 'Bearer ${token}' } })` with `updateMeMutation`, but the pending token was in `sessionStorage`, not `localStorage` — so the orpc client sent no auth header and the update threw `UNAUTHORIZED`
- Fix: write the pending token directly to `localStorage` before calling `updateMeMutation`, so the orpc client picks it up without triggering auth state / the dashboard redirect
- Also adds `STUB_GOOGLE` env var so the Google stub can be forced on in `next start` environments (previously only worked in `next dev`), and adds an e2e test covering the full flow

## Test plan

- [ ] New e2e test: `Google signup: application message and profile fields saved and visible to admin` — click Google stub button, fill form, verify admin sees the application message on the applications list card
- [ ] Full auth test suite passes (16 passed, 1 intentionally skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)