### PR TITLE
Task reordering, assignment, deadlines, and project page redesign

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { use, useEffect, useState } from 'react'
+import React, { use, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -13,8 +14,27 @@ import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
+import type { InferRouterOutputs } from '@orpc/server'
+import type { AppRouter } from '@/server/router'
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 
 // ── Types ────────────────────────────────────────────────────────────────────
+
+type ProjectTask = InferRouterOutputs<AppRouter>['projects']['getById']['tasks'][number]
 
 const OWNER_STATUSES = [
   { value: 'seeking_owner', label: 'Seeking Owner' },
@@ -35,6 +55,157 @@ const ADMIN_EXTRA_STATUSES = [
 
 const card = 'bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word'
 
+// ── Task list item ──────────────────────────────────────────────────────────
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/)
+  return ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase()
+}
+
+function TaskAvatar({ name }: { name: string | null }) {
+  if (!name) {
+    return (
+      <span
+        aria-label="Unassigned"
+        title="Unassigned"
+        className="w-6 h-6 rounded-full border border-dashed border-brand-border shrink-0"
+      />
+    )
+  }
+  return (
+    <span
+      aria-label={`Assigned to ${name}`}
+      title={name}
+      className="w-6 h-6 rounded-full bg-secondary text-white text-xs font-semibold flex items-center justify-center shrink-0"
+    >
+      {initials(name)}
+    </span>
+  )
+}
+
+function ActionMenu({
+  ariaLabel,
+  children,
+}: {
+  ariaLabel: string
+  children: (close: () => void) => React.ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState({ top: 0, left: 0 })
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onClickOutside(e: MouseEvent) {
+      const target = e.target as Node
+      // A nested FilterDropdown's listbox portals to document.body too, so a
+      // click on one of its options looks like an outside click — ignore it.
+      if (target instanceof Element && target.closest('[role="listbox"]')) return
+      if (
+        triggerRef.current &&
+        !triggerRef.current.contains(target) &&
+        panelRef.current &&
+        !panelRef.current.contains(target)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [open])
+
+  return (
+    <div className="inline-block">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => {
+          const r = triggerRef.current!.getBoundingClientRect()
+          setPos({ top: r.bottom + window.scrollY + 6, left: r.right + window.scrollX - 256 })
+          setOpen((o) => !o)
+        }}
+        className="w-7 h-7 flex items-center justify-center rounded-md text-base font-bold text-brand-text bg-brand-bg hover:bg-brand-border transition-colors cursor-pointer"
+      >
+        ⋯
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={panelRef}
+            role="menu"
+            style={{
+              position: 'absolute',
+              top: pos.top,
+              left: pos.left,
+              width: 256,
+              zIndex: 9999,
+            }}
+            className="bg-surface border border-brand-border rounded-lg shadow-lg py-2"
+          >
+            {children(() => setOpen(false))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  )
+}
+
+function SortableTaskItem({
+  task,
+  draggable,
+  title,
+  chips,
+  assigneeName,
+  primaryAction,
+  menu,
+}: {
+  task: ProjectTask
+  draggable: boolean
+  title: React.ReactNode
+  chips: React.ReactNode
+  assigneeName: string | null
+  primaryAction: React.ReactNode
+  menu: React.ReactNode
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: task.id,
+  })
+  return (
+    <li
+      ref={setNodeRef}
+      className="group flex items-center gap-2 py-2 border-b border-brand-border last:border-0"
+      style={{
+        // dynamic: drag transform/transition/opacity
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }}
+    >
+      <span
+        {...(draggable ? attributes : {})}
+        {...(draggable ? listeners : {})}
+        className={`w-4 shrink-0 leading-none text-text-light text-center text-base opacity-60 group-hover:opacity-100 transition-opacity ${draggable ? 'cursor-grab' : ''}`}
+        title={draggable ? 'Drag to reorder' : undefined}
+      >
+        {draggable ? '⠿' : ''}
+      </span>
+      <span className="flex-1 min-w-0 truncate">{title}</span>
+      <div className="flex items-center gap-2 shrink-0">{chips}</div>
+      {primaryAction}
+      <TaskAvatar name={assigneeName} />
+      {menu && (
+        <div className="opacity-60 group-hover:opacity-100 focus-within:opacity-100 has-aria-expanded:opacity-100 transition-opacity">
+          {menu}
+        </div>
+      )}
+    </li>
+  )
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export default function ProjectDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -48,6 +219,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   // Task section
   const [showTaskForm, setShowTaskForm] = useState(false)
   const [newTaskTitle, setNewTaskTitle] = useState('')
+  const [newTaskEstimatedHours, setNewTaskEstimatedHours] = useState('')
+  const [newTaskDeadline, setNewTaskDeadline] = useState('')
+  const [orderedTasks, setOrderedTasks] = useState<ProjectTask[]>([])
+  const [taskAssignSelections, setTaskAssignSelections] = useState<Record<number, string>>({})
+  const taskDragSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  )
 
   // Status section
   const [newStatus, setNewStatus] = useState('')
@@ -97,6 +275,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   })
   const project = projectRaw
 
+  // Sync orderedTasks when project data loads/changes
+  useEffect(() => {
+    if (project?.tasks) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setOrderedTasks(project.tasks)
+    }
+  }, [project?.tasks])
+
   // Sync newStatus when project data first loads
   useEffect(() => {
     if (project?.status) {
@@ -114,7 +300,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
   const { data: volunteersData } = useQuery({
     ...orpc.volunteers.list.queryOptions({ input: { limit: 100 } }),
-    enabled: !!user?.isAdmin && !!project,
+    enabled: !!project && (!!user?.isAdmin || project.ownerId === user?.id),
   })
   const volunteers = volunteersData?.volunteers ?? []
 
@@ -134,6 +320,8 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     ...orpc.projects.createTask.mutationOptions(),
     onSuccess: () => {
       setNewTaskTitle('')
+      setNewTaskEstimatedHours('')
+      setNewTaskDeadline('')
       setShowTaskForm(false)
       showToast('Task added!', 'success')
       void invalidateProject()
@@ -164,6 +352,29 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     },
     onError: (err: unknown) =>
       showToast(err instanceof Error ? err.message : 'Failed to delete task', 'error'),
+  })
+
+  const reorderTasksMutation = useMutation({
+    ...orpc.projects.reorderTasks.mutationOptions(),
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to reorder tasks', 'error')
+      void invalidateProject()
+    },
+  })
+
+  const assignTaskMutation = useMutation({
+    ...orpc.projects.assignTask.mutationOptions(),
+    onSuccess: (_data, variables) => {
+      showToast('Task assigned!', 'success')
+      setTaskAssignSelections((s) => {
+        const next = { ...s }
+        delete next[variables.taskId]
+        return next
+      })
+      void invalidateProject()
+    },
+    onError: (err: unknown) =>
+      showToast(err instanceof Error ? err.message : 'Failed to assign task', 'error'),
   })
 
   const updateProjectMutation = useMutation({
@@ -298,6 +509,31 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
   const statusOptions = isAdmin ? [...OWNER_STATUSES, ...ADMIN_EXTRA_STATUSES] : OWNER_STATUSES
 
+  // Excludes the current owner — they're already shown in the Owner box above.
+  const volunteerInterests = (project.interests ?? []).filter(
+    (i) => i.volunteerId !== project.ownerId,
+  )
+  const interestedVolunteers = volunteerInterests.filter(
+    (i) => i.status !== InterestStatus.declined && i.status !== InterestStatus.withdrawn,
+  )
+  const interestedVolunteerIds = new Set(interestedVolunteers.map((i) => i.volunteerId))
+  const assignVolunteerOptions = [
+    { value: '', label: '— Select volunteer —' },
+    ...(interestedVolunteers.length > 0
+      ? [
+          { value: '__interested_header', label: 'Interested in this project', header: true },
+          ...interestedVolunteers.map((i) => ({
+            value: String(i.volunteerId),
+            label: i.volunteerName,
+          })),
+          { value: '__all_header', label: 'All volunteers', header: true },
+        ]
+      : []),
+    ...volunteers
+      .filter((v) => !interestedVolunteerIds.has(v.id))
+      .map((v) => ({ value: String(v.id), label: v.name })),
+  ]
+
   // ── Task handlers ────────────────────────────────────────────────────────
 
   function handleAddTask(e: React.FormEvent) {
@@ -306,6 +542,31 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     createTaskMutation.mutate({
       projectId: parseInt(idParam, 10),
       title: newTaskTitle.trim(),
+      estimatedHours: newTaskEstimatedHours ? parseFloat(newTaskEstimatedHours) : null,
+      deadline: newTaskDeadline ? new Date(newTaskDeadline) : null,
+    })
+  }
+
+  function handleAssignTask(taskId: number) {
+    const selected = taskAssignSelections[taskId]
+    if (!selected) return
+    assignTaskMutation.mutate({
+      projectId: parseInt(idParam, 10),
+      taskId,
+      assigneeId: parseInt(selected, 10),
+    })
+  }
+
+  function handleTaskDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = orderedTasks.findIndex((t) => t.id === active.id)
+    const newIndex = orderedTasks.findIndex((t) => t.id === over.id)
+    const reordered = arrayMove(orderedTasks, oldIndex, newIndex)
+    setOrderedTasks(reordered)
+    reorderTasksMutation.mutate({
+      projectId: parseInt(idParam, 10),
+      items: reordered.map((t, i) => ({ id: t.id, sortOrder: i + 1 })),
     })
   }
 
@@ -379,16 +640,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     })
   }
 
-  function handleTransfer(e: React.FormEvent) {
-    e.preventDefault()
-    if (!transferTo) return
-    if (!window.confirm('Transfer ownership to this volunteer?')) return
-    updateProjectMutation.mutate({
-      id: parseInt(idParam, 10),
-      assigneeId: parseInt(transferTo, 10),
-    })
-  }
-
   function handleRecordOutcome(e: React.FormEvent) {
     e.preventDefault()
     if (!outcomeValue) return
@@ -434,448 +685,649 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           {project.title}
         </h1>
 
-        {/* Main project card */}
-        <div className={card}>
-          <p className="whitespace-pre-wrap">{project.description}</p>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
+          {/* Main column */}
+          <div className="lg:col-span-2 min-w-0">
+            {/* Main project card */}
+            <div className={card}>
+              <p className="whitespace-pre-wrap">{project.description}</p>
 
-          {project.skills.length > 0 && (
-            <div className="mt-3">
-              <strong>Skills needed:</strong>
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                {project.skills.map((s) => (
-                  <span
-                    key={s.id}
-                    className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-                      s.isRequired
-                        ? 'bg-secondary text-white dark:bg-gray-600'
-                        : 'bg-accent text-secondary-dark dark:bg-gray-700 dark:text-gray-300'
-                    }`}
+              {project.skills.length > 0 && (
+                <div className="mt-3">
+                  <strong>Skills needed:</strong>
+                  <div className="flex flex-wrap gap-1.5 mt-2">
+                    {project.skills.map((s) => (
+                      <span
+                        key={s.id}
+                        className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
+                          s.isRequired
+                            ? 'bg-secondary text-white dark:bg-gray-600'
+                            : 'bg-accent text-secondary-dark dark:bg-gray-700 dark:text-gray-300'
+                        }`}
+                      >
+                        {s.name}
+                        {s.isRequired ? ' *' : ''}
+                      </span>
+                    ))}
+                  </div>
+                  <p className="text-xs text-text-light mt-1">* Required</p>
+                </div>
+              )}
+
+              {/* Match score */}
+              {!isOwner && project.match && project.match.overallScore > 0 && (
+                <div className="mt-3 flex items-center gap-2">
+                  <span className="text-sm text-text-light">Your skill match:</span>
+                  <Badge variant="success" className="text-sm">
+                    {project.match.overallScore}%
+                  </Badge>
+                </div>
+              )}
+
+              {project.collaborationLink && (
+                <p className="mt-2 text-sm">
+                  <a
+                    href={project.collaborationLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    role="link"
+                    className="underline text-primary-dark"
                   >
-                    {s.name}
-                    {s.isRequired ? ' *' : ''}
-                  </span>
-                ))}
-              </div>
-              <p className="text-xs text-text-light mt-1">* Required</p>
-            </div>
-          )}
-
-          {/* Match score */}
-          {!isOwner && project.match && project.match.overallScore > 0 && (
-            <div className="mt-3 flex items-center gap-2">
-              <span className="text-sm text-text-light">Your skill match:</span>
-              <Badge variant="success" className="text-sm">
-                {project.match.overallScore}%
-              </Badge>
-            </div>
-          )}
-
-          {project.owner && (
-            <p className="mt-2 text-text-light text-sm">
-              Owner:{' '}
-              <Link href={`/volunteers/${project.owner.id}`} className="underline">
-                {project.owner.name}
-              </Link>
-            </p>
-          )}
-
-          {project.ownerId && !isOwner && !isAdmin && (
-            <Button
-              variant="secondary"
-              size="sm"
-              className="mt-2"
-              onClick={() => setShowContactModal(true)}
-            >
-              Contact Owner
-            </Button>
-          )}
-
-          {project.collaborationLink && (
-            <p className="mt-2 text-sm">
-              <a
-                href={project.collaborationLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                role="link"
-                className="underline text-primary-dark"
-              >
-                Open Project Doc →
-              </a>
-            </p>
-          )}
-        </div>
-
-        {/* Outcome display */}
-        {project.outcome && (
-          <div
-            role="status"
-            className="bg-emerald-100 dark:bg-emerald-900 border border-emerald-300 dark:border-emerald-600 rounded-xl p-6 mb-4"
-          >
-            <strong>Outcome: </strong>
-            {project.outcome === 'successful'
-              ? 'Successful'
-              : project.outcome === 'partial'
-                ? 'Partial'
-                : project.outcome === 'not_completed'
-                  ? 'Not Completed'
-                  : project.outcome === 'ongoing'
-                    ? 'Ongoing'
-                    : project.outcome}
-            {project.outcomeNotes && <p className="mt-1 text-sm">{project.outcomeNotes}</p>}
-          </div>
-        )}
-
-        {/* Interest section */}
-        {canSeeInterest && (
-          <div className={card}>
-            <h2>Interested in this project?</h2>
-            {!project.myInterest ? (
-              <form onSubmit={handleExpressInterest}>
-                <div className="mb-5">
-                  <label className="flex items-center gap-2 cursor-pointer mb-2 font-normal">
-                    <input
-                      type="radio"
-                      name="interest_type"
-                      value="want_to_contribute"
-                      checked={interestType === 'want_to_contribute'}
-                      onChange={() => setInterestType('want_to_contribute')}
-                    />
-                    I want to help out / contribute to this project
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer font-normal">
-                    <input
-                      type="radio"
-                      name="interest_type"
-                      value="want_to_own"
-                      checked={interestType === 'want_to_own'}
-                      onChange={() => setInterestType('want_to_own')}
-                    />
-                    I want to own / lead this project
-                  </label>
-                </div>
-                <div className="mb-5">
-                  <label htmlFor="interest-message">Message (optional)</label>
-                  <textarea
-                    id="interest-message"
-                    rows={3}
-                    value={interestMessage}
-                    onChange={(e) => setInterestMessage(e.target.value)}
-                    placeholder="Tell them why you're interested…"
-                  />
-                </div>
-                <Button type="submit" disabled={expressInterestMutation.isPending}>
-                  {expressInterestMutation.isPending ? 'Submitting…' : 'Express Interest'}
-                </Button>
-              </form>
-            ) : (
-              <div>
-                <p>
-                  Your interest status:{' '}
-                  <span aria-label="interest status" className="font-semibold">
-                    {project.myInterest.status}
-                  </span>
+                    Open Project Doc →
+                  </a>
                 </p>
-                {project.myInterest.responseMessage && (
-                  <p className="text-text-light text-sm">{project.myInterest.responseMessage}</p>
-                )}
-                {project.myInterest.status === InterestStatus.pending && (
-                  <Button variant="secondary" className="mt-2" onClick={handleWithdrawInterest}>
-                    Withdraw Interest
-                  </Button>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Tasks */}
-        <div className={card}>
-          <div className="flex justify-between items-center mb-3">
-            <h2 className="m-0">Tasks</h2>
-            {isOwnerOrAdmin && (
-              <Button variant="secondary" onClick={() => setShowTaskForm((v) => !v)}>
-                Add Task
-              </Button>
-            )}
-          </div>
-
-          {showTaskForm && isOwnerOrAdmin && (
-            <div className="bg-brand-bg rounded-lg p-3 mb-4 border border-brand-border">
-              <form onSubmit={handleAddTask}>
-                <div className="mb-3">
-                  <label htmlFor="new-task-title">Task title</label>
-                  <input
-                    id="new-task-title"
-                    type="text"
-                    aria-label="Task title"
-                    value={newTaskTitle}
-                    onChange={(e) => setNewTaskTitle(e.target.value)}
-                    placeholder="Describe the task…"
-                    autoFocus
-                  />
-                </div>
-                <div className="flex gap-2">
-                  <Button type="submit" disabled={createTaskMutation.isPending}>
-                    {createTaskMutation.isPending ? 'Creating…' : 'Create Task'}
-                  </Button>
-                  <Button type="button" variant="ghost" onClick={() => setShowTaskForm(false)}>
-                    Cancel
-                  </Button>
-                </div>
-              </form>
+              )}
             </div>
-          )}
 
-          {project.tasks.length === 0 ? (
-            <p className="text-text-light">No tasks yet.</p>
-          ) : (
-            <ul className="list-none p-0 m-0">
-              {project.tasks.map((task) => (
-                <li
-                  key={task.id}
-                  className="flex items-center gap-2 py-2 border-b border-brand-border last:border-0 flex-wrap"
-                >
-                  <span className="flex-1">{task.title}</span>
-                  {task.status === TaskStatus.completed && (
-                    <span className="text-success text-sm font-semibold">done</span>
-                  )}
-                  {task.assignedToName && task.status !== TaskStatus.completed && (
-                    <span className="text-text-light text-sm">→ {task.assignedToName}</span>
-                  )}
-                  {task.status === TaskStatus.open && (
-                    <Button variant="secondary" size="sm" onClick={() => handleClaimTask(task.id)}>
-                      Claim
-                    </Button>
-                  )}
-                  {task.status === TaskStatus.in_progress && task.assignedToId === user.id && (
-                    <Button variant="secondary" size="sm" onClick={() => handleDoneTask(task.id)}>
-                      Done
-                    </Button>
-                  )}
-                  {isOwnerOrAdmin && (
-                    <Button variant="danger" size="sm" onClick={() => handleDeleteTask(task.id)}>
-                      Delete task
-                    </Button>
-                  )}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        {/* Manage status */}
-        {isOwnerOrAdmin && (
-          <div className={card}>
-            <h2>Manage Project Status</h2>
-            <form onSubmit={handleUpdateStatus} className="flex gap-2 items-end flex-wrap">
-              <div className="mb-0 flex-1 min-w-[160px]">
-                <FilterDropdown
-                  id="change-status"
-                  label="Change Status"
-                  ariaLabel="Change Status"
-                  value={newStatus}
-                  options={statusOptions}
-                  onChange={(v) => setNewStatus(v)}
-                />
+            {/* Outcome display */}
+            {project.outcome && (
+              <div
+                role="status"
+                className="bg-emerald-100 dark:bg-emerald-900 border border-emerald-300 dark:border-emerald-600 rounded-xl p-6 mb-4"
+              >
+                <strong>Outcome: </strong>
+                {project.outcome === 'successful'
+                  ? 'Successful'
+                  : project.outcome === 'partial'
+                    ? 'Partial'
+                    : project.outcome === 'not_completed'
+                      ? 'Not Completed'
+                      : project.outcome === 'ongoing'
+                        ? 'Ongoing'
+                        : project.outcome}
+                {project.outcomeNotes && <p className="mt-1 text-sm">{project.outcomeNotes}</p>}
               </div>
-              <Button type="submit" disabled={updateProjectMutation.isPending}>
-                {updateProjectMutation.isPending ? 'Updating…' : 'Update Status'}
-              </Button>
-            </form>
-          </div>
-        )}
+            )}
 
-        {/* Interested Volunteers */}
-        {isOwnerOrAdmin && Array.isArray(project.interests) && (
-          <div className={card}>
-            <h2>Interested Volunteers</h2>
+            {/* Tasks */}
+            <div className={card}>
+              <div className="flex justify-between items-center mb-3">
+                <h2 className="m-0">Tasks</h2>
+                {isOwnerOrAdmin && (
+                  <Button variant="secondary" onClick={() => setShowTaskForm((v) => !v)}>
+                    Add Task
+                  </Button>
+                )}
+              </div>
 
-            {project.interests.length === 0 ? (
-              <p className="text-text-light">No interests yet.</p>
-            ) : (
-              <div>
-                {project.interests.map((interest) => (
-                  // [test hook] interest-card class used as test selector
-                  <div
-                    key={interest.id}
-                    className="interest-card bg-brand-bg rounded-lg p-3 mb-3 border border-brand-border"
-                  >
-                    <div className="flex justify-between items-start flex-wrap gap-2">
+              {showTaskForm && isOwnerOrAdmin && (
+                <div className="bg-brand-bg rounded-lg p-3 mb-4 border border-brand-border">
+                  <form onSubmit={handleAddTask}>
+                    <div className="mb-3">
+                      <label htmlFor="new-task-title">Task title</label>
+                      <input
+                        id="new-task-title"
+                        type="text"
+                        aria-label="Task title"
+                        value={newTaskTitle}
+                        onChange={(e) => setNewTaskTitle(e.target.value)}
+                        placeholder="Describe the task…"
+                        autoFocus
+                      />
+                    </div>
+                    <div className="flex gap-3 flex-wrap mb-3">
                       <div>
-                        <strong>{interest.volunteerName}</strong>
-                        <span className="ml-2 text-text-light text-sm">
-                          {interest.interestType === 'want_to_own'
-                            ? 'wants to own'
-                            : 'wants to help'}
-                        </span>
-                        <Badge variant={projectStatusVariant(interest.status)} className="ml-2">
-                          {interest.status}
-                        </Badge>
-                        {interest.message && (
-                          <p className="text-sm mt-1 mb-0">{interest.message}</p>
-                        )}
+                        <label htmlFor="new-task-hours">Estimated hours</label>
+                        <input
+                          id="new-task-hours"
+                          type="number"
+                          min="0"
+                          step="0.5"
+                          aria-label="Estimated hours"
+                          value={newTaskEstimatedHours}
+                          onChange={(e) => setNewTaskEstimatedHours(e.target.value)}
+                          placeholder="e.g. 3"
+                          className="w-30"
+                        />
                       </div>
-                      {interest.status === InterestStatus.pending && (
-                        <div className="flex gap-2">
-                          <Button size="sm" onClick={() => handleAcceptInterest(interest.id)}>
-                            Accept
-                          </Button>
+                      <div>
+                        <label htmlFor="new-task-deadline">Deadline</label>
+                        <input
+                          id="new-task-deadline"
+                          type="date"
+                          aria-label="Deadline"
+                          value={newTaskDeadline}
+                          onChange={(e) => setNewTaskDeadline(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button type="submit" disabled={createTaskMutation.isPending}>
+                        {createTaskMutation.isPending ? 'Creating…' : 'Create Task'}
+                      </Button>
+                      <Button type="button" variant="ghost" onClick={() => setShowTaskForm(false)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  </form>
+                </div>
+              )}
+
+              {orderedTasks.length === 0 ? (
+                <p className="text-text-light">No tasks yet.</p>
+              ) : (
+                <DndContext
+                  sensors={taskDragSensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={isOwnerOrAdmin ? handleTaskDragEnd : undefined}
+                >
+                  <SortableContext
+                    items={orderedTasks.map((t) => t.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <ul className="list-none p-0 m-0">
+                      {orderedTasks.map((task) => {
+                        const isOverdue =
+                          task.deadline &&
+                          task.status !== TaskStatus.completed &&
+                          // eslint-disable-next-line react-hooks/purity -- wall-clock comparison for overdue display
+                          new Date(task.deadline).getTime() < Date.now()
+                        const canAssign =
+                          isOwnerOrAdmin &&
+                          task.status !== TaskStatus.completed &&
+                          volunteers.length > 0
+
+                        return (
+                          <SortableTaskItem
+                            key={task.id}
+                            task={task}
+                            draggable={isOwnerOrAdmin}
+                            title={task.title}
+                            assigneeName={
+                              task.status !== TaskStatus.completed ? task.assignedToName : null
+                            }
+                            chips={
+                              <>
+                                {task.status === TaskStatus.completed && (
+                                  <span className="text-success text-sm font-semibold">done</span>
+                                )}
+                                {isOverdue && <Badge variant="danger">Overdue</Badge>}
+                                {task.estimatedHours !== null && (
+                                  <span className="text-text-light text-xs whitespace-nowrap">
+                                    ~{task.estimatedHours}h
+                                  </span>
+                                )}
+                                {task.deadline && (
+                                  <span className="text-text-light text-xs whitespace-nowrap">
+                                    Due {new Date(task.deadline).toLocaleDateString()}
+                                  </span>
+                                )}
+                              </>
+                            }
+                            primaryAction={
+                              <>
+                                {task.status === TaskStatus.open && (
+                                  <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={() => handleClaimTask(task.id)}
+                                  >
+                                    Claim
+                                  </Button>
+                                )}
+                                {task.status === TaskStatus.in_progress &&
+                                  task.assignedToId === user.id && (
+                                    <Button
+                                      variant="secondary"
+                                      size="sm"
+                                      onClick={() => handleDoneTask(task.id)}
+                                    >
+                                      Done
+                                    </Button>
+                                  )}
+                              </>
+                            }
+                            menu={
+                              (canAssign || isOwnerOrAdmin) && (
+                                <ActionMenu ariaLabel={`Task actions for ${task.title}`}>
+                                  {(close) => (
+                                    <>
+                                      {canAssign && (
+                                        <div className="px-3 py-2 flex flex-col gap-2">
+                                          <FilterDropdown
+                                            id={`assign-task-${task.id}`}
+                                            label="Assign to"
+                                            ariaLabel={`Assign volunteer to ${task.title}`}
+                                            value={taskAssignSelections[task.id] ?? ''}
+                                            options={assignVolunteerOptions}
+                                            onChange={(v) =>
+                                              setTaskAssignSelections((s) => ({
+                                                ...s,
+                                                [task.id]: v,
+                                              }))
+                                            }
+                                            searchable
+                                          />
+                                          <Button
+                                            variant="secondary"
+                                            size="sm"
+                                            disabled={
+                                              !taskAssignSelections[task.id] ||
+                                              assignTaskMutation.isPending
+                                            }
+                                            onClick={() => {
+                                              handleAssignTask(task.id)
+                                              close()
+                                            }}
+                                          >
+                                            Assign
+                                          </Button>
+                                        </div>
+                                      )}
+                                      {isOwnerOrAdmin && (
+                                        <button
+                                          role="menuitem"
+                                          className={`w-full text-left px-3 py-2 text-sm text-red-700 dark:text-red-400 hover:bg-accent transition-colors cursor-pointer ${canAssign ? 'border-t border-brand-border mt-1' : ''}`}
+                                          onClick={() => {
+                                            handleDeleteTask(task.id)
+                                            close()
+                                          }}
+                                        >
+                                          Delete task
+                                        </button>
+                                      )}
+                                    </>
+                                  )}
+                                </ActionMenu>
+                              )
+                            }
+                          />
+                        )
+                      })}
+                    </ul>
+                  </SortableContext>
+                </DndContext>
+              )}
+            </div>
+
+            {/* Project Updates */}
+            <div className={card}>
+              <h2>Project Updates</h2>
+              <CommentThread
+                workItemId={project.id}
+                emptyText="No updates yet."
+                placeholder="Share a progress update…"
+              />
+            </div>
+          </div>
+
+          {/* Sidebar */}
+          <div className="lg:col-span-1 min-w-0 flex flex-col gap-4">
+            {/* Admin triage */}
+            {isAdmin &&
+              (project.status === ProjectStatus.pending_review ||
+                project.status === ProjectStatus.needs_discussion) &&
+              !reviewDone && (
+                <div className={card}>
+                  <h2>Review Project</h2>
+                  <form onSubmit={handleSubmitReview}>
+                    <div className="mb-5">
+                      <label className="flex items-center gap-2 cursor-pointer mb-2 font-normal">
+                        <input
+                          type="radio"
+                          name="review_status"
+                          value="approved"
+                          checked={reviewStatus === 'approved'}
+                          onChange={() => setReviewStatus('approved')}
+                        />
+                        Approve
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer font-normal">
+                        <input
+                          type="radio"
+                          name="review_status"
+                          value="needs_discussion"
+                          checked={reviewStatus === 'needs_discussion'}
+                          onChange={() => setReviewStatus('needs_discussion')}
+                        />
+                        Needs Discussion
+                      </label>
+                    </div>
+                    {reviewStatus === 'needs_discussion' && (
+                      <div className="mb-5">
+                        <label htmlFor="review-message">Message to Proposer</label>
+                        <textarea
+                          id="review-message"
+                          aria-label="Message to Proposer"
+                          rows={3}
+                          value={reviewMessage}
+                          onChange={(e) => setReviewMessage(e.target.value)}
+                          placeholder="What do you want to discuss?"
+                        />
+                      </div>
+                    )}
+                    <Button type="submit" disabled={reviewMutation.isPending}>
+                      {reviewMutation.isPending ? 'Submitting…' : 'Submit Review'}
+                    </Button>
+                  </form>
+                </div>
+              )}
+
+            {/* Record Outcome */}
+            {isAdmin && project.status === ProjectStatus.completed && !project.outcome && (
+              <div className={card}>
+                <h2>Record Project Outcome</h2>
+                <form onSubmit={handleRecordOutcome}>
+                  <div className="mb-5">
+                    <FilterDropdown
+                      id="outcome-select"
+                      label="Outcome"
+                      ariaLabel="Outcome"
+                      value={outcomeValue}
+                      options={outcomeOptions}
+                      onChange={setOutcomeValue}
+                    />
+                  </div>
+                  <div className="mb-5">
+                    <label htmlFor="outcome-notes">Outcome Notes</label>
+                    <textarea
+                      id="outcome-notes"
+                      aria-label="Outcome Notes"
+                      rows={3}
+                      value={outcomeNotes}
+                      onChange={(e) => setOutcomeNotes(e.target.value)}
+                      placeholder="Notes about the outcome…"
+                    />
+                  </div>
+                  <Button type="submit" disabled={!outcomeValue || setOutcomeMutation.isPending}>
+                    {setOutcomeMutation.isPending ? 'Recording…' : 'Record Outcome'}
+                  </Button>
+                </form>
+              </div>
+            )}
+
+            {/* Manage status */}
+            {isOwnerOrAdmin && (
+              <div className={card}>
+                <h2>Manage Project Status</h2>
+                <form onSubmit={handleUpdateStatus} className="flex gap-2 items-end flex-wrap">
+                  <div className="mb-0 flex-1 min-w-40">
+                    <FilterDropdown
+                      id="change-status"
+                      label="Change Status"
+                      ariaLabel="Change Status"
+                      value={newStatus}
+                      options={statusOptions}
+                      onChange={(v) => setNewStatus(v)}
+                    />
+                  </div>
+                  <Button type="submit" disabled={updateProjectMutation.isPending}>
+                    {updateProjectMutation.isPending ? 'Updating…' : 'Update Status'}
+                  </Button>
+                </form>
+              </div>
+            )}
+
+            {/* Ownership */}
+            <div className={card}>
+              <h2>Owner</h2>
+              <div className="flex items-center justify-between gap-2">
+                {project.owner ? (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <TaskAvatar name={project.owner.name} />
+                    <Link href={`/volunteers/${project.owner.id}`} className="underline truncate">
+                      {project.owner.name}
+                    </Link>
+                  </div>
+                ) : (
+                  <p className="text-text-light text-sm m-0">No owner yet.</p>
+                )}
+                {isAdmin && volunteers.length > 0 && (
+                  <ActionMenu ariaLabel="Ownership actions">
+                    {(close) => (
+                      <>
+                        <div className="px-3 py-2 flex flex-col gap-2">
+                          <h3 className="m-0 text-sm">Transfer Ownership</h3>
+                          <FilterDropdown
+                            id="transfer-to"
+                            label="Transfer to"
+                            ariaLabel="Transfer to"
+                            value={transferTo}
+                            options={[
+                              { value: '', label: '— Select volunteer —' },
+                              ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
+                            ]}
+                            onChange={(v) => setTransferTo(v)}
+                            searchable
+                          />
                           <Button
                             variant="secondary"
                             size="sm"
-                            onClick={() => handleDeclineInterest(interest.id)}
+                            disabled={!transferTo || updateProjectMutation.isPending}
+                            onClick={() => {
+                              if (!transferTo) return
+                              if (!window.confirm('Transfer ownership to this volunteer?')) return
+                              updateProjectMutation.mutate({
+                                id: parseInt(idParam, 10),
+                                assigneeId: parseInt(transferTo, 10),
+                              })
+                              close()
+                            }}
                           >
-                            Decline
+                            {updateProjectMutation.isPending ? 'Transferring…' : 'Transfer'}
                           </Button>
                         </div>
-                      )}
-                    </div>
-                  </div>
-                ))}
+                        {project.owner && (
+                          <button
+                            role="menuitem"
+                            className="w-full text-left px-3 py-2 text-sm text-red-700 dark:text-red-400 hover:bg-accent transition-colors cursor-pointer border-t border-brand-border mt-1"
+                            onClick={() => {
+                              if (!window.confirm('Remove the current owner from this project?'))
+                                return
+                              updateProjectMutation.mutate({
+                                id: parseInt(idParam, 10),
+                                assigneeId: null,
+                              })
+                              close()
+                            }}
+                          >
+                            Remove ownership
+                          </button>
+                        )}
+                      </>
+                    )}
+                  </ActionMenu>
+                )}
               </div>
-            )}
-
-            {volunteers.length > 0 && (
-              <form onSubmit={handleAssign} className="flex gap-2 items-end flex-wrap mt-4">
-                <div className="flex-1 min-w-[200px]">
-                  <FilterDropdown
-                    id="assign-volunteer"
-                    label="Assign volunteer directly"
-                    ariaLabel="Volunteer to assign"
-                    value={assignTo}
-                    options={[
-                      { value: '', label: '— Select volunteer —' },
-                      ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                    ]}
-                    onChange={(v) => setAssignTo(v)}
-                    searchable
-                  />
-                </div>
-                <Button type="submit" disabled={!assignTo || assignMutation.isPending}>
-                  {assignMutation.isPending ? 'Assigning…' : 'Assign'}
+              {project.ownerId && !isOwner && !isAdmin && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="mt-3"
+                  onClick={() => setShowContactModal(true)}
+                >
+                  Contact Owner
                 </Button>
-              </form>
-            )}
-          </div>
-        )}
+              )}
 
-        {/* Transfer Ownership — admin only */}
-        {isAdmin && volunteers.length > 0 && (
-          <div className={card}>
-            <h3>Transfer Ownership</h3>
-            <form onSubmit={handleTransfer} className="flex gap-2 items-end flex-wrap">
-              <div className="flex-1 min-w-[200px]">
-                <FilterDropdown
-                  id="transfer-to"
-                  label="Transfer to"
-                  ariaLabel="Transfer to"
-                  value={transferTo}
-                  options={[
-                    { value: '', label: '— Select volunteer —' },
-                    ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                  ]}
-                  onChange={(v) => setTransferTo(v)}
-                  searchable
-                />
-              </div>
-              <Button type="submit" disabled={!transferTo || updateProjectMutation.isPending}>
-                {updateProjectMutation.isPending ? 'Transferring…' : 'Transfer'}
-              </Button>
-            </form>
-          </div>
-        )}
+              {isOwnerOrAdmin && Array.isArray(project.interests) && (
+                <div className="mt-4 pt-4 border-t border-brand-border">
+                  <h3 className="text-sm mb-2">Volunteers</h3>
 
-        {/* Record Outcome */}
-        {isAdmin && project.status === ProjectStatus.completed && !project.outcome && (
-          <div className={card}>
-            <h2>Record Project Outcome</h2>
-            <form onSubmit={handleRecordOutcome}>
-              <div className="mb-5">
-                <FilterDropdown
-                  id="outcome-select"
-                  label="Outcome"
-                  ariaLabel="Outcome"
-                  value={outcomeValue}
-                  options={outcomeOptions}
-                  onChange={setOutcomeValue}
-                />
-              </div>
-              <div className="mb-5">
-                <label htmlFor="outcome-notes">Outcome Notes</label>
-                <textarea
-                  id="outcome-notes"
-                  aria-label="Outcome Notes"
-                  rows={3}
-                  value={outcomeNotes}
-                  onChange={(e) => setOutcomeNotes(e.target.value)}
-                  placeholder="Notes about the outcome…"
-                />
-              </div>
-              <Button type="submit" disabled={!outcomeValue || setOutcomeMutation.isPending}>
-                {setOutcomeMutation.isPending ? 'Recording…' : 'Record Outcome'}
-              </Button>
-            </form>
-          </div>
-        )}
+                  {volunteerInterests.length === 0 ? (
+                    <p className="text-text-light text-sm">No interests yet.</p>
+                  ) : (
+                    <ul className="list-none p-0 m-0">
+                      {volunteerInterests.map((interest) => (
+                        // [test hook] interest-card class used as test selector
+                        <li
+                          key={interest.id}
+                          className="interest-card flex items-center gap-2 py-2 border-b border-brand-border last:border-0 flex-wrap"
+                        >
+                          <TaskAvatar name={interest.volunteerName} />
+                          <div className="flex-1 min-w-0">
+                            <div className="truncate">{interest.volunteerName}</div>
+                            <div className="text-text-light text-xs">
+                              {interest.status === InterestStatus.accepted
+                                ? interest.interestType === 'want_to_own'
+                                  ? 'Owner'
+                                  : 'Helper'
+                                : interest.status === InterestStatus.pending
+                                  ? interest.interestType === 'want_to_own'
+                                    ? 'wants to own'
+                                    : 'wants to help'
+                                  : interest.interestType === 'want_to_own'
+                                    ? 'wanted to own'
+                                    : 'wanted to help'}
+                            </div>
+                          </div>
+                          {interest.status === InterestStatus.pending ? (
+                            <div className="flex gap-2 shrink-0">
+                              <Button size="sm" onClick={() => handleAcceptInterest(interest.id)}>
+                                Accept
+                              </Button>
+                              <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => handleDeclineInterest(interest.id)}
+                              >
+                                Decline
+                              </Button>
+                            </div>
+                          ) : interest.status === InterestStatus.accepted ? (
+                            <div className="flex items-center gap-2 shrink-0">
+                              <Badge variant={projectStatusVariant(interest.status)}>
+                                {interest.status}
+                              </Badge>
+                              <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => handleDeclineInterest(interest.id)}
+                              >
+                                Remove
+                              </Button>
+                            </div>
+                          ) : (
+                            <Badge variant={projectStatusVariant(interest.status)}>
+                              {interest.status}
+                            </Badge>
+                          )}
+                          {interest.message && interest.status !== InterestStatus.accepted && (
+                            <p className="text-sm text-text-light w-full m-0">{interest.message}</p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
 
-        {/* Admin triage */}
-        {isAdmin &&
-          (project.status === ProjectStatus.pending_review ||
-            project.status === ProjectStatus.needs_discussion) &&
-          !reviewDone && (
-            <div className={card}>
-              <h2>Review Project</h2>
-              <form onSubmit={handleSubmitReview}>
-                <div className="mb-5">
-                  <label className="flex items-center gap-2 cursor-pointer mb-2 font-normal">
-                    <input
-                      type="radio"
-                      name="review_status"
-                      value="approved"
-                      checked={reviewStatus === 'approved'}
-                      onChange={() => setReviewStatus('approved')}
-                    />
-                    Approve
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer font-normal">
-                    <input
-                      type="radio"
-                      name="review_status"
-                      value="needs_discussion"
-                      checked={reviewStatus === 'needs_discussion'}
-                      onChange={() => setReviewStatus('needs_discussion')}
-                    />
-                    Needs Discussion
-                  </label>
+                  {volunteers.length > 0 && (
+                    <form
+                      onSubmit={handleAssign}
+                      className="flex gap-2 items-center flex-wrap mt-3 pt-3 border-t border-brand-border"
+                    >
+                      <span className="text-text-light text-sm shrink-0">+ Add</span>
+                      <div className="flex-1 min-w-40">
+                        <FilterDropdown
+                          id="assign-volunteer"
+                          label=""
+                          ariaLabel="Volunteer to assign"
+                          value={assignTo}
+                          options={[
+                            { value: '', label: '— Select volunteer —' },
+                            ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
+                          ]}
+                          onChange={(v) => setAssignTo(v)}
+                          searchable
+                        />
+                      </div>
+                      <Button
+                        type="submit"
+                        size="sm"
+                        disabled={!assignTo || assignMutation.isPending}
+                      >
+                        {assignMutation.isPending ? 'Assigning…' : 'Assign'}
+                      </Button>
+                    </form>
+                  )}
                 </div>
-                {reviewStatus === 'needs_discussion' && (
-                  <div className="mb-5">
-                    <label htmlFor="review-message">Message to Proposer</label>
-                    <textarea
-                      id="review-message"
-                      aria-label="Message to Proposer"
-                      rows={3}
-                      value={reviewMessage}
-                      onChange={(e) => setReviewMessage(e.target.value)}
-                      placeholder="What do you want to discuss?"
-                    />
+              )}
+            </div>
+
+            {/* Interest section */}
+            {canSeeInterest && (
+              <div className={card}>
+                <h2>Interested in this project?</h2>
+                {!project.myInterest ? (
+                  <form onSubmit={handleExpressInterest}>
+                    <div className="mb-5">
+                      <label className="flex items-center gap-2 cursor-pointer mb-2 font-normal">
+                        <input
+                          type="radio"
+                          name="interest_type"
+                          value="want_to_contribute"
+                          checked={interestType === 'want_to_contribute'}
+                          onChange={() => setInterestType('want_to_contribute')}
+                        />
+                        I want to help out / contribute to this project
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer font-normal">
+                        <input
+                          type="radio"
+                          name="interest_type"
+                          value="want_to_own"
+                          checked={interestType === 'want_to_own'}
+                          onChange={() => setInterestType('want_to_own')}
+                        />
+                        I want to own / lead this project
+                      </label>
+                    </div>
+                    <div className="mb-5">
+                      <label htmlFor="interest-message">Message (optional)</label>
+                      <textarea
+                        id="interest-message"
+                        rows={3}
+                        value={interestMessage}
+                        onChange={(e) => setInterestMessage(e.target.value)}
+                        placeholder="Tell them why you're interested…"
+                      />
+                    </div>
+                    <Button type="submit" disabled={expressInterestMutation.isPending}>
+                      {expressInterestMutation.isPending ? 'Submitting…' : 'Express Interest'}
+                    </Button>
+                  </form>
+                ) : (
+                  <div>
+                    <p>
+                      Your interest status:{' '}
+                      <span aria-label="interest status" className="font-semibold">
+                        {project.myInterest.status}
+                      </span>
+                    </p>
+                    {project.myInterest.responseMessage && (
+                      <p className="text-text-light text-sm">
+                        {project.myInterest.responseMessage}
+                      </p>
+                    )}
+                    {project.myInterest.status === InterestStatus.pending && (
+                      <Button variant="secondary" className="mt-2" onClick={handleWithdrawInterest}>
+                        Withdraw Interest
+                      </Button>
+                    )}
                   </div>
                 )}
-                <Button type="submit" disabled={reviewMutation.isPending}>
-                  {reviewMutation.isPending ? 'Submitting…' : 'Submit Review'}
-                </Button>
-              </form>
-            </div>
-          )}
-
-        {/* Project Updates */}
-        <div className={card}>
-          <h2>Project Updates</h2>
-          <CommentThread
-            workItemId={project.id}
-            emptyText="No updates yet."
-            placeholder="Share a progress update…"
-          />
+              </div>
+            )}
+          </div>
         </div>
       </main>
 

--- a/components/FilterDropdown.tsx
+++ b/components/FilterDropdown.tsx
@@ -7,6 +7,7 @@ export interface FilterOption<T extends string = string> {
   value: T
   label: string
   indent?: boolean
+  header?: boolean
 }
 
 export function useFilterOptions<const Options extends readonly FilterOption[]>(
@@ -110,10 +111,17 @@ export default function FilterDropdown<T extends string>({
       : options
 
   function select(opt: FilterOption<T>) {
+    if (opt.header) return
     onChange(opt.value)
     setOpen(false)
     setQuery('')
     setFocusedIndex(-1)
+  }
+
+  function nextSelectableIndex(from: number, direction: 1 | -1): number {
+    let i = from + direction
+    while (i >= 0 && i < filtered.length && filtered[i]?.header) i += direction
+    return Math.max(0, Math.min(i, filtered.length - 1))
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -127,19 +135,15 @@ export default function FilterDropdown<T extends string>({
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
-        setFocusedIndex((i) => Math.min(i + 1, filtered.length - 1))
+        setFocusedIndex((i) => nextSelectableIndex(i, 1))
         break
       case 'Tab':
         e.preventDefault()
-        if (e.shiftKey) {
-          setFocusedIndex((i) => Math.max(i - 1, 0))
-        } else {
-          setFocusedIndex((i) => Math.min(i + 1, filtered.length - 1))
-        }
+        setFocusedIndex((i) => nextSelectableIndex(i, e.shiftKey ? -1 : 1))
         break
       case 'ArrowUp':
         e.preventDefault()
-        setFocusedIndex((i) => Math.max(i - 1, 0))
+        setFocusedIndex((i) => nextSelectableIndex(i, -1))
         break
       case 'Enter':
         e.preventDefault()
@@ -222,19 +226,29 @@ export default function FilterDropdown<T extends string>({
               }}
               className="mt-1 bg-surface border border-brand-border rounded-lg shadow-lg py-1 max-h-72 overflow-y-auto"
             >
-              {filtered.map((opt, i) => (
-                <div
-                  key={opt.value}
-                  id={`${id}-opt-${i}`}
-                  role="option"
-                  aria-selected={value === opt.value}
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => select(opt)}
-                  className={`px-3 py-2 cursor-pointer rounded-md hover:bg-accent transition-colors text-sm ${value === opt.value || i === focusedIndex ? 'bg-accent' : ''} ${opt.indent ? 'pl-6' : ''}`}
-                >
-                  {opt.label}
-                </div>
-              ))}
+              {filtered.map((opt, i) =>
+                opt.header ? (
+                  <div
+                    key={opt.value}
+                    role="presentation"
+                    className="px-3 pt-2 pb-1 text-xs font-semibold text-text-light uppercase tracking-wide"
+                  >
+                    {opt.label}
+                  </div>
+                ) : (
+                  <div
+                    key={opt.value}
+                    id={`${id}-opt-${i}`}
+                    role="option"
+                    aria-selected={value === opt.value}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => select(opt)}
+                    className={`px-3 py-2 cursor-pointer rounded-md hover:bg-accent transition-colors text-sm ${value === opt.value || i === focusedIndex ? 'bg-accent' : ''} ${opt.indent ? 'pl-6' : ''}`}
+                  >
+                    {opt.label}
+                  </div>
+                ),
+              )}
               {filtered.length === 0 && (
                 <div className="px-3 py-2 text-sm text-text-light">No results</div>
               )}

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -129,12 +129,13 @@ export async function transferProjectOwnership(
   if (!adminPage.url().includes(`/projects/${projectId}`)) {
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
   }
+  await adminPage.getByRole('button', { name: 'Ownership actions' }).click()
   await expect(
     adminPage.getByRole('heading', { level: 3, name: 'Transfer Ownership' }),
   ).toBeVisible({ timeout: 10_000 })
   await selectFilterDropdown(adminPage, 'Transfer to', volunteerName)
   adminPage.once('dialog', (dialog) => dialog.accept())
-  await adminPage.getByRole('button', { name: 'Transfer', exact: true }).click()
+  await adminPage.getByRole('menu').getByRole('button', { name: 'Transfer', exact: true }).click()
   await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
 }
 

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -186,7 +186,9 @@ test.describe('Project Lifecycle', () => {
     // Outcome is visible on the project detail
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
     await expect(adminPage.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
-    const outcomeDisplay = adminPage.getByRole('status')
+    // dnd-kit's DndContext (used for task reordering) injects its own hidden
+    // role="status" live region, so scope to the visible outcome banner.
+    const outcomeDisplay = adminPage.getByRole('status').filter({ hasText: 'Outcome' })
     await expect(outcomeDisplay).toBeVisible({ timeout: 10_000 })
     await expect(outcomeDisplay).toContainText('Successful')
     await expect(outcomeDisplay).toContainText(outcomeNotes)

--- a/e2e/tests/08-project-tasks.spec.ts
+++ b/e2e/tests/08-project-tasks.spec.ts
@@ -194,8 +194,9 @@ test.describe('Project Tasks', () => {
     await adminPage.getByRole('button', { name: 'Create Task' }).click()
     await expect(getAlert(adminPage)).toContainText('Task added!', { timeout: 10_000 })
 
+    await adminPage.getByRole('button', { name: 'Task actions for Task to delete' }).click()
     adminPage.once('dialog', (dialog) => dialog.accept())
-    await adminPage.getByRole('button', { name: 'Delete task' }).click()
+    await adminPage.getByRole('menuitem', { name: 'Delete task' }).click()
 
     await expect(getAlert(adminPage)).toContainText('Task deleted!', { timeout: 10_000 })
     await expect(adminPage.getByText('Task to delete')).not.toBeVisible({ timeout: 10_000 })

--- a/e2e/tests/09-project-interests-assignment.spec.ts
+++ b/e2e/tests/09-project-interests-assignment.spec.ts
@@ -52,6 +52,55 @@ test.describe('Project Interests and Assignment', () => {
     })
   })
 
+  test('Accepting a want-to-own interest promotes the volunteer to Owner, not a duplicate volunteer row', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupSeekingProject(baseUrl, adminPage)
+
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await volunteer.page.getByRole('radio', { name: /I want to own/ }).click()
+    await volunteer.page.getByRole('button', { name: 'Express Interest' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Interest expressed!', { timeout: 10_000 })
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    const interestCard = adminPage.locator('.interest-card').filter({ hasText: volunteer.name })
+    await expect(interestCard).toBeVisible({ timeout: 10_000 })
+    await interestCard.getByRole('button', { name: 'Accept' }).click()
+    await expect(getAlert(adminPage)).toContainText('Interest accepted', { timeout: 10_000 })
+
+    // Volunteer now appears once, as Owner — not also listed below in Volunteers
+    await expect(adminPage.getByRole('link', { name: volunteer.name })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(
+      adminPage.locator('.interest-card').filter({ hasText: volunteer.name }),
+    ).toHaveCount(0)
+  })
+
+  test("Volunteer's message is hidden once their interest is accepted", async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const applicantMessage = fake.feedbackText()
+
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await volunteer.page.getByLabel('Message (optional)').fill(applicantMessage)
+    await volunteer.page.getByRole('button', { name: 'Express Interest' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Interest expressed!', { timeout: 10_000 })
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    const interestCard = adminPage.locator('.interest-card').filter({ hasText: volunteer.name })
+    await expect(interestCard).toContainText(applicantMessage, { timeout: 10_000 })
+
+    await interestCard.getByRole('button', { name: 'Accept' }).click()
+    await expect(getAlert(adminPage)).toContainText('Interest accepted', { timeout: 10_000 })
+    await expect(interestCard).not.toContainText(applicantMessage, { timeout: 10_000 })
+  })
+
   test('Project owner accepts a pending interest; volunteer receives a notification', async ({
     adminPage,
     volunteer,
@@ -147,23 +196,43 @@ test.describe('Project Interests and Assignment', () => {
     const projectId = await setupSeekingProject(baseUrl, adminPage)
 
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
-    await expect(adminPage.getByRole('heading', { name: 'Interested Volunteers' })).toBeVisible({
+    await expect(adminPage.getByRole('heading', { name: 'Volunteers' })).toBeVisible({
       timeout: 10_000,
     })
     await selectFilterDropdown(adminPage, 'Volunteer to assign', volunteer.name)
     await adminPage.getByRole('button', { name: 'Assign', exact: true }).click()
     await expect(getAlert(adminPage)).toContainText('Volunteer assigned!', { timeout: 10_000 })
 
-    // Volunteer's interest record appears as accepted
-    await expect(
-      adminPage.locator('.interest-card').filter({ hasText: volunteer.name }),
-    ).toContainText('accepted', { timeout: 10_000 })
+    // Volunteer's interest record appears as accepted, labeled as a role
+    // rather than a pending request since they were assigned directly
+    const assignedCard = adminPage.locator('.interest-card').filter({ hasText: volunteer.name })
+    await expect(assignedCard).toContainText('accepted', { timeout: 10_000 })
+    await expect(assignedCard).toContainText('Helper')
+    await expect(assignedCard).not.toContainText('wants to help')
 
     // Volunteer receives an assignment notification
     await goToDashboardNotifications(baseUrl, volunteer.page)
     await expect(
       volunteer.page.locator('strong').filter({ hasText: "You've been assigned to" }),
     ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('Owner removes an already-accepted volunteer', async ({ adminPage, volunteer, baseUrl }) => {
+    const projectId = await setupSeekingProject(baseUrl, adminPage)
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await selectFilterDropdown(adminPage, 'Volunteer to assign', volunteer.name)
+    await adminPage.getByRole('button', { name: 'Assign', exact: true }).click()
+    await expect(getAlert(adminPage)).toContainText('Volunteer assigned!', { timeout: 10_000 })
+
+    const volunteerCard = adminPage.locator('.interest-card').filter({ hasText: volunteer.name })
+    await expect(volunteerCard).toBeVisible({ timeout: 10_000 })
+
+    adminPage.once('dialog', (dialog) => dialog.accept())
+    await volunteerCard.getByRole('button', { name: 'Remove' }).click()
+    await expect(getAlert(adminPage)).toContainText('Interest declined', { timeout: 10_000 })
+    await expect(volunteerCard).toContainText('declined', { timeout: 10_000 })
+    await expect(volunteerCard.getByRole('button', { name: 'Remove' })).toHaveCount(0)
   })
 
   test('Non-participant can read a project comment thread but cannot post', async ({

--- a/e2e/tests/20-task-management.spec.ts
+++ b/e2e/tests/20-task-management.spec.ts
@@ -1,0 +1,387 @@
+import { test, expect, readAdminToken, confirmVolunteerEmail, approveVolunteer } from '../fixtures'
+import { fake } from '../fake'
+import { createApiClient } from '../client'
+import { goToDashboardNotifications } from '../actions/dashboard'
+import type { RouterClient } from '@orpc/server'
+import type { appRouter } from '@/server/router'
+
+async function createAdminProject(
+  adminApi: RouterClient<typeof appRouter>,
+  description: string,
+  opts?: { isSeekingHelp?: boolean },
+): Promise<number> {
+  const created = await adminApi.admin.projects.create({
+    body: {
+      title: fake.projectTitle(),
+      description,
+      projectType: null,
+      estimatedDuration: null,
+      timeCommitmentHoursPerWeek: null,
+      urgency: 'medium',
+      collaborationLink: null,
+      country: null,
+      localGroup: null,
+      isSeekingHelp: opts?.isSeekingHelp ?? false,
+      isSeekingOwner: false,
+    },
+  })
+  return (created.body as { id: number }).id
+}
+
+async function signupApprovedVolunteer(
+  baseUrl: string,
+): Promise<{ id: number; token: string; name: string }> {
+  const person = fake.person()
+  const api = createApiClient(baseUrl)
+  const signup = await api.auth.signup({
+    body: {
+      name: person.name,
+      email: person.email,
+      password: 'testpassword1',
+      consentMakeProfileVisibleInDirectory: true,
+      consentContactableByProjectOwners: true,
+    },
+  })
+  const { id, token, emailVerificationToken } = signup.body as {
+    id: number
+    token: string
+    emailVerificationToken?: string
+  }
+  if (emailVerificationToken) await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+  await approveVolunteer(baseUrl, id)
+  return { id, token, name: person.name }
+}
+
+test.describe('Task Reordering', () => {
+  test('Owner sees drag handles on tasks, a volunteer does not', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+
+    const projectCreated = await adminApi.admin.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Drag handle visibility test',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: false,
+        isSeekingOwner: false,
+      },
+    })
+    const projectId = (projectCreated.body as { id: number }).id
+
+    await adminApi.projects.createTask({ body: { projectId, title: 'Task A' } })
+    await adminApi.projects.createTask({ body: { projectId, title: 'Task B' } })
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByText('Task A')).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.getByTitle('Drag to reorder').first()).toBeVisible({ timeout: 10_000 })
+
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByText('Task A')).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.getByTitle('Drag to reorder')).toHaveCount(0)
+  })
+
+  test('Reordered tasks persist their order after reload', async ({ adminPage, baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+
+    const projectCreated = await adminApi.admin.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Reorder persistence test',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: false,
+        isSeekingOwner: false,
+      },
+    })
+    const projectId = (projectCreated.body as { id: number }).id
+
+    const taskA = await adminApi.projects.createTask({ body: { projectId, title: 'First' } })
+    const taskB = await adminApi.projects.createTask({ body: { projectId, title: 'Second' } })
+    const taskC = await adminApi.projects.createTask({ body: { projectId, title: 'Third' } })
+    const idA = (taskA.body as { id: number }).id
+    const idB = (taskB.body as { id: number }).id
+    const idC = (taskC.body as { id: number }).id
+
+    // Reorder to Third, First, Second
+    const reorder = await adminApi.projects.reorderTasks({
+      body: {
+        projectId,
+        items: [
+          { id: idC, sortOrder: 1 },
+          { id: idA, sortOrder: 2 },
+          { id: idB, sortOrder: 3 },
+        ],
+      },
+    })
+    expect(reorder.status).toBe(200)
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByText('Third')).toBeVisible({ timeout: 10_000 })
+
+    const taskTitles = await adminPage.locator('ul > li > span.flex-1').allTextContents()
+    expect(taskTitles).toEqual(['Third', 'First', 'Second'])
+  })
+
+  test('Assigning a task keeps its priority position instead of sinking below open tasks', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Assign keeps order test')
+
+    await adminApi.projects.createTask({ body: { projectId, title: 'First' } })
+    const taskB = await adminApi.projects.createTask({ body: { projectId, title: 'Second' } })
+    await adminApi.projects.createTask({ body: { projectId, title: 'Third' } })
+    const idB = (taskB.body as { id: number }).id
+
+    const volunteer = await signupApprovedVolunteer(baseUrl)
+    const assign = await adminApi.projects.assignTask({
+      body: { projectId, taskId: idB, assigneeId: volunteer.id },
+    })
+    expect(assign.status).toBe(200)
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByText('Third')).toBeVisible({ timeout: 10_000 })
+    const taskTitles = await adminPage.locator('ul > li > span.flex-1').allTextContents()
+    expect(taskTitles).toEqual(['First', 'Second', 'Third'])
+  })
+
+  test('A volunteer cannot reorder tasks via the API', async ({ baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+
+    const projectCreated = await adminApi.admin.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Reorder permission test',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: false,
+        isSeekingOwner: false,
+      },
+    })
+    const projectId = (projectCreated.body as { id: number }).id
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: 'Solo task' },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+
+    const person = fake.person()
+    const api = createApiClient(baseUrl)
+    const signup = await api.auth.signup({
+      body: {
+        name: person.name,
+        email: person.email,
+        password: 'testpassword1',
+        consentMakeProfileVisibleInDirectory: true,
+        consentContactableByProjectOwners: true,
+      },
+    })
+    const {
+      id: volId,
+      token: volToken,
+      emailVerificationToken,
+    } = signup.body as { id: number; token: string; emailVerificationToken?: string }
+    if (emailVerificationToken) await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+    await approveVolunteer(baseUrl, volId)
+    const volApi = createApiClient(baseUrl, volToken)
+
+    const reorder = await volApi.projects.reorderTasks({
+      body: { projectId, items: [{ id: taskId, sortOrder: 1 }] },
+    })
+    expect(reorder.status).toBe(403)
+  })
+})
+
+test.describe('Task Assignment', () => {
+  test('Owner assigns a volunteer directly to an open task; assignee shows on the task', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Direct task assignment test')
+    await adminApi.projects.createTask({ body: { projectId, title: 'Assign me' } })
+
+    const volunteer = await signupApprovedVolunteer(baseUrl)
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByText('Assign me')).toBeVisible({ timeout: 10_000 })
+
+    const taskItem = adminPage.locator('li').filter({ hasText: 'Assign me' })
+    await taskItem.getByRole('button', { name: 'Task actions for Assign me' }).click()
+    await adminPage.getByLabel('Assign volunteer to Assign me', { exact: true }).click()
+    const searchInput = adminPage.locator(
+      `input[type="search"][aria-label="Assign volunteer to Assign me"]`,
+    )
+    await searchInput.fill(volunteer.name)
+    await adminPage.getByRole('option', { name: volunteer.name, exact: true }).click()
+    await adminPage.getByRole('menu').getByRole('button', { name: 'Assign', exact: true }).click()
+
+    await expect(adminPage.getByText('Task assigned!')).toBeVisible({ timeout: 10_000 })
+    await expect(taskItem.getByLabel(`Assigned to ${volunteer.name}`)).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('Assigned volunteer receives an in-app notification', async ({ adminPage, baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Task assignment notification test')
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: 'Notify me' },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+
+    const volunteer = await signupApprovedVolunteer(baseUrl)
+    const assign = await adminApi.projects.assignTask({
+      body: { projectId, taskId, assigneeId: volunteer.id },
+    })
+    expect(assign.status).toBe(200)
+
+    const context = await adminPage.context().browser()!.newContext()
+    await context.addInitScript((token: string) => {
+      localStorage.setItem('authToken', token)
+    }, volunteer.token)
+    const volPage = await context.newPage()
+
+    await goToDashboardNotifications(baseUrl, volPage)
+    await expect(volPage.getByText(/assigned/i).first()).toBeVisible({ timeout: 10_000 })
+
+    await context.close()
+  })
+
+  test('A volunteer cannot assign a task via the API', async ({ baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Task assignment permission test')
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: 'Solo task' },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+
+    const volunteer = await signupApprovedVolunteer(baseUrl)
+    const other = await signupApprovedVolunteer(baseUrl)
+    const volApi = createApiClient(baseUrl, volunteer.token)
+
+    const assign = await volApi.projects.assignTask({
+      body: { projectId, taskId, assigneeId: other.id },
+    })
+    expect(assign.status).toBe(403)
+  })
+
+  test('Interested volunteers are grouped first in the assign dropdown', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Interested volunteer grouping test', {
+      isSeekingHelp: true,
+    })
+    await adminApi.projects.createTask({ body: { projectId, title: 'Group test task' } })
+
+    const interested = await signupApprovedVolunteer(baseUrl)
+    const other = await signupApprovedVolunteer(baseUrl)
+    const interestedApi = createApiClient(baseUrl, interested.token)
+    await interestedApi.projects.expressInterest({
+      body: { projectId, interestType: 'want_to_contribute' },
+    })
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.getByText('Group test task')).toBeVisible({ timeout: 10_000 })
+
+    const taskItem = adminPage.locator('li').filter({ hasText: 'Group test task' })
+    await taskItem.getByRole('button', { name: 'Task actions for Group test task' }).click()
+    await adminPage.getByLabel('Assign volunteer to Group test task', { exact: true }).click()
+    const listbox = adminPage.getByRole('listbox')
+    await expect(listbox).toBeVisible({ timeout: 10_000 })
+    const optionTexts = await listbox.locator('div').allTextContents()
+    const interestedHeaderIndex = optionTexts.indexOf('Interested in this project')
+    const interestedNameIndex = optionTexts.indexOf(interested.name)
+    const otherNameIndex = optionTexts.indexOf(other.name)
+    expect(interestedHeaderIndex).toBeGreaterThanOrEqual(0)
+    expect(interestedNameIndex).toBeGreaterThan(interestedHeaderIndex)
+    expect(otherNameIndex).toBeGreaterThan(interestedNameIndex)
+  })
+})
+
+test.describe('Task Deadlines', () => {
+  test('Owner sets estimated hours and a deadline when creating a task', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Task deadline creation test')
+
+    const futureDeadline = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+    const deadlineValue = futureDeadline.toISOString().slice(0, 10)
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await adminPage.getByRole('button', { name: 'Add Task' }).click()
+    await adminPage.getByLabel('Task title').fill('Task with deadline')
+    await adminPage.getByLabel('Estimated hours').fill('4')
+    await adminPage.getByLabel('Deadline').fill(deadlineValue)
+    await adminPage.getByRole('button', { name: 'Create Task' }).click()
+
+    await expect(adminPage.getByText('Task added!')).toBeVisible({ timeout: 10_000 })
+    const taskItem = adminPage.locator('li').filter({ hasText: 'Task with deadline' })
+    await expect(taskItem.getByText('~4h')).toBeVisible({ timeout: 10_000 })
+    await expect(taskItem.getByText(/Due/)).toBeVisible({ timeout: 10_000 })
+    await expect(taskItem.getByText('Overdue')).toHaveCount(0)
+  })
+
+  test('A task with a past deadline shows an Overdue badge; a completed one does not', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const projectId = await createAdminProject(adminApi, 'Overdue badge test')
+
+    const pastDeadline = new Date(Date.now() - 24 * 60 * 60 * 1000)
+
+    await adminApi.projects.createTask({
+      body: { projectId, title: 'Overdue task', deadline: pastDeadline },
+    })
+    const doneTask = await adminApi.projects.createTask({
+      body: { projectId, title: 'Overdue but done task', deadline: pastDeadline },
+    })
+    const doneTaskId = (doneTask.body as { id: number }).id
+    await adminApi.projects.updateTask({
+      body: { projectId, taskId: doneTaskId, data: { status: 'completed' } },
+    })
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    const overdueItem = adminPage.locator('li').filter({ hasText: 'Overdue task' })
+    await expect(overdueItem.getByText('Overdue', { exact: true })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    const doneItem = adminPage.locator('li').filter({ hasText: 'Overdue but done task' })
+    await expect(doneItem.getByText('Overdue', { exact: true })).toHaveCount(0)
+  })
+})

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -137,12 +137,16 @@ export const ProjectInterestBodySchema = z.object({
 export const CreateProjectTaskSchema = WorkItemSchema.pick({
   title: true,
   description: true,
-}).partial({ description: true })
+  estimatedHours: true,
+  deadline: true,
+}).partial({ description: true, estimatedHours: true, deadline: true })
 
 export const UpdateProjectTaskSchema = WorkItemSchema.pick({
   title: true,
   description: true,
   assigneeId: true,
+  estimatedHours: true,
+  deadline: true,
 })
   .partial()
   .extend({ status: TaskStatusSchema.optional() })

--- a/prisma/migrations/20260703174607_add_work_item_sort_order/migration.sql
+++ b/prisma/migrations/20260703174607_add_work_item_sort_order/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "work_items" ADD COLUMN "sort_order" INTEGER DEFAULT 0;
+

--- a/prisma/migrations/20260703183056_add_work_item_deadline/migration.sql
+++ b/prisma/migrations/20260703183056_add_work_item_deadline/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "work_items" ADD COLUMN "deadline" DATETIME;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,7 +169,7 @@ model DeletionRequest {
 model Notification {
   id          Int       @id @default(autoincrement())
   volunteerId Int       @map("volunteer_id")
-  type        String // TODO: enum — new_project_proposal, project_approved, project_needs_discussion, project_status_changed, new_interest, interest_accepted, interest_declined, interest_withdrawn, assigned_to_project, new_bug_report, starter_task_assigned, starter_task_submitted, starter_task_reviewed, local_group_suggestion
+  type        String // TODO: enum — new_project_proposal, project_approved, project_needs_discussion, project_status_changed, new_interest, interest_accepted, interest_declined, interest_withdrawn, assigned_to_project, task_assigned, new_bug_report, starter_task_assigned, starter_task_submitted, starter_task_reviewed, local_group_suggestion
   title       String
   body        String?
   link        String?
@@ -220,6 +220,7 @@ model WorkItem {
   /// @zod.string.min(1, { message: "Title is required" })
   title       String
   description String?
+  deadline    DateTime? // applies to PROJECT, TASK, or STARTER_TASK
 
   // Hierarchy: TASK has parentId → PROJECT
   parentId Int?       @map("parent_id")
@@ -260,6 +261,7 @@ model WorkItem {
   estimatedHours     Float?    @map("estimated_hours")
   nudgeSentAt        DateTime? @map("nudge_sent_at")
   finalWarningSentAt DateTime? @map("final_warning_sent_at")
+  sortOrder          Int?      @default(0) @map("sort_order")
 
   country    String?
   localGroup String?   @map("local_group")

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -39,10 +39,12 @@ const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
   ProjectStatus.completed,
 ]
 
+// open and in_progress share a bucket so claiming/assigning a task doesn't
+// disturb its priority position — only completed tasks sink to the bottom.
 const TASK_ORDER: Record<string, number> = {
   [TaskStatus.open]: 0,
-  [TaskStatus.in_progress]: 1,
-  [TaskStatus.completed]: 2,
+  [TaskStatus.in_progress]: 0,
+  [TaskStatus.completed]: 1,
 }
 
 export const projectsRouter = {
@@ -308,12 +310,15 @@ export const projectsRouter = {
           assignee: { select: { name: true } },
           creator: { select: { name: true } },
         },
-        orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
       })
 
-      const sortedTasks = tasks.sort(
-        (a, b) => (TASK_ORDER[a.status] ?? 0) - (TASK_ORDER[b.status] ?? 0),
-      )
+      const sortedTasks = tasks.sort((a, b) => {
+        const orderDiff = (TASK_ORDER[a.status] ?? 0) - (TASK_ORDER[b.status] ?? 0)
+        if (orderDiff !== 0) return orderDiff
+        const sortOrderDiff = (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
+        if (sortOrderDiff !== 0) return sortOrderDiff
+        return (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0)
+      })
 
       const mappedTasks = sortedTasks.map((t) => ({
         id: t.id,
@@ -325,6 +330,9 @@ export const projectsRouter = {
         createdById: isPending ? null : t.creatorId,
         createdByName: isPending ? null : (t.creator?.name ?? null),
         status: t.status,
+        sortOrder: t.sortOrder,
+        estimatedHours: t.estimatedHours,
+        deadline: t.deadline,
         completedAt: t.completedAt,
         createdAt: t.createdAt,
         updatedAt: t.updatedAt,
@@ -786,7 +794,6 @@ export const projectsRouter = {
             volunteerId: input.volunteerId,
             workItemId: input.projectId,
             interestType: input.interestType,
-            message: 'Assigned by admin/owner',
             status: InterestStatus.accepted,
             respondedAt: new Date(),
           },
@@ -835,6 +842,8 @@ export const projectsRouter = {
       tasks.sort((a, b) => {
         const orderDiff = (TASK_ORDER[a.status] ?? 0) - (TASK_ORDER[b.status] ?? 0)
         if (orderDiff !== 0) return orderDiff
+        const sortOrderDiff = (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
+        if (sortOrderDiff !== 0) return sortOrderDiff
         return (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0)
       })
 
@@ -848,6 +857,9 @@ export const projectsRouter = {
         createdById: isPending ? null : t.creatorId,
         createdByName: isPending ? null : (t.creator?.name ?? null),
         status: t.status,
+        sortOrder: t.sortOrder,
+        estimatedHours: t.estimatedHours,
+        deadline: t.deadline,
         completedAt: t.completedAt,
         createdAt: t.createdAt,
         updatedAt: t.updatedAt,
@@ -870,6 +882,10 @@ export const projectsRouter = {
       }
 
       const task = await prisma.$transaction(async (tx) => {
+        const max = await tx.workItem.aggregate({
+          where: { parentId: input.projectId, type: WorkItemType.TASK },
+          _max: { sortOrder: true },
+        })
         const newTask = await tx.workItem.create({
           data: {
             type: WorkItemType.TASK,
@@ -877,7 +893,10 @@ export const projectsRouter = {
             parentId: input.projectId,
             title: input.title,
             description: input.description ?? null,
+            estimatedHours: input.estimatedHours ?? null,
+            deadline: input.deadline ?? null,
             creatorId: volunteer.id,
+            sortOrder: (max._max.sortOrder ?? 0) + 1,
           },
         })
         if (project.status === ProjectStatus.needs_tasks) {
@@ -890,6 +909,38 @@ export const projectsRouter = {
       })
 
       return { id: task.id, message: 'Task created' }
+    }),
+
+  reorderTasks: authedProcedure
+    .input(
+      z.object({
+        projectId: z.number().int(),
+        items: z.array(z.object({ id: z.number().int(), sortOrder: z.number().int() })),
+      }),
+    )
+    .handler(async ({ input, context }) => {
+      const volunteer = context.volunteer
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
+      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
+
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
+        throw new ORPCError('FORBIDDEN', {
+          message: 'Only project owner or admin can reorder tasks',
+        })
+      }
+
+      await prisma.$transaction(
+        input.items.map(({ id, sortOrder }) =>
+          prisma.workItem.updateMany({
+            where: { id, parentId: input.projectId, type: WorkItemType.TASK },
+            data: { sortOrder },
+          }),
+        ),
+      )
+
+      return { success: true }
     }),
 
   updateTask: authedProcedure
@@ -950,6 +1001,64 @@ export const projectsRouter = {
 
       await prisma.workItem.update({ where: { id: input.taskId }, data })
       return { message: 'Task updated' }
+    }),
+
+  assignTask: authedProcedure
+    .input(
+      z.object({
+        projectId: z.number().int(),
+        taskId: z.number().int(),
+        assigneeId: z.number().int(),
+      }),
+    )
+    .handler(async ({ input, context }) => {
+      const volunteer = context.volunteer
+      const [project, task] = await Promise.all([
+        prisma.workItem.findFirst({ where: { id: input.projectId, type: WorkItemType.PROJECT } }),
+        prisma.workItem.findFirst({
+          where: { id: input.taskId, parentId: input.projectId, type: WorkItemType.TASK },
+        }),
+      ])
+      if (!project || !task)
+        throw new ORPCError('NOT_FOUND', { message: 'Project or task not found' })
+
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
+        throw new ORPCError('FORBIDDEN', { message: 'Only project owner or admin can assign' })
+      }
+      if (task.status === TaskStatus.completed) {
+        throw new ORPCError('BAD_REQUEST', { message: 'Cannot assign a completed task' })
+      }
+
+      const assignee = await prisma.volunteer.findFirst({
+        where: { id: input.assigneeId, deletedAt: null },
+      })
+      if (!assignee) throw new ORPCError('BAD_REQUEST', { message: 'Volunteer not found' })
+
+      await prisma.workItem.update({
+        where: { id: input.taskId },
+        data: {
+          assigneeId: input.assigneeId,
+          status: TaskStatus.in_progress,
+          updatedAt: new Date(),
+          nudgeSentAt: null,
+          finalWarningSentAt: null,
+        },
+      })
+
+      await notifyUser(
+        input.assigneeId,
+        'task_assigned',
+        `You've been assigned a task on '${project.title}'`,
+        task.title,
+        `/projects/${input.projectId}`,
+        {
+          message: `You've been assigned the task <strong>${task.title}</strong> on the project <strong>${project.title}</strong>.`,
+          projectTitle: project.title,
+          projectId: input.projectId,
+        },
+      )
+
+      return { message: 'Task assigned' }
     }),
 
   deleteTask: authedProcedure


### PR DESCRIPTION
## Summary

Implements the asks from #174:
- **Reordering** — drag-and-drop task priority (`sortOrder`). Open/in-progress tasks share one sort bucket so claiming or assigning a task no longer sinks it below still-open tasks.
- **Claimer visibility** — assignee always shown on the task row (avatar + name).
- **Owner/admin assignment** — direct assign-to-volunteer on tasks, with in-app + email notification. Assignable volunteers are grouped by whether they've already expressed interest in the project.
- **Deadlines & estimates** — tasks can carry an estimated-hours figure and a deadline; overdue tasks get a badge. `deadline` was added as a shared `WorkItem` field so projects/starter tasks can use it later too.

## Also included (from review feedback during the branch)

- Reworked the project detail page into a two-column layout: sidebar (Owner, status, volunteers) + main column (description, tasks, updates), matching the rest of the app's conventions more closely.
- Hover-reveal kebab menus for secondary actions (transfer/remove ownership, per-task assign/delete) instead of always-on buttons cluttering each row.
- Merged the redundant "Ownership" and "Interested Volunteers" boxes into one, since they overlapped.
- Fixed volunteer role labeling — accepted volunteers now show as **Owner**/**Helper** instead of the pending-request phrasing "wants to X".
- A volunteer's application message is hidden from view once their interest is accepted (it was only ever meant to help the owner/admin decide).
- Removed a stray hardcoded "Assigned by admin/owner" placeholder message on direct-assigns.

## Test plan

- [x] `npm run check-all` (typecheck, lint, format, full e2e suite) passes
- [x] New e2e coverage: `e2e/tests/20-task-management.spec.ts` (reordering, assignment, deadlines/overdue) plus additions to `09-project-interests-assignment.spec.ts` (owner/helper labeling, message visibility, remove-volunteer, dedup of owner in volunteer list)
- [x] Manually verified drag-and-drop, kebab menus, and sidebar layout via screenshots at multiple viewport sizes

cc @Username-Matilda

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mKxP6z9yGSK2uNLJpH2HV