### PR TITLE
fix: gate signup/edit actions behind volunteer approval

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -96,6 +96,44 @@ export function readAdminToken(baseUrl: string): string | null {
   }
 }
 
+export interface ApiVolunteer {
+  id: number
+  token: string
+  name: string
+  email: string
+}
+
+export async function createPendingVolunteer(baseUrl: string): Promise<ApiVolunteer> {
+  const person = fake.person()
+  const api = createApiClient(baseUrl)
+  const result = await api.auth.signup({
+    body: {
+      name: person.name,
+      email: person.email,
+      password: 'testpassword1',
+      consentMakeProfileVisibleInDirectory: true,
+      consentContactableByProjectOwners: true,
+    },
+  })
+  if (result.status !== 200)
+    throw new Error(`Volunteer signup failed: ${JSON.stringify(result.body)}`)
+  const { id, token, emailVerificationToken } = result.body as {
+    id: number
+    token: string
+    emailVerificationToken?: string
+  }
+  if (emailVerificationToken) {
+    await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+  }
+  return { id, token, name: person.name, email: person.email }
+}
+
+export async function createApprovedVolunteer(baseUrl: string): Promise<ApiVolunteer> {
+  const pending = await createPendingVolunteer(baseUrl)
+  await approveVolunteer(baseUrl, pending.id)
+  return pending
+}
+
 export async function rejectVolunteer(
   baseUrl: string,
   volunteerId: number,

--- a/e2e/tests/21-approval-gate.spec.ts
+++ b/e2e/tests/21-approval-gate.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from '../fixtures'
+import { readAdminToken, createPendingVolunteer, createApprovedVolunteer } from '../fixtures'
+import { createApiClient } from '../client'
+import { fake } from '../fake'
+
+async function createAdminProject(
+  adminApi: ReturnType<typeof createApiClient>,
+  description: string,
+  opts?: { isSeekingHelp?: boolean; tasks?: { title: string }[] },
+): Promise<number> {
+  const created = await adminApi.admin.projects.create({
+    body: {
+      title: fake.projectTitle(),
+      description,
+      projectType: null,
+      estimatedDuration: null,
+      timeCommitmentHoursPerWeek: null,
+      urgency: 'medium',
+      collaborationLink: null,
+      country: null,
+      localGroup: null,
+      isSeekingHelp: opts?.isSeekingHelp ?? true,
+      isSeekingOwner: false,
+      tasks: opts?.tasks ?? [],
+    },
+  })
+  return (created.body as { id: number }).id
+}
+
+test.describe('Approval Gate', () => {
+  test('Unapproved volunteer cannot propose a project', async ({ baseUrl }) => {
+    const pending = await createPendingVolunteer(baseUrl)
+    const api = createApiClient(baseUrl, pending.token)
+
+    const result = await api.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Should be blocked',
+        tasks: [{ title: 'Initial task' }],
+      },
+    })
+
+    expect(result.status).toBe(403)
+  })
+
+  test('Unapproved volunteer cannot express interest in a project', async ({ baseUrl }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const projectId = await createAdminProject(adminApi, 'Interest gate test', {
+      tasks: [{ title: 'Task' }],
+    })
+
+    const pending = await createPendingVolunteer(baseUrl)
+    const api = createApiClient(baseUrl, pending.token)
+
+    const result = await api.projects.expressInterest({
+      body: { projectId, interestType: 'want_to_contribute' },
+    })
+
+    expect(result.status).toBe(403)
+  })
+
+  test('Unapproved volunteer cannot self-claim an open task', async ({ baseUrl }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const projectId = await createAdminProject(adminApi, 'Task self-claim gate test')
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: 'Open task' },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+
+    const pending = await createPendingVolunteer(baseUrl)
+    const api = createApiClient(baseUrl, pending.token)
+
+    const result = await api.projects.updateTask({
+      body: {
+        projectId,
+        taskId,
+        data: { status: 'in_progress', assigneeId: pending.id },
+      },
+    })
+
+    expect(result.status).toBe(403)
+  })
+
+  test('Unapproved volunteer cannot send a message', async ({ baseUrl }) => {
+    const recipient = await createApprovedVolunteer(baseUrl)
+    const pending = await createPendingVolunteer(baseUrl)
+    const api = createApiClient(baseUrl, pending.token)
+
+    const result = await api.messages.send({
+      body: {
+        recipientId: recipient.id,
+        subject: 'Hello',
+        message: 'Should be blocked',
+      },
+    })
+
+    expect(result.status).toBe(403)
+  })
+
+  test('Unapproved volunteer cannot submit a local group suggestion', async ({ baseUrl }) => {
+    const pending = await createPendingVolunteer(baseUrl)
+    const api = createApiClient(baseUrl, pending.token)
+
+    const result = await api.localGroupSuggestions.create({
+      body: { name: fake.personName(), country: 'Canada' },
+    })
+
+    expect(result.status).toBe(403)
+  })
+
+  test('Admin cannot assign a project to an unapproved volunteer', async ({ baseUrl }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const projectId = await createAdminProject(adminApi, 'Project assign gate test')
+    const pending = await createPendingVolunteer(baseUrl)
+
+    const result = await adminApi.projects.assign({
+      body: { projectId, volunteerId: pending.id },
+    })
+
+    expect(result.status).toBe(400)
+  })
+
+  test('Admin cannot assign a task to an unapproved volunteer', async ({ baseUrl }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const projectId = await createAdminProject(adminApi, 'Task assign gate test')
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: 'Assignable task' },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+    const pending = await createPendingVolunteer(baseUrl)
+
+    const result = await adminApi.projects.assignTask({
+      body: { projectId, taskId, assigneeId: pending.id },
+    })
+
+    expect(result.status).toBe(400)
+  })
+
+  test('Admin cannot assign a starter task to an unapproved volunteer', async ({ baseUrl }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const taskCreated = await adminApi.starterTasks.create({
+      body: { title: fake.starterTaskTitle(), description: 'Starter task assign gate test' },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+    const pending = await createPendingVolunteer(baseUrl)
+
+    const result = await adminApi.starterTasks.assign({
+      body: { id: taskId, volunteerId: pending.id },
+    })
+
+    expect(result.status).toBe(400)
+  })
+
+  test('Unapproved volunteers do not appear in the volunteer directory', async ({ baseUrl }) => {
+    const pending = await createPendingVolunteer(baseUrl)
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+
+    const result = await adminApi.volunteers.list({ body: { limit: 100 } })
+    const ids = (result.body as { volunteers: { id: number }[] }).volunteers.map((v) => v.id)
+
+    expect(ids).not.toContain(pending.id)
+  })
+})

--- a/server/procedures.ts
+++ b/server/procedures.ts
@@ -1,4 +1,5 @@
 import { os, ORPCError } from '@orpc/server'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 import { isSuperAdmin } from '@/lib/auth'
 import type { Context } from './context'
 
@@ -9,6 +10,13 @@ export const publicProcedure = base
 export const authedProcedure = base.use(({ context, next }) => {
   if (!context.volunteer) throw new ORPCError('UNAUTHORIZED')
   return next({ context: { volunteer: context.volunteer } })
+})
+
+export const approvedProcedure = authedProcedure.use(({ context, next }) => {
+  if (context.volunteer.approvalStatus !== ApprovalStatus.approved && !context.volunteer.isAdmin) {
+    throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
+  }
+  return next({ context })
 })
 
 export const adminProcedure = base.use(({ context, next }) => {

--- a/server/routers/localGroupSuggestions.ts
+++ b/server/routers/localGroupSuggestions.ts
@@ -2,7 +2,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { BASE_LOCATION_OPTIONS } from '@/lib/filter-options'
 import { LocalGroupSuggestionBodySchema } from '@/lib/schemas'
-import { authedProcedure } from '../procedures'
+import { authedProcedure, approvedProcedure } from '../procedures'
 
 const VALID_COUNTRIES = new Set(
   BASE_LOCATION_OPTIONS.filter((o) => o.value && o.value !== 'Remote' && o.value !== 'Other').map(
@@ -30,7 +30,7 @@ export const localGroupSuggestionsRouter = {
     }
   }),
 
-  create: authedProcedure
+  create: approvedProcedure
     .input(LocalGroupSuggestionBodySchema)
     .handler(async ({ input, context }) => {
       if (!VALID_COUNTRIES.has(input.country)) {

--- a/server/routers/messages.ts
+++ b/server/routers/messages.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { sendRelayMessage, isEmailConfigured } from '@/lib/email'
-import { authedProcedure } from '../procedures'
+import { authedProcedure, approvedProcedure } from '../procedures'
 import { WorkItemType } from '@/generated/prisma/enums'
 
 const ContactSchema = z.object({
@@ -67,7 +67,7 @@ export const messagesRouter = {
       return { message: 'Marked as read' }
     }),
 
-  send: authedProcedure.input(ContactSchema).handler(async ({ input, context }) => {
+  send: approvedProcedure.input(ContactSchema).handler(async ({ input, context }) => {
     const sender = context.volunteer
     if (sender.id === input.recipientId) {
       throw new ORPCError('BAD_REQUEST', { message: 'Cannot message yourself' })

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -11,7 +11,7 @@ import {
   CreateProjectTaskSchema,
   UpdateProjectTaskSchema,
 } from '@/lib/schemas'
-import { publicProcedure, authedProcedure, adminProcedure } from '../procedures'
+import { publicProcedure, authedProcedure, approvedProcedure, adminProcedure } from '../procedures'
 import {
   ApprovalStatus,
   InterestStatus,
@@ -185,12 +185,8 @@ export const projectsRouter = {
       return { projects, total }
     }),
 
-  create: authedProcedure.input(CreateProjectSchema).handler(async ({ input, context }) => {
+  create: approvedProcedure.input(CreateProjectSchema).handler(async ({ input, context }) => {
     const volunteer = context.volunteer
-    if (volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin) {
-      throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
-    }
-
     const { tasks, wantToOwn, skillIds, skillRequiredMap } = input
     if (tasks.length === 0) {
       throw new ORPCError('BAD_REQUEST', {
@@ -435,7 +431,7 @@ export const projectsRouter = {
       }
     }),
 
-  update: authedProcedure
+  update: approvedProcedure
     .input(z.object({ id: z.number().int() }).merge(UpdateProjectSchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
@@ -578,14 +574,10 @@ export const projectsRouter = {
     return { message: `Project '${project.title}' deleted` }
   }),
 
-  expressInterest: authedProcedure
+  expressInterest: approvedProcedure
     .input(z.object({ projectId: z.number().int() }).merge(ProjectInterestBodySchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      if (volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin) {
-        throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
-      }
-
       const project = await prisma.workItem.findFirst({
         where: {
           id: input.projectId,
@@ -699,8 +691,17 @@ export const projectsRouter = {
 
       const interest = await prisma.workItemInterest.findFirst({
         where: { id: input.interestId, workItemId: input.projectId },
+        include: { volunteer: { select: { approvalStatus: true } } },
       })
       if (!interest) throw new ORPCError('NOT_FOUND', { message: 'Interest not found' })
+      if (
+        input.status === InterestStatus.accepted &&
+        interest.volunteer.approvalStatus !== ApprovalStatus.approved
+      ) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'Cannot accept interest from a volunteer who is not yet approved',
+        })
+      }
 
       await prisma.workItemInterest.update({
         where: { id: input.interestId },
@@ -765,6 +766,16 @@ export const projectsRouter = {
       if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', {
           message: 'Only project owner or admin can assign volunteers',
+        })
+      }
+
+      const targetVolunteer = await prisma.volunteer.findFirst({
+        where: { id: input.volunteerId, deletedAt: null },
+      })
+      if (!targetVolunteer) throw new ORPCError('BAD_REQUEST', { message: 'Volunteer not found' })
+      if (targetVolunteer.approvalStatus !== ApprovalStatus.approved) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'Cannot assign a project to a volunteer who is not yet approved',
         })
       }
 
@@ -863,7 +874,7 @@ export const projectsRouter = {
       }))
     }),
 
-  createTask: authedProcedure
+  createTask: approvedProcedure
     .input(z.object({ projectId: z.number().int() }).merge(CreateProjectTaskSchema))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
@@ -908,7 +919,7 @@ export const projectsRouter = {
       return { id: task.id, message: 'Task created' }
     }),
 
-  reorderTasks: authedProcedure
+  reorderTasks: approvedProcedure
     .input(
       z.object({
         projectId: z.number().int(),
@@ -940,7 +951,7 @@ export const projectsRouter = {
       return { success: true }
     }),
 
-  updateTask: authedProcedure
+  updateTask: approvedProcedure
     .input(
       z.object({
         projectId: z.number().int(),
@@ -1000,7 +1011,7 @@ export const projectsRouter = {
       return { message: 'Task updated' }
     }),
 
-  assignTask: authedProcedure
+  assignTask: approvedProcedure
     .input(
       z.object({
         projectId: z.number().int(),
@@ -1030,6 +1041,11 @@ export const projectsRouter = {
         where: { id: input.assigneeId, deletedAt: null },
       })
       if (!assignee) throw new ORPCError('BAD_REQUEST', { message: 'Volunteer not found' })
+      if (assignee.approvalStatus !== ApprovalStatus.approved) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'Cannot assign a task to a volunteer who is not yet approved',
+        })
+      }
 
       await prisma.workItem.update({
         where: { id: input.taskId },
@@ -1058,7 +1074,7 @@ export const projectsRouter = {
       return { message: 'Task assigned' }
     }),
 
-  deleteTask: authedProcedure
+  deleteTask: approvedProcedure
     .input(z.object({ projectId: z.number().int(), taskId: z.number().int() }))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer

--- a/server/routers/starterTasks.ts
+++ b/server/routers/starterTasks.ts
@@ -8,7 +8,7 @@ import {
   ReviewStarterTaskSchema,
 } from '@/lib/schemas'
 import { adminProcedure, authedProcedure, publicProcedure } from '../procedures'
-import { StarterTaskStatus, WorkItemType } from '@/generated/prisma/enums'
+import { ApprovalStatus, StarterTaskStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const starterTasksRouter = {
   list: adminProcedure
@@ -146,6 +146,16 @@ export const starterTasksRouter = {
         where: { id: input.id, type: WorkItemType.STARTER_TASK },
       })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
+
+      const assignee = await prisma.volunteer.findFirst({
+        where: { id: input.volunteerId, deletedAt: null },
+      })
+      if (!assignee) throw new ORPCError('BAD_REQUEST', { message: 'Volunteer not found' })
+      if (assignee.approvalStatus !== ApprovalStatus.approved) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'Cannot assign a task to a volunteer who is not yet approved',
+        })
+      }
 
       await prisma.workItem.update({
         where: { id: input.id },

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -36,6 +36,7 @@ export const volunteersRouter = {
       const where: Record<string, unknown> = {
         deletedAt: null,
         consentMakeProfileVisibleInDirectory: true,
+        approvalStatus: ApprovalStatus.approved,
         ...(input.skillIds && input.skillIds.length > 0
           ? { skills: { some: { skillId: { in: input.skillIds } } } }
           : {}),


### PR DESCRIPTION
## Summary
- Non-approved applicants could bypass the approval gate on several write paths: self-claiming an open task via `updateTask`, editing a project, messaging volunteers, and submitting local group suggestions were only checking auth, not `approvalStatus`.
- Added `approvedProcedure` in `server/procedures.ts` and applied it to `projects.create/update/expressInterest/createTask/reorderTasks/updateTask/assignTask/deleteTask`, `messages.send`, `localGroupSuggestions.create`.
- Backend now also rejects admins assigning a project/task/starter-task to a not-yet-approved volunteer (`projects.assign`, `projects.assignTask`, `starterTasks.assign` — the last had no check at all).
- `volunteers.list` now excludes unapproved volunteers, which fixes both the assign dropdowns (previously listed unapproved volunteers who'd then fail on submit) and the public volunteer directory.

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite — 142 passed / 6 skipped)
- [x] New `e2e/tests/21-approval-gate.spec.ts` covers: blocked propose/express-interest/self-claim-task/message/local-group-suggestion for unapproved volunteers, blocked admin-assign to unapproved volunteer (project/task/starter-task), and unapproved volunteers excluded from `volunteers.list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQAA85HZaaMjk12sx5xjbZ