### PR TITLE
fix: auth:expired dispatch, verify-email CTA, CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  typecheck:
+  static-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,27 +17,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run typecheck
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
       - run: npm run lint
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
       - run: npm run format:check
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      APP_URL: http://localhost:3000
+      CRON_SECRET: ci-dummy-secret
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Do **not** run `prisma migrate dev` — it checks for schema drift and will fail
 1. Edit `prisma/schema.prisma`
 2. `npm run new-migration your_migration_name` — generates the SQL diff file
 3. Review the generated SQL and remove any unrelated statements
+   - Adding a `NOT NULL` column: if existing rows need a value other than the column default, backfill them in the same migration. SQLite's table-rebuild (`INSERT INTO "new_x" (...) SELECT ... FROM "x"`) silently applies the column default to every existing row — it does not run any backfill logic for you.
 4. `npm run migrate` — applies it
 5. `npm run generate` — regenerates the client and zod schema
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
 import { InferRouterInputs } from '@orpc/server'
+import { ORPCError } from '@orpc/client'
 import { orpc } from '@/lib/orpc'
 import { AppRouter } from '@/server/router'
 import { type Project, ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
@@ -288,6 +289,13 @@ export default function ProjectsPage() {
                 ? projectsError.message
                 : 'Something went wrong loading projects.'}
             </p>
+            {projectsError instanceof ORPCError && projectsError.code === 'FORBIDDEN' && (
+              <p className="mt-2">
+                <Link href="/verify-email" className="underline">
+                  Confirm your email
+                </Link>
+              </p>
+            )}
           </div>
         ) : projects.length === 0 ? (
           <div className="text-center py-15 px-5 text-text-light">

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,4 +1,4 @@
-import { createORPCClient } from '@orpc/client'
+import { createORPCClient, ORPCError } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
 import type { RouterClient } from '@orpc/server'
 import type { appRouter } from '@/server/router'
@@ -12,6 +12,22 @@ const link = new RPCLink({
     const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null
     return token ? { Authorization: `Bearer ${token}` } : {}
   },
+  interceptors: [
+    async ({ next }) => {
+      try {
+        return await next()
+      } catch (error) {
+        if (
+          error instanceof ORPCError &&
+          error.code === 'UNAUTHORIZED' &&
+          typeof window !== 'undefined'
+        ) {
+          window.dispatchEvent(new Event('auth:expired'))
+        }
+        throw error
+      }
+    },
+  ],
 })
 
 export const client = createORPCClient<RouterClient<typeof appRouter>>(link)


### PR DESCRIPTION
## Summary
- Wire `auth:expired` dispatch on UNAUTHORIZED so a mid-session token expiry does a clean logout instead of opaque errors on every subsequent request
- Add verify-email CTA link when project queries fail with FORBIDDEN (unconfirmed email)
- Add CI workflow (typecheck/lint/format/test), later combined into one job to cut checkout+setup overhead
- Codify NOT NULL backfill rule in migration checklist (root cause of the underlying incident)

Closes #166

## Test plan
- [ ] CI workflow runs green on this PR
- [ ] Manually trigger a 401 mid-session, confirm clean logout
- [ ] Manually trigger FORBIDDEN on projects query, confirm verify-email CTA renders and links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQL4yjdQ6AgFH8q6NzWEnU