### PR TITLE
General fixes: admin notifications, filters, dates, UI polish

### DIFF
--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { ApprovalStatus } from '@/generated/prisma/enums'
 
 export default function ApplicationReviewPage() {
@@ -104,7 +105,7 @@ export default function ApplicationReviewPage() {
   const locationParts = [app.localGroup, app.country ?? app.location].filter(Boolean)
   const meta = [
     locationParts.length ? locationParts.join(' · ') : null,
-    app.createdAt ? `Applied ${app.createdAt.toLocaleDateString()}` : null,
+    app.createdAt ? `Applied ${formatDate(app.createdAt)}` : null,
     app.reviewer ? `Reviewer: ${app.reviewer.name}` : null,
   ].filter(Boolean)
 
@@ -127,8 +128,7 @@ export default function ApplicationReviewPage() {
         <p
           className={`text-sm mb-4 ${daysUntilAnonymise !== null && daysUntilAnonymise <= 1 ? 'text-red-500' : 'text-amber-500'}`}
         >
-          Personally Identifiable Information will be anonymised on{' '}
-          {anonymiseDate.toLocaleDateString()}
+          Personally Identifiable Information will be anonymised on {formatDate(anonymiseDate)}
           {daysUntilAnonymise !== null && daysUntilAnonymise >= 0
             ? ` (${daysUntilAnonymise === 0 ? 'today' : `${daysUntilAnonymise} day${daysUntilAnonymise === 1 ? '' : 's'}`})`
             : ''}
@@ -212,7 +212,7 @@ export default function ApplicationReviewPage() {
               className={i > 0 ? 'mt-3 pt-3 border-t border-amber-200 dark:border-amber-700' : ''}
             >
               <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 uppercase tracking-wide mb-1">
-                {new Date(r.rejectedAt).toLocaleDateString()}
+                {formatDate(r.rejectedAt)}
               </p>
               {r.adminNotes && (
                 <div className="mb-1">

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { InferRouterOutputs } from '@orpc/server'
 import { AppRouter } from '@/server/router'
 import { ApprovalStatus } from '@/generated/prisma/enums'
@@ -140,7 +141,7 @@ function ApplicationCard({
   const locationParts = [app.localGroup, app.country ?? app.location].filter(Boolean)
   const meta = [
     locationParts.length ? locationParts.join(' · ') : null,
-    `Applied ${new Date(app.createdAt!).toLocaleDateString()}`,
+    `Applied ${formatDate(app.createdAt!)}`,
     app.reviewer ? `Reviewer: ${app.reviewer.name}` : null,
   ].filter(Boolean)
 
@@ -153,8 +154,7 @@ function ApplicationCard({
         <p
           className={`text-sm mb-3 ${daysUntilAnonymise !== null && daysUntilAnonymise <= 1 ? 'text-red-500' : 'text-amber-500'}`}
         >
-          Personally Identifiable Information will be anonymised on{' '}
-          {anonymiseDate.toLocaleDateString()}
+          Personally Identifiable Information will be anonymised on {formatDate(anonymiseDate)}
           {daysUntilAnonymise !== null && daysUntilAnonymise >= 0
             ? ` (${daysUntilAnonymise === 0 ? 'today' : `${daysUntilAnonymise} day${daysUntilAnonymise === 1 ? '' : 's'}`})`
             : ''}
@@ -250,7 +250,7 @@ function ApplicationCard({
               className={i > 0 ? 'mt-3 pt-3 border-t border-amber-200 dark:border-amber-700' : ''}
             >
               <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 uppercase tracking-wide mb-1">
-                {new Date(r.rejectedAt).toLocaleDateString()}
+                {formatDate(r.rejectedAt)}
               </p>
               {r.adminNotes && (
                 <div className="mb-1">
@@ -301,7 +301,7 @@ function AnonymisedCard({ app }: { app: AnonymisedApplication }) {
   return (
     <div role="article" className="bg-surface rounded-xl shadow p-6 opacity-75">
       <p className="text-sm text-text-light mb-4">
-        [Identity anonymised] · Rejected {new Date(app.rejectedAt).toLocaleDateString()}
+        [Identity anonymised] · Rejected {formatDate(app.rejectedAt)}
       </p>
       {app.adminNotes && (
         <div className="mb-4">

--- a/app/admin/bugs/page.tsx
+++ b/app/admin/bugs/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { Badge, type BadgeVariant } from '@/components/Badge'
 
 const STATUS_OPTIONS = [
@@ -129,7 +130,7 @@ export default function AdminBugsPage() {
                     {r.category && <span>{r.category}</span>}
                     {r.severity && <span>· {r.severity}</span>}
                     {r.reporterName && <span>· {r.reporterName}</span>}
-                    <span>· {r.createdAt?.toLocaleDateString()}</span>
+                    <span>· {r.createdAt ? formatDate(r.createdAt) : ''}</span>
                     {r.pageUrl &&
                       (() => {
                         let path: string

--- a/app/admin/local-groups/page.tsx
+++ b/app/admin/local-groups/page.tsx
@@ -10,6 +10,7 @@ import FilterDropdown, { FilterOption, useFilterOptions } from '@/components/Fil
 import { orpc } from '@/lib/orpc'
 import { COUNTRY_OPTIONS } from '@/lib/filter-options'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { LocalGroupSuggestionStatus } from '@/generated/prisma/enums'
 
 type StatusFilter = 'all' | 'active' | 'pending' | 'on_hold' | 'declined'
@@ -398,11 +399,7 @@ export default function AdminLocalGroupsPage() {
                           {item.suggestedBy.name}
                         </Link>
                         {' · '}
-                        {new Date(item.createdAt).toLocaleDateString('en-GB', {
-                          day: 'numeric',
-                          month: 'short',
-                          year: 'numeric',
-                        })}
+                        {formatDate(item.createdAt)}
                       </p>
                     )}
                     {item.kind === 'suggestion' && item.adminNotes && (

--- a/app/admin/starter-tasks/page.tsx
+++ b/app/admin/starter-tasks/page.tsx
@@ -10,6 +10,7 @@ import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { StarterTaskStatus } from '@/generated/prisma/enums'
 
 interface Skill {
@@ -56,14 +57,6 @@ const RATING_LABELS: Record<string, string> = {
   excellent: 'Excellent',
   good: 'Good',
   needs_improvement: 'Needs improvement',
-}
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString(undefined, {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  })
 }
 
 export default function AdminStarterTasksPage() {

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button'
 import Tabs from '@/components/Tabs'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { InviteStatus } from '@/generated/prisma/enums'
 
 export default function AdminTeamPage() {
@@ -163,8 +164,7 @@ export default function AdminTeamPage() {
                         <div>
                           <strong>{inv.email}</strong>
                           <p className="text-text-light text-sm m-0">
-                            Invited by {inv.invitedByName} · Expires{' '}
-                            {new Date(inv.expiresAt).toLocaleDateString()}
+                            Invited by {inv.invitedByName} · Expires {formatDate(inv.expiresAt)}
                           </p>
                         </div>
                         <Button variant="secondary" size="sm" onClick={() => cancelInvite(inv.id)}>

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -16,6 +16,7 @@ import {
 import Tabs from '@/components/Tabs'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
 export default function TriagePage() {
@@ -171,13 +172,7 @@ export default function TriagePage() {
                           </Link>
                         </p>
                         <p className="text-xs text-text-light m-0 mt-1">
-                          {i.createdAt
-                            ? new Date(i.createdAt).toLocaleDateString('en-GB', {
-                                day: 'numeric',
-                                month: 'short',
-                                year: 'numeric',
-                              })
-                            : ''}
+                          {i.createdAt ? formatDate(i.createdAt) : ''}
                           {' · '}Owner: {i.ownerName ?? 'None'}
                           {' · '}Project:{' '}
                           <span className={statusBadgeClasses(i.projectStatus)}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -125,16 +125,18 @@ a:not([class]) {
   text-decoration: underline;
 }
 
-label {
-  display: block;
-  font-weight: 500;
-  margin-bottom: 6px;
-  color: var(--text);
-}
+@layer base {
+  label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 6px;
+    color: var(--text);
+  }
 
-label.required::after {
-  content: ' *';
-  color: var(--error);
+  label.required::after {
+    content: ' *';
+    color: var(--error);
+  }
 }
 
 input[type='text'],

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import FloatingActions from '@/components/FloatingActions'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import CookieConsentBanner from '@/components/CookieConsentBanner'
+import ConfirmLocationModal from '@/components/ConfirmLocationModal'
 import Script from 'next/script'
 import './globals.css'
 
@@ -66,6 +67,7 @@ export default function RootLayout({
                   <Footer />
                   <FloatingActions />
                   <CookieConsentBanner />
+                  <ConfirmLocationModal />
                 </CookieConsentProvider>
               </ToastProvider>
             </AuthProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from '@/lib/auth-context'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { ToastProvider } from '@/lib/toast'
 import { CookieConsentProvider } from '@/lib/cookie-consent-context'
+import { LocationModalProvider } from '@/lib/location-modal-context'
 import Providers from '@/components/Providers'
 import FloatingActions from '@/components/FloatingActions'
 import Header from '@/components/Header'
@@ -62,12 +63,14 @@ export default function RootLayout({
             <AuthProvider>
               <ToastProvider>
                 <CookieConsentProvider>
-                  <Header />
-                  {children}
-                  <Footer />
-                  <FloatingActions />
-                  <CookieConsentBanner />
-                  <ConfirmLocationModal />
+                  <LocationModalProvider>
+                    <Header />
+                    {children}
+                    <Footer />
+                    <FloatingActions />
+                    <CookieConsentBanner />
+                    <ConfirmLocationModal />
+                  </LocationModalProvider>
                 </CookieConsentProvider>
               </ToastProvider>
             </AuthProvider>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,7 +9,12 @@ import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
-import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
+import {
+  COUNTRY_OPTIONS,
+  NO_LOCAL_GROUP,
+  buildLocalGroupOptionsForCountry,
+  type LocalGroupOption,
+} from '@/lib/filter-options'
 
 interface SelectedSkill {
   skillId: number
@@ -22,7 +27,8 @@ export default function ProfilePage() {
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
   const [location, setLocation] = useState('')
-  const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
+  const [countryValue, setCountryValue] = useState('')
+  const [localGroupValue, setLocalGroupValue] = useState('')
   const [hours, setHours] = useState('')
   const [consentMakeProfileVisibleInDirectory, setConsentMakeProfileVisibleInDirectory] =
     useState(true)
@@ -77,7 +83,8 @@ export default function ProfilePage() {
     setName(me.name ?? '')
     setBio(me.bio ?? '')
     setLocation(me.location ?? '')
-    setLocationValue(me.country ? `${me.country}${me.localGroup ? `:${me.localGroup}` : ''}` : '')
+    setCountryValue(me.country ?? '')
+    setLocalGroupValue(me.localGroup ?? (me.location ? NO_LOCAL_GROUP : ''))
     setHours(me.availabilityHoursPerWeek !== null ? String(me.availabilityHoursPerWeek) : '')
     setConsentMakeProfileVisibleInDirectory(!!me.consentMakeProfileVisibleInDirectory)
     setConsentContactableByProjectOwners(!!me.consentContactableByProjectOwners)
@@ -108,15 +115,25 @@ export default function ProfilePage() {
     },
   })
 
+  const localGroupOptions = countryValue
+    ? buildLocalGroupOptionsForCountry(countryValue, allLocalGroups)
+    : []
+  const hasLocalGroups = localGroupOptions.some((o) => o.value && o.value !== NO_LOCAL_GROUP)
+  const showCityInput = localGroupValue === NO_LOCAL_GROUP || (!!countryValue && !hasLocalGroups)
+
+  function handleCountryChange(value: string) {
+    setCountryValue(value)
+    setLocalGroupValue('')
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    const [country, localGroup] = locationValue.split(':')
     updateMutation.mutate({
       name: name.trim(),
       bio: bio.trim() || null,
       location: location.trim() || null,
-      country: country || null,
-      localGroup: localGroup || null,
+      country: countryValue || null,
+      localGroup: localGroupValue && localGroupValue !== NO_LOCAL_GROUP ? localGroupValue : null,
       availabilityHoursPerWeek: hours ? Number(hours) : null,
       consentMakeProfileVisibleInDirectory,
       consentContactableByProjectOwners,
@@ -238,19 +255,44 @@ export default function ProfilePage() {
 
           {/* Availability */}
           <h3 className="mt-6 mb-4">Availability</h3>
-          <div className="grid grid-cols-2 gap-5 mb-5 max-sm:grid-cols-1">
-            <div>
-              <label htmlFor="hours">Hours per Week</label>
-              <input
-                type="number"
-                id="hours"
-                min={0}
-                max={168}
-                value={hours}
-                onChange={(e) => setHours(e.target.value)}
+          <div className="mb-5">
+            <label htmlFor="hours">Hours per Week</label>
+            <input
+              type="number"
+              id="hours"
+              min={0}
+              max={168}
+              value={hours}
+              onChange={(e) => setHours(e.target.value)}
+            />
+          </div>
+
+          <div className="mb-5">
+            <FilterDropdown
+              id="locationCountry"
+              label="Country"
+              ariaLabel="Select country"
+              value={countryValue}
+              options={COUNTRY_OPTIONS}
+              onChange={handleCountryChange}
+              searchable
+            />
+          </div>
+          {countryValue && hasLocalGroups && (
+            <div className="mb-5">
+              <FilterDropdown
+                id="locationGroup"
+                label="Local Group"
+                ariaLabel="Select local group"
+                value={localGroupValue}
+                options={localGroupOptions}
+                onChange={setLocalGroupValue}
+                searchable
               />
             </div>
-            <div>
+          )}
+          {showCityInput && (
+            <div className="mb-5">
               <label htmlFor="location">City / Area</label>
               <input
                 type="text"
@@ -260,19 +302,7 @@ export default function ProfilePage() {
                 placeholder="e.g. Shoreditch"
               />
             </div>
-          </div>
-
-          <div className="mb-5">
-            <FilterDropdown
-              id="locationValue"
-              label="Country/Group"
-              ariaLabel="Select country/group"
-              value={locationValue}
-              options={buildLocationOptions(allLocalGroups)}
-              onChange={setLocationValue}
-              searchable
-            />
-          </div>
+          )}
 
           {/* Skills */}
           <h3 className="mt-6 mb-4">Your Skills</h3>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,6 +9,7 @@ import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
 
 interface SelectedSkill {
   skillId: number
@@ -21,6 +22,7 @@ export default function ProfilePage() {
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
   const [location, setLocation] = useState('')
+  const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
   const [hours, setHours] = useState('')
   const [consentMakeProfileVisibleInDirectory, setConsentMakeProfileVisibleInDirectory] =
     useState(true)
@@ -65,6 +67,8 @@ export default function ProfilePage() {
     ...orpc.auth.me.queryOptions(),
     enabled: !!user,
   })
+  const { data: localGroupsData } = useQuery(orpc.localGroups.list.queryOptions({ input: {} }))
+  const allLocalGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
 
   useEffect(() => {
     if (!me || initialized) return
@@ -73,6 +77,7 @@ export default function ProfilePage() {
     setName(me.name ?? '')
     setBio(me.bio ?? '')
     setLocation(me.location ?? '')
+    setLocationValue(me.country ? `${me.country}${me.localGroup ? `:${me.localGroup}` : ''}` : '')
     setHours(me.availabilityHoursPerWeek !== null ? String(me.availabilityHoursPerWeek) : '')
     setConsentMakeProfileVisibleInDirectory(!!me.consentMakeProfileVisibleInDirectory)
     setConsentContactableByProjectOwners(!!me.consentContactableByProjectOwners)
@@ -105,10 +110,13 @@ export default function ProfilePage() {
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
+    const [country, localGroup] = locationValue.split(':')
     updateMutation.mutate({
       name: name.trim(),
       bio: bio.trim() || null,
       location: location.trim() || null,
+      country: country || null,
+      localGroup: localGroup || null,
       availabilityHoursPerWeek: hours ? Number(hours) : null,
       consentMakeProfileVisibleInDirectory,
       consentContactableByProjectOwners,
@@ -243,15 +251,27 @@ export default function ProfilePage() {
               />
             </div>
             <div>
-              <label htmlFor="location">Location</label>
+              <label htmlFor="location">City / Area</label>
               <input
                 type="text"
                 id="location"
                 value={location}
                 onChange={(e) => setLocation(e.target.value)}
-                placeholder="e.g. London, UK"
+                placeholder="e.g. Shoreditch"
               />
             </div>
+          </div>
+
+          <div className="mb-5">
+            <FilterDropdown
+              id="locationValue"
+              label="Country/Group"
+              ariaLabel="Select country/group"
+              value={locationValue}
+              options={buildLocationOptions(allLocalGroups)}
+              onChange={setLocationValue}
+              searchable
+            />
           </div>
 
           {/* Skills */}

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -13,6 +13,7 @@ import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 import type { InferRouterOutputs } from '@orpc/server'
 import type { AppRouter } from '@/server/router'
@@ -869,7 +870,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                                 )}
                                 {task.deadline && (
                                   <span className="text-text-light text-xs whitespace-nowrap">
-                                    Due {new Date(task.deadline).toLocaleDateString()}
+                                    Due {formatDate(task.deadline)}
                                   </span>
                                 )}
                               </>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -10,6 +10,7 @@ import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
 import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
+import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
 
 interface SelectedSkill {
   skillId: number
@@ -58,8 +59,7 @@ export default function SignupPage() {
   const [contactNotes, setContactNotes] = useState('')
   const [availability, setAvailability] = useState('')
   const [location, setLocation] = useState('')
-  const [country, setCountry] = useState('')
-  const [localGroup, setLocalGroup] = useState('')
+  const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
   const [otherSkills, setOtherSkills] = useState('')
   const [applicationMessage, setApplicationMessage] = useState('')
   const [consentVisible, setConsentVisible] = useState(true)
@@ -86,6 +86,8 @@ export default function SignupPage() {
     ...orpc.auth.me.queryOptions(),
     enabled: !!googlePendingToken,
   })
+  const { data: localGroupsData } = useQuery(orpc.localGroups.list.queryOptions({ input: {} }))
+  const allLocalGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (meData?.name) setName(meData.name)
@@ -186,6 +188,7 @@ export default function SignupPage() {
     // Write directly to localStorage (not setToken) so the orpc client sends
     // the auth header without triggering auth state and the dashboard redirect.
     localStorage.setItem('authToken', googlePendingToken)
+    const [country, localGroup] = locationValue.split(':')
     try {
       await updateMeMutation.mutateAsync({
         name,
@@ -259,6 +262,7 @@ export default function SignupPage() {
     }
 
     setSubmitting(true)
+    const [country, localGroup] = locationValue.split(':')
     try {
       const data = await signupMutation.mutateAsync({
         name,
@@ -445,33 +449,24 @@ export default function SignupPage() {
                   />
                 </div>
                 <div className="mb-5">
-                  <label htmlFor="g_location">Location</label>
+                  <label htmlFor="g_location">City / Area</label>
                   <input
                     type="text"
                     id="g_location"
-                    placeholder="e.g., London, UK"
+                    placeholder="e.g., Shoreditch"
                     value={location}
                     onChange={(e) => setLocation(e.target.value)}
                   />
                 </div>
                 <div className="mb-5">
-                  <label htmlFor="g_country">Country</label>
-                  <input
-                    type="text"
-                    id="g_country"
-                    placeholder="e.g., United Kingdom"
-                    value={country}
-                    onChange={(e) => setCountry(e.target.value)}
-                  />
-                </div>
-                <div className="mb-5">
-                  <label htmlFor="g_localGroup">Local Group</label>
-                  <input
-                    type="text"
-                    id="g_localGroup"
-                    placeholder="e.g., London"
-                    value={localGroup}
-                    onChange={(e) => setLocalGroup(e.target.value)}
+                  <FilterDropdown
+                    id="g_locationValue"
+                    label="Country/Group"
+                    ariaLabel="Select country/group"
+                    value={locationValue}
+                    options={buildLocationOptions(allLocalGroups)}
+                    onChange={setLocationValue}
+                    searchable
                   />
                 </div>
               </div>
@@ -856,36 +851,25 @@ export default function SignupPage() {
                 />
               </div>
               <div className="mb-5">
-                <label htmlFor="location">Location</label>
+                <label htmlFor="location">City / Area</label>
                 <input
                   type="text"
                   id="location"
                   name="location"
-                  placeholder="e.g., London, UK"
+                  placeholder="e.g., Shoreditch"
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
                 />
               </div>
               <div className="mb-5">
-                <label htmlFor="country">Country</label>
-                <input
-                  type="text"
-                  id="country"
-                  name="country"
-                  placeholder="e.g., United Kingdom"
-                  value={country}
-                  onChange={(e) => setCountry(e.target.value)}
-                />
-              </div>
-              <div className="mb-5">
-                <label htmlFor="localGroup">Local Group</label>
-                <input
-                  type="text"
-                  id="localGroup"
-                  name="localGroup"
-                  placeholder="e.g., London"
-                  value={localGroup}
-                  onChange={(e) => setLocalGroup(e.target.value)}
+                <FilterDropdown
+                  id="locationValue"
+                  label="Country/Group"
+                  ariaLabel="Select country/group"
+                  value={locationValue}
+                  options={buildLocationOptions(allLocalGroups)}
+                  onChange={setLocationValue}
+                  searchable
                 />
               </div>
             </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -10,7 +10,12 @@ import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
 import { useAuth } from '@/lib/auth-context'
 import { orpc } from '@/lib/orpc'
-import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
+import {
+  COUNTRY_OPTIONS,
+  NO_LOCAL_GROUP,
+  buildLocalGroupOptionsForCountry,
+  type LocalGroupOption,
+} from '@/lib/filter-options'
 
 interface SelectedSkill {
   skillId: number
@@ -59,7 +64,8 @@ export default function SignupPage() {
   const [contactNotes, setContactNotes] = useState('')
   const [availability, setAvailability] = useState('')
   const [location, setLocation] = useState('')
-  const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
+  const [countryValue, setCountryValue] = useState('')
+  const [localGroupValue, setLocalGroupValue] = useState('')
   const [otherSkills, setOtherSkills] = useState('')
   const [applicationMessage, setApplicationMessage] = useState('')
   const [consentVisible, setConsentVisible] = useState(true)
@@ -181,6 +187,17 @@ export default function SignupPage() {
     )
   }
 
+  const localGroupOptions = countryValue
+    ? buildLocalGroupOptionsForCountry(countryValue, allLocalGroups)
+    : []
+  const hasLocalGroups = localGroupOptions.some((o) => o.value && o.value !== NO_LOCAL_GROUP)
+  const showCityInput = localGroupValue === NO_LOCAL_GROUP || (!!countryValue && !hasLocalGroups)
+
+  function handleCountryChange(value: string) {
+    setCountryValue(value)
+    setLocalGroupValue('')
+  }
+
   async function handleGoogleApplicationSubmit(e: FormEvent) {
     e.preventDefault()
     if (!googlePendingToken) return
@@ -188,7 +205,6 @@ export default function SignupPage() {
     // Write directly to localStorage (not setToken) so the orpc client sends
     // the auth header without triggering auth state and the dashboard redirect.
     localStorage.setItem('authToken', googlePendingToken)
-    const [country, localGroup] = locationValue.split(':')
     try {
       await updateMeMutation.mutateAsync({
         name,
@@ -201,8 +217,9 @@ export default function SignupPage() {
         contactNotes: contactNotes || undefined,
         availabilityHoursPerWeek: availability ? Number(availability) : undefined,
         location: location || undefined,
-        country: country || undefined,
-        localGroup: localGroup || undefined,
+        country: countryValue || undefined,
+        localGroup:
+          localGroupValue && localGroupValue !== NO_LOCAL_GROUP ? localGroupValue : undefined,
         otherSkills: otherSkills || undefined,
         skillIds: skills.map((s) => s.skillId),
         consentMakeProfileVisibleInDirectory: consentVisible,
@@ -262,7 +279,6 @@ export default function SignupPage() {
     }
 
     setSubmitting(true)
-    const [country, localGroup] = locationValue.split(':')
     try {
       const data = await signupMutation.mutateAsync({
         name,
@@ -277,8 +293,9 @@ export default function SignupPage() {
         contactNotes: contactNotes || undefined,
         availabilityHoursPerWeek: availability ? Number(availability) : undefined,
         location: location || undefined,
-        country: country || undefined,
-        localGroup: localGroup || undefined,
+        country: countryValue || undefined,
+        localGroup:
+          localGroupValue && localGroupValue !== NO_LOCAL_GROUP ? localGroupValue : undefined,
         otherSkills: otherSkills || undefined,
         skillIds: skills.map((s) => s.skillId),
         consentMakeProfileVisibleInDirectory: consentVisible,
@@ -435,19 +452,43 @@ export default function SignupPage() {
               </div>
 
               <h3 className="mt-6">Availability</h3>
-              <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-5">
+              <div className="mb-5">
+                <label htmlFor="g_availability">Hours per Week</label>
+                <input
+                  type="number"
+                  id="g_availability"
+                  min={1}
+                  max={40}
+                  placeholder="e.g., 5"
+                  value={availability}
+                  onChange={(e) => setAvailability(e.target.value)}
+                />
+              </div>
+              <div className="mb-5">
+                <FilterDropdown
+                  id="g_locationCountry"
+                  label="Country"
+                  ariaLabel="Select country"
+                  value={countryValue}
+                  options={COUNTRY_OPTIONS}
+                  onChange={handleCountryChange}
+                  searchable
+                />
+              </div>
+              {countryValue && hasLocalGroups && (
                 <div className="mb-5">
-                  <label htmlFor="g_availability">Hours per Week</label>
-                  <input
-                    type="number"
-                    id="g_availability"
-                    min={1}
-                    max={40}
-                    placeholder="e.g., 5"
-                    value={availability}
-                    onChange={(e) => setAvailability(e.target.value)}
+                  <FilterDropdown
+                    id="g_locationGroup"
+                    label="Local Group"
+                    ariaLabel="Select local group"
+                    value={localGroupValue}
+                    options={localGroupOptions}
+                    onChange={setLocalGroupValue}
+                    searchable
                   />
                 </div>
+              )}
+              {showCityInput && (
                 <div className="mb-5">
                   <label htmlFor="g_location">City / Area</label>
                   <input
@@ -458,18 +499,7 @@ export default function SignupPage() {
                     onChange={(e) => setLocation(e.target.value)}
                   />
                 </div>
-                <div className="mb-5">
-                  <FilterDropdown
-                    id="g_locationValue"
-                    label="Country/Group"
-                    ariaLabel="Select country/group"
-                    value={locationValue}
-                    options={buildLocationOptions(allLocalGroups)}
-                    onChange={setLocationValue}
-                    searchable
-                  />
-                </div>
-              </div>
+              )}
 
               <h3 className="mt-6">Your Skills</h3>
               <p className="text-sm text-text-light mt-1 mb-3">
@@ -836,20 +866,44 @@ export default function SignupPage() {
             </div>
 
             <h3 className="mt-6">Availability</h3>
-            <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-5">
+            <div className="mb-5">
+              <label htmlFor="availability">Hours per Week</label>
+              <input
+                type="number"
+                id="availability"
+                name="availabilityHoursPerWeek"
+                min={1}
+                max={40}
+                placeholder="e.g., 5"
+                value={availability}
+                onChange={(e) => setAvailability(e.target.value)}
+              />
+            </div>
+            <div className="mb-5">
+              <FilterDropdown
+                id="locationCountry"
+                label="Country"
+                ariaLabel="Select country"
+                value={countryValue}
+                options={COUNTRY_OPTIONS}
+                onChange={handleCountryChange}
+                searchable
+              />
+            </div>
+            {countryValue && hasLocalGroups && (
               <div className="mb-5">
-                <label htmlFor="availability">Hours per Week</label>
-                <input
-                  type="number"
-                  id="availability"
-                  name="availabilityHoursPerWeek"
-                  min={1}
-                  max={40}
-                  placeholder="e.g., 5"
-                  value={availability}
-                  onChange={(e) => setAvailability(e.target.value)}
+                <FilterDropdown
+                  id="locationGroup"
+                  label="Local Group"
+                  ariaLabel="Select local group"
+                  value={localGroupValue}
+                  options={localGroupOptions}
+                  onChange={setLocalGroupValue}
+                  searchable
                 />
               </div>
+            )}
+            {showCityInput && (
               <div className="mb-5">
                 <label htmlFor="location">City / Area</label>
                 <input
@@ -861,18 +915,7 @@ export default function SignupPage() {
                   onChange={(e) => setLocation(e.target.value)}
                 />
               </div>
-              <div className="mb-5">
-                <FilterDropdown
-                  id="locationValue"
-                  label="Country/Group"
-                  ariaLabel="Select country/group"
-                  value={locationValue}
-                  options={buildLocationOptions(allLocalGroups)}
-                  onChange={setLocationValue}
-                  searchable
-                />
-              </div>
-            </div>
+            )}
 
             <h3 className="mt-6">Your Skills</h3>
             <p className="text-sm text-text-light mt-1 mb-3">

--- a/app/suggest-local-group/page.tsx
+++ b/app/suggest-local-group/page.tsx
@@ -8,6 +8,7 @@ import FilterDropdown from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { COUNTRY_OPTIONS } from '@/lib/filter-options'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 
 const SUGGESTION_COUNTRIES = COUNTRY_OPTIONS.filter(
   (o) => o.value && o.value !== 'Remote' && o.value !== 'Other',
@@ -124,14 +125,7 @@ export default function SuggestLocalGroupPage() {
                         )}
                       </p>
                       <p className="text-xs text-text-light m-0 mt-1">
-                        Submitted{' '}
-                        {s.createdAt
-                          ? new Date(s.createdAt).toLocaleDateString('en-GB', {
-                              day: 'numeric',
-                              month: 'short',
-                              year: 'numeric',
-                            })
-                          : ''}
+                        Submitted {s.createdAt ? formatDate(s.createdAt) : ''}
                       </p>
                       {s.adminNotes && (
                         <p className="text-sm text-text-light mt-2 mb-0 italic">{s.adminNotes}</p>

--- a/components/Checkbox.tsx
+++ b/components/Checkbox.tsx
@@ -10,8 +10,21 @@ export default function Checkbox({ children, ...props }: CheckboxProps) {
       <span className="relative flex-shrink-0">
         <input type="checkbox" className="sr-only peer" {...props} />
         <span className="block w-5 h-5 rounded border-2 border-brand-border dark:border-secondary bg-surface peer-checked:bg-primary peer-checked:border-primary dark:peer-checked:border-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 transition-colors" />
-        <span className="absolute inset-0 flex items-center justify-center text-white dark:text-[#111827] text-xs font-bold opacity-0 peer-checked:opacity-100 pointer-events-none select-none">
-          ✓
+        <span className="absolute inset-0 flex items-center justify-center opacity-0 peer-checked:opacity-100 pointer-events-none">
+          <svg
+            className="w-3.5 h-3.5 text-white dark:text-[#111827]"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M3.5 8.5L6.5 11.5L12.5 4.5"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
         </span>
       </span>
       {children !== null && <span>{children}</span>}

--- a/components/CommentThread.tsx
+++ b/components/CommentThread.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from './Button'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
 
 interface CommentThreadProps {
   workItemId: number
@@ -72,8 +73,7 @@ export default function CommentThread({
             <li key={c.id} className="py-3 border-b border-brand-border last:border-0">
               <p className="m-0 mb-1 whitespace-pre-wrap">{c.content}</p>
               <span className="text-xs text-text-light">
-                {c.authorName ?? 'Unknown'} ·{' '}
-                {c.createdAt ? new Date(c.createdAt).toLocaleDateString() : ''}
+                {c.authorName ?? 'Unknown'} · {c.createdAt ? formatDate(c.createdAt) : ''}
               </span>
             </li>
           ))}

--- a/components/ConfirmLocationModal.tsx
+++ b/components/ConfirmLocationModal.tsx
@@ -5,18 +5,29 @@ import { useQuery, useMutation } from '@tanstack/react-query'
 import Modal from '@/components/ui/Modal'
 import Button from '@/components/Button'
 import FilterDropdown from '@/components/FilterDropdown'
-import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
+import {
+  BASE_LOCATION_OPTIONS,
+  COUNTRY_OPTIONS,
+  NO_LOCAL_GROUP,
+  buildLocalGroupOptionsForCountry,
+  type LocalGroupOption,
+} from '@/lib/filter-options'
 import { useAuth } from '@/lib/auth-context'
+import { useLocationModal } from '@/lib/location-modal-context'
 import { orpc } from '@/lib/orpc'
 
 export default function ConfirmLocationModal() {
   const { user, refreshUser } = useAuth()
-  const [dismissed, setDismissed] = useState(false)
+  const { open, hide } = useLocationModal()
   const [location, setLocation] = useState(user?.location ?? '')
-  const [locationValue, setLocationValue] = useState(
-    user?.country ? `${user.country}${user.localGroup ? `:${user.localGroup}` : ''}` : '',
-  )
+  const [countryValue, setCountryValue] = useState(user?.country ?? '')
+  const [localGroupValue, setLocalGroupValue] = useState(user?.localGroup ?? '')
   const [initialized, setInitialized] = useState(false)
+
+  const hasValidCountry =
+    !!user?.country && BASE_LOCATION_OPTIONS.some((o) => o.value === user.country)
+  const effectiveCountry = hasValidCountry ? user!.country! : countryValue
+  const showCityInput = localGroupValue === NO_LOCAL_GROUP
 
   const { data: localGroupsData } = useQuery({
     ...orpc.localGroups.list.queryOptions({ input: {} }),
@@ -31,64 +42,78 @@ export default function ConfirmLocationModal() {
     },
   })
 
-  const shouldShow = !!user && !user.locationConfirmedAt && !dismissed
+  const shouldShow = !!user && !user.locationConfirmedAt && open
 
   useEffect(() => {
     if (!shouldShow || initialized) return
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setInitialized(true)
     setLocation(user!.location ?? '')
-    setLocationValue(
-      user!.country ? `${user!.country}${user!.localGroup ? `:${user!.localGroup}` : ''}` : '',
-    )
+    setCountryValue(user!.country ?? '')
+    setLocalGroupValue(user!.localGroup ?? '')
   }, [shouldShow, initialized, user])
 
+  function handleCountryChange(value: string) {
+    setCountryValue(value)
+    setLocalGroupValue('')
+  }
+
   function handleSubmit() {
-    const [country, localGroup] = locationValue.split(':')
     updateMutation.mutate({
       location: location.trim() || null,
-      country: country || null,
-      localGroup: localGroup || null,
+      country: effectiveCountry || null,
+      localGroup: localGroupValue && localGroupValue !== NO_LOCAL_GROUP ? localGroupValue : null,
     })
   }
 
   return (
-    <Modal
-      id="confirm-location"
-      title="Confirm your location"
-      isOpen={shouldShow}
-      onClose={() => setDismissed(true)}
-    >
+    <Modal id="confirm-location" title="Confirm your location" isOpen={shouldShow} onClose={hide}>
       <p className="text-text-light mb-4">
-        Help us match you with nearby projects and local groups &mdash; confirm your country and, if
-        you have one, your local group.
+        Help us match you with nearby projects and local groups.
       </p>
-      <div className="mb-4">
-        <FilterDropdown
-          id="confirm-location-value"
-          label="Country/Group"
-          ariaLabel="Select country/group"
-          value={locationValue}
-          options={buildLocationOptions(allLocalGroups)}
-          onChange={setLocationValue}
-          searchable
-        />
-      </div>
-      <div className="mb-5">
-        <label htmlFor="confirm-location-city">City / Area</label>
-        <input
-          type="text"
-          id="confirm-location-city"
-          value={location}
-          onChange={(e) => setLocation(e.target.value)}
-          placeholder="e.g. Shoreditch"
-        />
-      </div>
+      {!hasValidCountry && (
+        <div className="mb-4">
+          <FilterDropdown
+            id="confirm-location-country"
+            label="Country"
+            ariaLabel="Select country"
+            value={countryValue}
+            options={COUNTRY_OPTIONS}
+            onChange={handleCountryChange}
+            searchable
+          />
+        </div>
+      )}
+      {effectiveCountry && (
+        <div className="mb-4">
+          <FilterDropdown
+            id="confirm-location-group"
+            label={hasValidCountry ? `Local group (${effectiveCountry})` : 'Local group'}
+            ariaLabel="Select local group"
+            value={localGroupValue}
+            options={buildLocalGroupOptionsForCountry(effectiveCountry, allLocalGroups)}
+            onChange={setLocalGroupValue}
+            searchable
+          />
+        </div>
+      )}
+      {showCityInput && (
+        <div className="mb-5">
+          <label htmlFor="confirm-location-city">City / Area</label>
+          <input
+            type="text"
+            id="confirm-location-city"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="e.g. Shoreditch"
+          />
+        </div>
+      )}
       <div className="flex items-center gap-3">
         <Button onClick={handleSubmit} disabled={updateMutation.isPending}>
           {updateMutation.isPending ? 'Saving…' : 'Confirm'}
         </Button>
-        <Button variant="secondary" onClick={() => setDismissed(true)}>
+        <Button variant="secondary" onClick={hide}>
           Ask me later
         </Button>
       </div>

--- a/components/ConfirmLocationModal.tsx
+++ b/components/ConfirmLocationModal.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import Modal from '@/components/ui/Modal'
+import Button from '@/components/Button'
+import FilterDropdown from '@/components/FilterDropdown'
+import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
+import { useAuth } from '@/lib/auth-context'
+import { orpc } from '@/lib/orpc'
+
+export default function ConfirmLocationModal() {
+  const { user, refreshUser } = useAuth()
+  const [dismissed, setDismissed] = useState(false)
+  const [location, setLocation] = useState(user?.location ?? '')
+  const [locationValue, setLocationValue] = useState(
+    user?.country ? `${user.country}${user.localGroup ? `:${user.localGroup}` : ''}` : '',
+  )
+  const [initialized, setInitialized] = useState(false)
+
+  const { data: localGroupsData } = useQuery({
+    ...orpc.localGroups.list.queryOptions({ input: {} }),
+    enabled: !!user && !user.locationConfirmedAt,
+  })
+  const allLocalGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
+
+  const updateMutation = useMutation({
+    ...orpc.volunteers.updateMe.mutationOptions(),
+    onSuccess: async () => {
+      await refreshUser()
+    },
+  })
+
+  const shouldShow = !!user && !user.locationConfirmedAt && !dismissed
+
+  useEffect(() => {
+    if (!shouldShow || initialized) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setInitialized(true)
+    setLocation(user!.location ?? '')
+    setLocationValue(
+      user!.country ? `${user!.country}${user!.localGroup ? `:${user!.localGroup}` : ''}` : '',
+    )
+  }, [shouldShow, initialized, user])
+
+  function handleSubmit() {
+    const [country, localGroup] = locationValue.split(':')
+    updateMutation.mutate({
+      location: location.trim() || null,
+      country: country || null,
+      localGroup: localGroup || null,
+    })
+  }
+
+  return (
+    <Modal
+      id="confirm-location"
+      title="Confirm your location"
+      isOpen={shouldShow}
+      onClose={() => setDismissed(true)}
+    >
+      <p className="text-text-light mb-4">
+        Help us match you with nearby projects and local groups &mdash; confirm your country and, if
+        you have one, your local group.
+      </p>
+      <div className="mb-4">
+        <FilterDropdown
+          id="confirm-location-value"
+          label="Country/Group"
+          ariaLabel="Select country/group"
+          value={locationValue}
+          options={buildLocationOptions(allLocalGroups)}
+          onChange={setLocationValue}
+          searchable
+        />
+      </div>
+      <div className="mb-5">
+        <label htmlFor="confirm-location-city">City / Area</label>
+        <input
+          type="text"
+          id="confirm-location-city"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          placeholder="e.g. Shoreditch"
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button onClick={handleSubmit} disabled={updateMutation.isPending}>
+          {updateMutation.isPending ? 'Saving…' : 'Confirm'}
+        </Button>
+        <Button variant="secondary" onClick={() => setDismissed(true)}>
+          Ask me later
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/components/ConfirmLocationModal.tsx
+++ b/components/ConfirmLocationModal.tsx
@@ -27,13 +27,19 @@ export default function ConfirmLocationModal() {
   const hasValidCountry =
     !!user?.country && BASE_LOCATION_OPTIONS.some((o) => o.value === user.country)
   const effectiveCountry = hasValidCountry ? user!.country! : countryValue
-  const showCityInput = localGroupValue === NO_LOCAL_GROUP
 
   const { data: localGroupsData } = useQuery({
     ...orpc.localGroups.list.queryOptions({ input: {} }),
     enabled: !!user && !user.locationConfirmedAt,
   })
   const allLocalGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
+
+  const localGroupOptions = effectiveCountry
+    ? buildLocalGroupOptionsForCountry(effectiveCountry, allLocalGroups)
+    : []
+  const hasLocalGroups = localGroupOptions.some((o) => o.value && o.value !== NO_LOCAL_GROUP)
+  const showCityInput =
+    localGroupValue === NO_LOCAL_GROUP || (!!effectiveCountry && !hasLocalGroups)
 
   const updateMutation = useMutation({
     ...orpc.volunteers.updateMe.mutationOptions(),
@@ -84,14 +90,14 @@ export default function ConfirmLocationModal() {
           />
         </div>
       )}
-      {effectiveCountry && (
+      {effectiveCountry && hasLocalGroups && (
         <div className="mb-4">
           <FilterDropdown
             id="confirm-location-group"
             label={hasValidCountry ? `Local group (${effectiveCountry})` : 'Local group'}
             ariaLabel="Select local group"
             value={localGroupValue}
-            options={buildLocalGroupOptionsForCountry(effectiveCountry, allLocalGroups)}
+            options={localGroupOptions}
             onChange={setLocalGroupValue}
             searchable
           />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/lib/auth-context'
+import { useLocationModal } from '@/lib/location-modal-context'
 import Button from '@/components/Button'
 import { orpc } from '@/lib/orpc'
 import { ThemeToggle } from './ThemeToggle'
@@ -124,6 +125,7 @@ const ADMIN_NAV_ITEMS: { href: string; label: string; superAdminOnly?: boolean }
 
 export default function Header() {
   const { user, loading, logout } = useAuth()
+  const { show: showLocationModal } = useLocationModal()
   const pathname = usePathname()
   const queryClient = useQueryClient()
   const [mounted, setMounted] = useState(false)
@@ -206,7 +208,17 @@ export default function Header() {
             {mounted &&
               !loading &&
               (user ? (
-                <div className="relative">
+                <div className="relative flex items-center gap-2">
+                  {!user.locationConfirmedAt && (
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={showLocationModal}
+                      className="animate-pulse"
+                    >
+                      Confirm your location
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
                     size="sm"
@@ -315,10 +327,16 @@ export default function Header() {
               variant="ghost"
               size="md"
               icon
-              className="border border-brand-border"
+              className="border border-brand-border relative"
               aria-label="Open menu"
               onClick={() => setMobileMenuOpen(true)}
             >
+              {mounted && !loading && user && !user.locationConfirmedAt && (
+                <span
+                  className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-primary"
+                  aria-hidden="true"
+                />
+              )}
               <svg
                 width="22"
                 height="22"
@@ -382,6 +400,17 @@ export default function Header() {
               (user ? (
                 <>
                   <MobileNavSection>Account</MobileNavSection>
+                  {!user.locationConfirmedAt && (
+                    <button
+                      onClick={() => {
+                        showLocationModal()
+                        setMobileMenuOpen(false)
+                      }}
+                      className="block w-full text-left px-5 py-4 text-primary font-medium text-base border-b border-brand-border hover:bg-brand-bg cursor-pointer bg-transparent"
+                    >
+                      Confirm your location
+                    </button>
+                  )}
                   <MobileNavLink href="/dashboard">
                     Dashboard
                     {unreadCount > 0 && (

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -23,14 +23,17 @@ export default function Tabs<T extends string = string>({
   className = 'mb-6',
 }: TabsProps<T>) {
   return (
-    <div role={role} className={`flex border-b border-brand-border ${className}`}>
+    <div
+      role={role}
+      className={`flex overflow-x-auto border-b border-brand-border ${className}`}
+    >
       {tabs.map(({ key, label, 'data-tab': dataTab }) => (
         <button
           key={key}
           role="tab"
           aria-selected={activeTab === key}
           data-tab={dataTab}
-          className={`px-5 py-3 font-medium border-b-2 -mb-px cursor-pointer transition-colors ${
+          className={`shrink-0 whitespace-nowrap px-5 py-3 font-medium border-b-2 -mb-px cursor-pointer transition-colors ${
             activeTab === key
               ? 'active text-primary border-primary'
               : 'text-text-light border-transparent hover:text-brand-text'

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -23,10 +23,7 @@ export default function Tabs<T extends string = string>({
   className = 'mb-6',
 }: TabsProps<T>) {
   return (
-    <div
-      role={role}
-      className={`flex overflow-x-auto border-b border-brand-border ${className}`}
-    >
+    <div role={role} className={`flex overflow-x-auto border-b border-brand-border ${className}`}>
       {tabs.map(({ key, label, 'data-tab': dataTab }) => (
         <button
           key={key}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -24,22 +24,27 @@ export default function Modal({ id, title, children, isOpen, onClose }: ModalPro
   if (!isOpen) return null
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
       <div
         id={id}
-        className="modal"
+        className="bg-surface max-h-[90vh] w-full max-w-md overflow-y-auto rounded-lg p-6 shadow-lg"
         role="dialog"
         aria-modal="true"
         aria-labelledby={`${id}-title`}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="modal-header">
-          <h2 id={`${id}-title`}>{title}</h2>
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <h2 id={`${id}-title`} style={{ margin: 0, lineHeight: 1 }}>
+            {title}
+          </h2>
           <Button variant="ghost" icon onClick={onClose} aria-label="Close">
             ×
           </Button>
         </div>
-        <div className="modal-body">{children}</div>
+        {children}
       </div>
     </div>
   )

--- a/e2e/tests/05-volunteer-profile.spec.ts
+++ b/e2e/tests/05-volunteer-profile.spec.ts
@@ -27,7 +27,7 @@ test.describe('Volunteer Profile', () => {
 
     await volunteer.page.getByLabel('Your Name').fill(uniqueName)
     await volunteer.page.getByLabel('About You').fill('Bio text for e2e test')
-    await volunteer.page.getByLabel('Location').fill('Test City')
+    await volunteer.page.getByLabel('City / Area').fill('Test City')
     await volunteer.page.getByLabel('Hours per Week').fill('10')
     await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
 

--- a/e2e/tests/05-volunteer-profile.spec.ts
+++ b/e2e/tests/05-volunteer-profile.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, getAlert } from '../fixtures'
 import { Page } from '@playwright/test'
 import { fake } from '../fake'
 import { selectFilterDropdown } from '../actions/ui'
+import { adminAddGroup, navigateToAdminLocalGroups } from '../actions/local-groups'
 import { createApiClient } from '../client'
 
 async function getVolunteerId(page: Page, baseUrl: string): Promise<number> {
@@ -27,7 +28,6 @@ test.describe('Volunteer Profile', () => {
 
     await volunteer.page.getByLabel('Your Name').fill(uniqueName)
     await volunteer.page.getByLabel('About You').fill('Bio text for e2e test')
-    await volunteer.page.getByLabel('City / Area').fill('Test City')
     await volunteer.page.getByLabel('Hours per Week').fill('10')
     await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
 
@@ -207,5 +207,71 @@ test.describe('Volunteer Profile', () => {
     } finally {
       await ctx2.close()
     }
+  })
+
+  test('Volunteer sets location: selects country with local groups, picks group, city stays hidden unless "None of these"', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const groupName = fake.localGroupName()
+
+    // Create a UK local group via admin so the volunteer can select it
+    await navigateToAdminLocalGroups(baseUrl, adminPage)
+    await adminAddGroup(adminPage, 'UK', groupName)
+
+    await volunteer.page.goto(`${baseUrl}/profile`)
+    await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 })
+
+    // No local group dropdown yet (no country selected)
+    await expect(volunteer.page.getByLabel('Select local group', { exact: true })).not.toBeVisible()
+    await expect(volunteer.page.getByLabel('City / Area')).not.toBeVisible()
+
+    // Select UK — local group dropdown should appear, city should stay hidden
+    await selectFilterDropdown(volunteer.page, 'Select country', 'UK')
+    await expect(volunteer.page.getByLabel('Select local group', { exact: true })).toBeVisible({
+      timeout: 5_000,
+    })
+    await expect(volunteer.page.getByLabel('City / Area')).not.toBeVisible()
+
+    // Pick "None of these" — city input should appear
+    await selectFilterDropdown(
+      volunteer.page,
+      'Select local group',
+      "None of these — I'll enter my city",
+    )
+    await expect(volunteer.page.getByLabel('City / Area')).toBeVisible({ timeout: 5_000 })
+
+    // Switch to the real group — city input should disappear again
+    await selectFilterDropdown(volunteer.page, 'Select local group', groupName)
+    await expect(volunteer.page.getByLabel('City / Area')).not.toBeVisible()
+
+    // Save and verify
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Profile updated!', { timeout: 10_000 })
+  })
+
+  test('Volunteer sets location: country with no local groups skips dropdown, city input appears directly', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    await volunteer.page.goto(`${baseUrl}/profile`)
+    await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 })
+
+    // Select Germany — no local groups exist for it, so dropdown should be skipped
+    await selectFilterDropdown(volunteer.page, 'Select country', 'Germany')
+    await expect(volunteer.page.getByLabel('Select local group', { exact: true })).not.toBeVisible()
+    await expect(volunteer.page.getByLabel('City / Area')).toBeVisible({ timeout: 5_000 })
+
+    // Fill city and save
+    await volunteer.page.getByLabel('City / Area').fill('Berlin')
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Profile updated!', { timeout: 10_000 })
+
+    // Reload and verify city persisted
+    await volunteer.page.goto(`${baseUrl}/profile`)
+    await expect(volunteer.page.getByLabel('Your Name')).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.getByLabel('City / Area')).toBeVisible({ timeout: 5_000 })
+    await expect(volunteer.page.getByLabel('City / Area')).toHaveValue('Berlin')
   })
 })

--- a/e2e/tests/16-messaging.spec.ts
+++ b/e2e/tests/16-messaging.spec.ts
@@ -135,7 +135,7 @@ test.describe('Messaging', () => {
     await expect(volunteer.page.getByText(/Message from /)).toBeVisible({ timeout: 10_000 })
     await expect(volunteer.page.getByText(subject)).toBeVisible({ timeout: 10_000 })
     const viewLink = volunteer.page.getByRole('link', { name: 'View' }).first()
-    await expect(viewLink).toHaveAttribute('href', '/dashboard')
+    await expect(viewLink).toHaveAttribute('href', '/dashboard#tab-notifications')
   })
 
   test.skip('Both parties see the message in their history', async () => {

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -14,6 +14,10 @@ interface User {
   hasPassword: boolean
   emailDigest: string | null
   cookieConsentAnalytics: boolean | null
+  location: string | null
+  country: string | null
+  localGroup: string | null
+  locationConfirmedAt: Date | null
   skills: Array<{
     id: number
     name: string

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -68,6 +68,7 @@ export function redactVolunteer(
     location: vol.location,
     country: vol.country,
     localGroup: vol.localGroup,
+    locationConfirmedAt: vol.locationConfirmedAt,
     availabilityHoursPerWeek: vol.availabilityHoursPerWeek,
     otherSkills: vol.otherSkills,
     consentMakeProfileVisibleInDirectory: vol.consentMakeProfileVisibleInDirectory,

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -347,6 +347,45 @@ export function buildProjectNotificationHtml(
 </div></body></html>`
 }
 
+export function buildAdminAlertHtml(
+  name: string,
+  subject: string,
+  message: string,
+  ctaLabel: string,
+  ctaUrl: string,
+): string {
+  const n = escapeHtml(name)
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
+<body><div class="container">
+  <h2>${subject}</h2>
+  <p>Hi ${n},</p>
+  <p>${message}</p>
+  <p style="text-align: center; margin: 32px 0;">
+    <a href="${ctaUrl}" class="button">${ctaLabel}</a>
+  </p>
+  ${footer([[ctaLabel, ctaUrl]])}
+</div></body></html>`
+}
+
+export async function sendAdminAlertEmail({
+  to,
+  name,
+  subject,
+  message,
+  ctaLabel,
+  ctaUrl,
+}: {
+  to: string
+  name: string
+  subject: string
+  message: string
+  ctaLabel: string
+  ctaUrl: string
+}): Promise<boolean> {
+  const url = ctaUrl.startsWith('http') ? ctaUrl : `${env.APP_URL}${ctaUrl}`
+  return sendEmail(to, subject, buildAdminAlertHtml(name, subject, message, ctaLabel, url))
+}
+
 export async function sendProjectNotificationEmail({
   to,
   name,

--- a/lib/filter-options.ts
+++ b/lib/filter-options.ts
@@ -62,6 +62,20 @@ export function buildLocationOptions(
   return result
 }
 
+export const NO_LOCAL_GROUP = '__none__'
+
+export function buildLocalGroupOptionsForCountry(
+  country: string,
+  groups: Pick<LocalGroupOption, 'name' | 'country'>[],
+): FilterOption[] {
+  const countryGroups = groups.filter((g) => g.country === country)
+  return [
+    { value: '', label: 'Select…' },
+    ...countryGroups.map((g) => ({ value: g.name, label: g.name })),
+    { value: NO_LOCAL_GROUP, label: "None of these — I'll enter my city" },
+  ]
+}
+
 export const COUNTRY_OPTIONS: FilterOption[] = [
   { value: '', label: 'Select…' },
   ...BASE_LOCATION_OPTIONS.filter((o) => o.value !== '' && !o.indent),

--- a/lib/format-date.ts
+++ b/lib/format-date.ts
@@ -1,0 +1,4 @@
+export function formatDate(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+}

--- a/lib/location-modal-context.tsx
+++ b/lib/location-modal-context.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+interface LocationModalContextValue {
+  open: boolean
+  show: () => void
+  hide: () => void
+}
+
+const LocationModalContext = createContext<LocationModalContextValue | null>(null)
+
+export function LocationModalProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(true)
+  return (
+    <LocationModalContext.Provider
+      value={{ open, show: () => setOpen(true), hide: () => setOpen(false) }}
+    >
+      {children}
+    </LocationModalContext.Provider>
+  )
+}
+
+export function useLocationModal() {
+  const ctx = useContext(LocationModalContext)
+  if (!ctx) throw new Error('useLocationModal must be used within LocationModalProvider')
+  return ctx
+}

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,5 +1,5 @@
 import { prisma } from './prisma'
-import { sendProjectNotificationEmail } from './email'
+import { sendProjectNotificationEmail, sendAdminAlertEmail } from './email'
 
 export async function createNotification(
   volunteerId: number,
@@ -13,19 +13,23 @@ export async function createNotification(
   })
 }
 
+type NotifyEmailPayload =
+  | {
+      subject?: string
+      message: string
+      projectId: number
+      projectTitle: string
+      extraHtml?: string
+    }
+  | { subject?: string; message: string; ctaLabel: string; ctaUrl: string }
+
 export async function notifyUser(
   volunteerId: number,
   type: string,
   title: string,
   body: string | null | undefined,
   link: string | null | undefined,
-  email?: {
-    subject?: string
-    message: string
-    projectId: number
-    projectTitle: string
-    extraHtml?: string
-  },
+  email?: NotifyEmailPayload,
 ): Promise<void> {
   createNotification(volunteerId, type, title, body, link).catch((e) =>
     console.error('[NOTIFY ERROR]', e),
@@ -38,13 +42,39 @@ export async function notifyUser(
   })
   if (!vol?.email) return
 
-  sendProjectNotificationEmail({
-    to: vol.email,
-    name: vol.name,
-    subject: email.subject ?? title,
-    message: email.message,
-    projectTitle: email.projectTitle,
-    projectId: email.projectId,
-    extraHtml: email.extraHtml,
-  }).catch((e) => console.error('[EMAIL ERROR]', e))
+  const send =
+    'projectId' in email
+      ? sendProjectNotificationEmail({
+          to: vol.email,
+          name: vol.name,
+          subject: email.subject ?? title,
+          message: email.message,
+          projectTitle: email.projectTitle,
+          projectId: email.projectId,
+          extraHtml: email.extraHtml,
+        })
+      : sendAdminAlertEmail({
+          to: vol.email,
+          name: vol.name,
+          subject: email.subject ?? title,
+          message: email.message,
+          ctaLabel: email.ctaLabel,
+          ctaUrl: email.ctaUrl,
+        })
+
+  send.catch((e) => console.error('[EMAIL ERROR]', e))
+}
+
+export async function notifyAdmins(
+  type: string,
+  title: string,
+  body: string | null | undefined,
+  link: string | null | undefined,
+  email?: NotifyEmailPayload,
+): Promise<void> {
+  const admins = await prisma.volunteer.findMany({
+    where: { isAdmin: true, deletedAt: null },
+    select: { id: true },
+  })
+  await Promise.all(admins.map((admin) => notifyUser(admin.id, type, title, body, link, email)))
 }

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -330,6 +330,7 @@ export const UpdateVolunteerSchema = VolunteerSchema.omit({
   reviewerId: true,
   emailConfirmed: true,
   deletedAt: true,
+  locationConfirmedAt: true,
 })
   .partial()
   .extend({

--- a/prisma/migrations/20260706195303_clear_seeking_owner_with_assignee/migration.sql
+++ b/prisma/migrations/20260706195303_clear_seeking_owner_with_assignee/migration.sql
@@ -1,0 +1,15 @@
+-- Clear the stale `is_seeking_owner` flag on projects that already have an
+-- assignee.
+--
+-- The admin "Transfer Ownership" path (projects.update in
+-- server/routers/projects.ts) set `assignee_id` directly without clearing
+-- `is_seeking_owner`, unlike the propose/accept flow which explicitly
+-- resets the flag when an owner interest is accepted. Any project an
+-- admin assigned an owner to this way is left stuck showing as
+-- "seeking owner" even though it has one. This one-off backfill fixes
+-- existing rows; the code fix (commit alongside this migration) prevents
+-- new ones.
+UPDATE "work_items"
+SET "is_seeking_owner" = 0
+WHERE "is_seeking_owner" = 1
+  AND "assignee_id" IS NOT NULL;

--- a/prisma/migrations/20260706203725_add_location_confirmed_at/migration.sql
+++ b/prisma/migrations/20260706203725_add_location_confirmed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "volunteers" ADD COLUMN "location_confirmed_at" DATETIME;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -487,6 +487,7 @@ model Volunteer {
   country                                 String?
   emailDigest                             String?                  @default("none") @map("email_digest") // TODO: enum — none, daily, weekly
   localGroup                              String?                  @map("local_group")
+  locationConfirmedAt                     DateTime?                @map("location_confirmed_at")
   approvalStatus                          ApprovalStatus           @default(pending) @map("approval_status")
   applicationMessage                      String?                  @map("application_message")
   applicationAdminNotes                   String?                  @map("application_admin_notes")

--- a/scripts/seed-location-modal-demo.ts
+++ b/scripts/seed-location-modal-demo.ts
@@ -1,0 +1,44 @@
+// Seeds db/anonymised_prod.db with two ConfirmLocationModal states:
+//   - volunteer@example.com: pre-migration, no country at all (freetext-only
+//     location) -> modal shows full country+group picker.
+//   - admin@example.com: valid country already set, no localGroup -> modal
+//     skips country picker, shows only local-group/city picker.
+// See components/ConfirmLocationModal.tsx.
+//
+// Run: NODE_OPTIONS=--experimental-sqlite npx tsx scripts/seed-location-modal-demo.ts
+// Login: volunteer@example.com / volunteer1  OR  admin@example.com / admin1
+//
+// Idempotent: UPDATE keyed off fixed ids.
+import { DatabaseSync } from 'node:sqlite'
+import { join } from 'path'
+
+const DB_PATH = join(process.cwd(), 'db', 'anonymised_prod.db')
+const VOL = 59 // volunteer@example.com
+const ADMIN = 60 // admin@example.com
+
+const db = new DatabaseSync(DB_PATH)
+
+console.log(`Seeding ${DB_PATH}`)
+
+const infoVol = db
+  .prepare(
+    `UPDATE volunteers
+     SET location='London, UK', country=NULL, local_group=NULL, location_confirmed_at=NULL
+     WHERE id=?`,
+  )
+  .run(VOL)
+console.log(`  volunteer -> pre-migration, no country: ${infoVol.changes} row(s)`)
+
+const infoAdmin = db
+  .prepare(
+    `UPDATE volunteers
+     SET location='', country='UK', local_group=NULL, location_confirmed_at=NULL
+     WHERE id=?`,
+  )
+  .run(ADMIN)
+console.log(`  admin -> valid country, no local group: ${infoAdmin.changes} row(s)`)
+
+db.close()
+console.log('Done.')
+console.log('  volunteer@example.com / volunteer1  -> full country+group picker')
+console.log('  admin@example.com / admin1          -> local group/city only')

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -252,6 +252,7 @@ export const authRouter = {
         location: input.location ?? null,
         country: input.country ?? null,
         localGroup: input.localGroup ?? null,
+        locationConfirmedAt: new Date(),
         otherSkills: input.otherSkills ?? null,
         consentMakeProfileVisibleInDirectory: input.consentMakeProfileVisibleInDirectory ?? true,
         consentContactableByProjectOwners: input.consentContactableByProjectOwners ?? true,

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -18,6 +18,7 @@ import {
   sendApplicationApprovedEmail,
 } from '@/lib/email'
 import { checkRateLimit } from '@/lib/rate-limit'
+import { notifyAdmins } from '@/lib/notify'
 import {
   SignupSchema,
   ChangePasswordSchema,
@@ -301,6 +302,20 @@ export const authRouter = {
     }
 
     const isApproved = wasBootstrapped || wasInvited || !platformSettings.requireApplicationApproval
+    if (!isApproved) {
+      notifyAdmins(
+        'new_volunteer_signup',
+        `New volunteer application: ${volunteer.name}`,
+        `${volunteer.name} has applied to join Catalyse`,
+        '/admin/applications',
+        {
+          message: `<strong>${volunteer.name}</strong> (${email}) has applied to join Catalyse. Please review their application.`,
+          ctaLabel: 'Review Application',
+          ctaUrl: '/admin/applications',
+        },
+      ).catch((e) => console.error('[SIGNUP NOTIFY]', e))
+    }
+
     return {
       id: volunteer.id,
       token: authToken,

--- a/server/routers/messages.ts
+++ b/server/routers/messages.ts
@@ -111,7 +111,7 @@ export const messagesRouter = {
           type: 'message_received',
           title: `Message from ${sender.name}`,
           body: input.subject,
-          link: '/dashboard',
+          link: '/dashboard#tab-notifications',
         },
       })
     })

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -498,7 +498,12 @@ export const projectsRouter = {
       }
       if (body.timeCommitmentHoursPerWeek !== undefined)
         data.timeCommitmentHoursPerWeek = body.timeCommitmentHoursPerWeek
-      if (body.assigneeId !== undefined) data.assigneeId = body.assigneeId
+      if (body.assigneeId !== undefined) {
+        data.assigneeId = body.assigneeId
+        if (body.assigneeId !== null && body.isSeekingOwner === undefined) {
+          data.isSeekingOwner = false
+        }
+      }
 
       if (newStatus !== undefined) {
         if (volunteer.isAdmin) {

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { Prisma } from '@/generated/prisma/client'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
-import { notifyUser } from '@/lib/notify'
+import { notifyUser, notifyAdmins } from '@/lib/notify'
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
@@ -244,25 +244,17 @@ export const projectsRouter = {
       return newProject
     })
 
-    const admins = await prisma.volunteer.findMany({
-      where: { isAdmin: true, deletedAt: null },
-      select: { id: true, name: true, email: true },
-    })
-
-    for (const admin of admins) {
-      await notifyUser(
-        admin.id,
-        'new_project_proposal',
-        `New project proposal: ${project.title}`,
-        `Proposed by ${volunteer.name}`,
-        '/admin/triage',
-        {
-          message: `<strong>${volunteer.name}</strong> has submitted a new project proposal: <strong>${project.title}</strong>. Please review it in the triage queue.`,
-          projectTitle: project.title,
-          projectId: project.id,
-        },
-      )
-    }
+    await notifyAdmins(
+      'new_project_proposal',
+      `New project proposal: ${project.title}`,
+      `Proposed by ${volunteer.name}`,
+      '/admin/triage',
+      {
+        message: `<strong>${volunteer.name}</strong> has submitted a new project proposal: <strong>${project.title}</strong>. Please review it in the triage queue.`,
+        projectTitle: project.title,
+        projectId: project.id,
+      },
+    )
 
     return { id: project.id, message: 'Project submitted for review' }
   }),

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -39,18 +39,31 @@ export const volunteersRouter = {
         ...(input.skillIds && input.skillIds.length > 0
           ? { skills: { some: { skillId: { in: input.skillIds } } } }
           : {}),
-        ...(input.search
-          ? { OR: [{ name: { contains: input.search } }, { bio: { contains: input.search } }] }
-          : {}),
-        ...(input.country
-          ? {
-              OR: [
-                { country: input.country },
-                { country: null, location: { contains: input.country } },
-              ],
-            }
-          : {}),
-        ...(input.localGroup ? { localGroup: input.localGroup } : {}),
+        AND: [
+          ...(input.search
+            ? [{ OR: [{ name: { contains: input.search } }, { bio: { contains: input.search } }] }]
+            : []),
+          ...(input.country
+            ? [
+                {
+                  OR: [
+                    { country: input.country },
+                    { country: null, location: { contains: input.country } },
+                  ],
+                },
+              ]
+            : []),
+          ...(input.localGroup
+            ? [
+                {
+                  OR: [
+                    { localGroup: input.localGroup },
+                    { localGroup: null, location: { contains: input.localGroup } },
+                  ],
+                },
+              ]
+            : []),
+        ],
       }
 
       const [volunteers, total] = await Promise.all([
@@ -259,6 +272,14 @@ export const volunteersRouter = {
       if (Object.prototype.hasOwnProperty.call(input, field)) {
         data[field] = input[field]
       }
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(input, 'location') ||
+      Object.prototype.hasOwnProperty.call(input, 'country') ||
+      Object.prototype.hasOwnProperty.call(input, 'localGroup')
+    ) {
+      data.locationConfirmedAt = new Date()
     }
 
     if (input.consentMakeProfileVisibleInDirectory !== undefined) {


### PR DESCRIPTION
## Summary

Batch of fixes accumulated on `general-fixes`:

- **Admin notifications on new applications** — volunteer signups now trigger the same immediate in-app + email notify to all admins that project proposals already got, instead of relying solely on the daily digest to super-admins. Generalized `notifyUser`'s email payload and added a `notifyAdmins()` helper to share the admin-loop logic.
- **Location/country filter** — volunteer location filtering now correctly matches on country/local-group instead of free text.
- **Location-confirmation modal + profile/signup UX overhaul** — `ConfirmLocationModal` referenced CSS classes that didn't exist, so it rendered inline; rebuilt with Tailwind. Country and local group are now separate dropdowns across the modal, profile page, and signup form. Country with no local groups skips the group picker and goes straight to City/Area. Choosing "None of these" in the group picker reveals a freetext city field (otherwise hidden). Members with an already-valid country skip re-picking it. Dismissing via "Ask me later" no longer requires a page reload — persistent header button/nav entry/hamburger indicator reopen it on demand.
- **Friendly date format** — replaced ~15 scattered `toLocaleDateString` calls with a shared formatter (e.g. "2 July 2026").
- **Message notification "View" link** — fixed a dead link that pointed at the page the user was already on; still one-way messaging overall, no reply/thread UI yet (tracked separately).
- **Checkbox/Radio label layout + mobile tabs overflow** — CSS fixes so checkmark/radio glyphs render inline with their labels and tabs no longer overflow on mobile.
- Two smaller pre-existing fixes: `isSeekingOwner` cleanup when an admin assigns an owner directly, plus a backfill migration for projects already stuck in that state.

## Test plan

- [x] `npm run check-all` (typecheck, lint, format, tests) passes — 139 e2e pass, 0 failures, 6 skipped
- [ ] Manual smoke test of admin notification email/in-app alert on a fresh signup
- [x] Manual smoke test of location-confirmation modal (both no-country and valid-country states) via `scripts/seed-location-modal-demo.ts`
- [x] Profile page: select country with groups → group dropdown appears, city hidden → "None of these" → city appears
- [x] Profile page: select country with no groups → group dropdown skipped, city appears directly

Closes #171
Closes #179
Closes #178
Closes #180
Addresses #176 (partially — link fix only; messaging is still one-way, follow-up needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGuCPeiGmh6LVJARhJkiu6