### PR TITLE
fix: exec next start directly to avoid spurious npm SIGTERM errors

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "NIXPACKS"
 buildCommand = "npm run build:railway"
 
 [deploy]
-startCommand = "npm run migrate && npm start"
+startCommand = "npm run migrate && exec npx next start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 


### PR DESCRIPTION
## Summary
- Railway logs showed `npm error signal SIGTERM` on every rolling deploy — the old container being stopped intentionally, not a crash
- Cause: `npm start` wraps `next start`; npm traps the shutdown signal sent to the old container and logs it as an error
- Fix: use `exec` so the shell process is replaced by `next start` directly — signal reaches Next.js cleanly, no npm relay/log

## Test plan
- [ ] Deploy to staging, confirm rolling deploy no longer logs `npm error signal SIGTERM`
- [ ] Confirm new container still starts/migrates/serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RsCHnJubdgg7igevQQrKX