### PR TITLE
Require at least one task when creating a project

### DIFF
--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -24,7 +24,6 @@ export default function AdminCreateProjectPage() {
           <ProjectForm
             onSubmitForm={(data) => createMutation.mutateAsync(data)}
             submitLabel="Create Project"
-            requireTasks
             onSuccess={(id) => router.push(`/projects/${id}`)}
             onCancel={() => router.back()}
           />

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -24,6 +24,7 @@ export default function AdminCreateProjectPage() {
           <ProjectForm
             onSubmitForm={(data) => createMutation.mutateAsync(data)}
             submitLabel="Create Project"
+            requireTasks
             onSuccess={(id) => router.push(`/projects/${id}`)}
             onCancel={() => router.back()}
           />

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -23,9 +23,9 @@ export default function TriagePage() {
   const { user, loading } = useRequireAdmin()
   const showToast = useToast()
   const queryClient = useQueryClient()
-  const [tab, setTab] = useState<'pending_review' | 'needs_discussion' | 'interests'>(
-    'pending_review',
-  )
+  const [tab, setTab] = useState<
+    'pending_review' | 'needs_discussion' | 'stale_in_progress' | 'interests'
+  >('pending_review')
 
   const {
     value: interestStatusFilter,
@@ -44,6 +44,11 @@ export default function TriagePage() {
 
   const { data: projects = [], isLoading: loadingProjects } = useQuery({
     ...orpc.admin.triage.list.queryOptions(),
+    enabled: !!user?.isAdmin,
+  })
+
+  const { data: staleProjects = [], isLoading: loadingStale } = useQuery({
+    ...orpc.admin.projects.staleInProgress.queryOptions(),
     enabled: !!user?.isAdmin,
   })
 
@@ -73,7 +78,9 @@ export default function TriagePage() {
     (p) => p.status === ProjectStatus.needs_discussion,
   )
   const pendingInterests = interests.filter((i) => i.status === InterestStatus.pending)
-  const visible = tab === 'pending_review' ? pending : discussion
+  const stale = staleProjects as unknown as CardProject[]
+  const visible =
+    tab === 'pending_review' ? pending : tab === 'needs_discussion' ? discussion : stale
 
   return (
     <>
@@ -103,6 +110,19 @@ export default function TriagePage() {
                   {discussion.length > 0 && (
                     <span className="bg-primary text-secondary-dark text-xs px-2 py-0.5 rounded-full ml-2">
                       {discussion.length}
+                    </span>
+                  )}
+                </>
+              ),
+            },
+            {
+              key: 'stale_in_progress',
+              label: (
+                <>
+                  {`No Open Tasks`}
+                  {stale.length > 0 && (
+                    <span className="bg-primary text-secondary-dark text-xs px-2 py-0.5 rounded-full ml-2">
+                      {stale.length}
                     </span>
                   )}
                 </>
@@ -253,10 +273,16 @@ export default function TriagePage() {
           </>
         ) : (
           <>
-            {loadingProjects ? (
+            {(tab === 'stale_in_progress' ? loadingStale : loadingProjects) ? (
               <div className="text-center py-10 text-text-light">Loading…</div>
             ) : visible.length === 0 ? (
-              <p>No projects awaiting {tab === 'pending_review' ? 'review' : 'discussion'}.</p>
+              <p>
+                {tab === 'pending_review'
+                  ? 'No projects awaiting review.'
+                  : tab === 'needs_discussion'
+                    ? 'No projects awaiting discussion.'
+                    : 'No in-progress projects with all tasks completed.'}
+              </p>
             ) : (
               <div className={CARD_GRID_CLASSES}>
                 {visible.map((p) => (

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -28,7 +28,6 @@ export default function SuggestPage() {
             onSubmitForm={(data) => createMutation.mutateAsync(data)}
             submitLabel="Submit Project Proposal"
             showReviewNotice
-            requireTasks
             onSuccess={() => {
               toast("Project submitted for review! We'll be in touch.", 'success')
               setTimeout(() => router.push('/dashboard#tab-proposed'), 2000)

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -44,7 +44,6 @@ interface ProjectFormProps {
   onSubmitForm: (data: ProjectCreateInput) => Promise<{ id: number }>
   submitLabel?: string
   showReviewNotice?: boolean
-  requireTasks?: boolean
   onSuccess: (id: number) => void
   onCancel?: () => void
 }
@@ -53,7 +52,6 @@ export default function ProjectForm({
   onSubmitForm,
   submitLabel = 'Submit',
   showReviewNotice = false,
-  requireTasks = false,
   onSuccess,
   onCancel,
 }: ProjectFormProps) {
@@ -105,7 +103,7 @@ export default function ProjectForm({
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const validTasks = tasks.filter((t) => t.title.trim())
-    if (requireTasks && !validTasks.length) {
+    if (!validTasks.length) {
       toast('At least one task with a title is required.', 'error')
       return
     }
@@ -354,10 +352,7 @@ export default function ProjectForm({
       </div>
 
       <div className="mb-5">
-        <label>
-          Initial Tasks{' '}
-          {!requireTasks && <span className="font-normal text-text-light">(optional)</span>}
-        </label>
+        <label>Initial Tasks</label>
         <p className="text-sm text-text-light mt-0 mb-2">
           Break the project into concrete tasks. This helps contributors understand the scope and
           gives them something to pick up.
@@ -365,10 +360,7 @@ export default function ProjectForm({
         {tasks.map((task, i) => (
           <div key={i} className="bg-brand-bg rounded-lg p-4 mb-3 border border-brand-border">
             <div className="mb-3">
-              <label
-                htmlFor={`task-title-${i}`}
-                className={`text-sm${requireTasks ? ' required' : ''}`}
-              >
+              <label htmlFor={`task-title-${i}`} className="text-sm required">
                 Task title
               </label>
               <input

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -68,6 +68,7 @@ export async function adminCreateProject(
 
   await adminPage.getByLabel('Project Title').fill(title)
   await adminPage.getByLabel('Description').fill(description)
+  await adminPage.getByLabel('Task title').first().fill('Initial task')
   await adminPage.getByRole('button', { name: 'Create Project' }).click()
 
   await adminPage.waitForURL(/\/projects\/\d+/, { timeout: 15_000 })

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -1,6 +1,7 @@
-import { test, expect, getAlert } from '../fixtures'
+import { test, expect, getAlert, readAdminToken, createApprovedVolunteer } from '../fixtures'
 import { goToDashboardNotifications } from '../actions/dashboard'
 import { fake } from '../fake'
+import { createApiClient } from '../client'
 import {
   proposeProject,
   adminCreateProject,
@@ -118,8 +119,8 @@ test.describe('Project Lifecycle', () => {
     const title = fake.projectTitle()
     await adminCreateProject(baseUrl, adminPage, title, 'Admin-created project description')
 
-    // Project starts in needs_tasks status
-    await expect(adminPage.getByLabel('project status')).toContainText('Needs Tasks', {
+    // Project starts in_progress since it must be created with at least one task
+    await expect(adminPage.getByLabel('project status')).toContainText('In Progress', {
       timeout: 10_000,
     })
 
@@ -199,4 +200,96 @@ test.describe('Project Lifecycle', () => {
   // way to verify this is via the admin API endpoint, which requires the volunteer's numeric ID.
   // Skip until endorsements become visible somewhere in the UI.
   test.skip('Required-skill endorsements are created for the project owner on a successful outcome', async () => {})
+})
+
+test.describe('Project Creation Requires At Least One Task', () => {
+  test('Suggesting a project without any task shows a validation error', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    await volunteer.page.goto(`${baseUrl}/suggest`)
+    await expect(
+      volunteer.page.getByRole('button', { name: 'Submit Project Proposal' }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    await volunteer.page.getByLabel('Project Title').fill(fake.projectTitle())
+    await volunteer.page.getByLabel('Description').fill('Proposal with no tasks')
+    await volunteer.page.getByRole('button', { name: 'Submit Project Proposal' }).click()
+
+    await expect(getAlert(volunteer.page)).toContainText(
+      'At least one task with a title is required.',
+      { timeout: 10_000 },
+    )
+    // Still on the form — submission was blocked client-side, no navigation happened
+    await expect(
+      volunteer.page.getByRole('button', { name: 'Submit Project Proposal' }),
+    ).toBeVisible()
+  })
+
+  test('Creating an org project without any task shows a validation error', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    await adminPage.goto(`${baseUrl}/admin/projects/new`)
+    await expect(
+      adminPage.getByRole('heading', { name: 'Create Organisation Project' }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    await adminPage.getByLabel('Project Title').fill(fake.projectTitle())
+    await adminPage.getByLabel('Description').fill('Org project with no tasks')
+    await adminPage.getByRole('button', { name: 'Create Project' }).click()
+
+    await expect(getAlert(adminPage)).toContainText('At least one task with a title is required.', {
+      timeout: 10_000,
+    })
+  })
+
+  test('The API rejects a project proposal with no tasks', async ({ baseUrl }) => {
+    const volunteer = await createApprovedVolunteer(baseUrl)
+    const api = createApiClient(baseUrl, volunteer.token)
+
+    const result = await api.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Proposal with no tasks, sent directly to the API',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: true,
+        isSeekingOwner: true,
+        tasks: [],
+      },
+    })
+
+    expect(result.status).toBe(400)
+    expect(JSON.stringify(result.body)).toContain('At least one task is required')
+  })
+
+  test('The API rejects an org project with no tasks', async ({ baseUrl }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+
+    const result = await adminApi.admin.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Org project with no tasks, sent directly to the API',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: false,
+        isSeekingOwner: false,
+        tasks: [],
+      },
+    })
+
+    expect(result.status).toBe(400)
+    expect(JSON.stringify(result.body)).toContain('At least one task is required')
+  })
 })

--- a/e2e/tests/08-project-tasks.spec.ts
+++ b/e2e/tests/08-project-tasks.spec.ts
@@ -5,6 +5,7 @@ import {
   readAdminToken,
   confirmVolunteerEmail,
   approveVolunteer,
+  createApprovedVolunteer,
 } from '../fixtures'
 import { fake } from '../fake'
 import { proposeProject, adminCreateProject, adminApproveProject } from '../actions/projects'
@@ -24,17 +25,58 @@ async function setupInProgressProject(
 }
 
 test.describe('Project Tasks', () => {
+  // A project can only reach `needs_tasks` after creation (every project now requires at
+  // least one task up front) — e.g. by accepting a `want_to_own` interest once its only
+  // task has been removed. Reproduce that path via the API, then verify the UI promotes
+  // the project back to In Progress as soon as a new task is added.
   test('Adding a task to a needs_tasks project auto-promotes it to In Progress', async ({
     adminPage,
     baseUrl,
   }) => {
-    await adminCreateProject(
-      baseUrl,
-      adminPage,
-      fake.projectTitle(),
-      'Project for auto-promotion test',
-    )
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
 
+    const created = await adminApi.admin.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Project for auto-promotion test',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: false,
+        isSeekingOwner: true,
+        tasks: [{ title: 'Initial task' }],
+      },
+    })
+    expect(created.status).toBe(200)
+    const projectId = (created.body as { id: number }).id
+
+    const detail = await adminApi.projects.getById({ body: { id: projectId } })
+    const taskId = (detail.body as { tasks: { id: number }[] }).tasks[0].id
+    const deleted = await adminApi.projects.deleteTask({ body: { projectId, taskId } })
+    expect(deleted.status).toBe(200)
+
+    const owner = await createApprovedVolunteer(baseUrl)
+    const ownerApi = createApiClient(baseUrl, owner.token)
+    const interest = await ownerApi.projects.expressInterest({
+      body: { projectId, interestType: 'want_to_own' },
+    })
+    expect(interest.status).toBe(200)
+
+    const withInterest = await adminApi.projects.getById({ body: { id: projectId } })
+    const interestId = (
+      withInterest.body as { interests: { id: number; volunteerId: number }[] }
+    ).interests.find((i) => i.volunteerId === owner.id)!.id
+    const accepted = await adminApi.projects.respondToInterest({
+      body: { projectId, interestId, status: 'accepted' },
+    })
+    expect(accepted.status).toBe(200)
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
     await expect(adminPage.getByLabel('project status')).toContainText('Needs Tasks', {
       timeout: 10_000,
     })
@@ -111,6 +153,7 @@ test.describe('Project Tasks', () => {
         localGroup: null,
         isSeekingHelp: false,
         isSeekingOwner: false,
+        tasks: [{ title: 'Setup task' }],
       },
     })
     expect(projectCreated.status).toBe(200)

--- a/e2e/tests/20-task-management.spec.ts
+++ b/e2e/tests/20-task-management.spec.ts
@@ -23,9 +23,18 @@ async function createAdminProject(
       localGroup: null,
       isSeekingHelp: opts?.isSeekingHelp ?? false,
       isSeekingOwner: false,
+      tasks: [{ title: 'Seed task' }],
     },
   })
-  return (created.body as { id: number }).id
+  const projectId = (created.body as { id: number }).id
+
+  // Remove the seed task used only to satisfy the "at least one task" requirement at
+  // creation — callers add their own tasks afterward and assert on the exact task list.
+  const detail = await adminApi.projects.getById({ body: { id: projectId } })
+  const seedTaskId = (detail.body as { tasks: { id: number }[] }).tasks[0].id
+  await adminApi.projects.deleteTask({ body: { projectId, taskId: seedTaskId } })
+
+  return projectId
 }
 
 async function signupApprovedVolunteer(
@@ -61,22 +70,7 @@ test.describe('Task Reordering', () => {
     const adminToken = readAdminToken(baseUrl)
     const adminApi = createApiClient(baseUrl, adminToken)
 
-    const projectCreated = await adminApi.admin.projects.create({
-      body: {
-        title: fake.projectTitle(),
-        description: 'Drag handle visibility test',
-        projectType: null,
-        estimatedDuration: null,
-        timeCommitmentHoursPerWeek: null,
-        urgency: 'medium',
-        collaborationLink: null,
-        country: null,
-        localGroup: null,
-        isSeekingHelp: false,
-        isSeekingOwner: false,
-      },
-    })
-    const projectId = (projectCreated.body as { id: number }).id
+    const projectId = await createAdminProject(adminApi, 'Drag handle visibility test')
 
     await adminApi.projects.createTask({ body: { projectId, title: 'Task A' } })
     await adminApi.projects.createTask({ body: { projectId, title: 'Task B' } })
@@ -94,22 +88,7 @@ test.describe('Task Reordering', () => {
     const adminToken = readAdminToken(baseUrl)
     const adminApi = createApiClient(baseUrl, adminToken)
 
-    const projectCreated = await adminApi.admin.projects.create({
-      body: {
-        title: fake.projectTitle(),
-        description: 'Reorder persistence test',
-        projectType: null,
-        estimatedDuration: null,
-        timeCommitmentHoursPerWeek: null,
-        urgency: 'medium',
-        collaborationLink: null,
-        country: null,
-        localGroup: null,
-        isSeekingHelp: false,
-        isSeekingOwner: false,
-      },
-    })
-    const projectId = (projectCreated.body as { id: number }).id
+    const projectId = await createAdminProject(adminApi, 'Reorder persistence test')
 
     const taskA = await adminApi.projects.createTask({ body: { projectId, title: 'First' } })
     const taskB = await adminApi.projects.createTask({ body: { projectId, title: 'Second' } })
@@ -167,22 +146,7 @@ test.describe('Task Reordering', () => {
     const adminToken = readAdminToken(baseUrl)
     const adminApi = createApiClient(baseUrl, adminToken)
 
-    const projectCreated = await adminApi.admin.projects.create({
-      body: {
-        title: fake.projectTitle(),
-        description: 'Reorder permission test',
-        projectType: null,
-        estimatedDuration: null,
-        timeCommitmentHoursPerWeek: null,
-        urgency: 'medium',
-        collaborationLink: null,
-        country: null,
-        localGroup: null,
-        isSeekingHelp: false,
-        isSeekingOwner: false,
-      },
-    })
-    const projectId = (projectCreated.body as { id: number }).id
+    const projectId = await createAdminProject(adminApi, 'Reorder permission test')
     const taskCreated = await adminApi.projects.createTask({
       body: { projectId, title: 'Solo task' },
     })

--- a/e2e/tests/21-approval-gate.spec.ts
+++ b/e2e/tests/21-approval-gate.spec.ts
@@ -21,7 +21,7 @@ async function createAdminProject(
       localGroup: null,
       isSeekingHelp: opts?.isSeekingHelp ?? true,
       isSeekingOwner: false,
-      tasks: opts?.tasks ?? [],
+      tasks: opts?.tasks ?? [{ title: 'Seed task' }],
     },
   })
   return (created.body as { id: number }).id

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -11,6 +11,11 @@ export const adminProjectsRouter = {
   create: adminProcedure.input(AdminCreateProjectSchema).handler(async ({ input, context }) => {
     const admin = context.volunteer
     const { wantToOwn, skillIds, skillRequiredMap, tasks } = input
+    if (tasks.length === 0) {
+      throw new ORPCError('BAD_REQUEST', {
+        message: 'At least one task is required to create a project',
+      })
+    }
 
     const project = await prisma.$transaction(async (tx) => {
       const newProject = await tx.workItem.create({
@@ -18,7 +23,7 @@ export const adminProjectsRouter = {
           type: WorkItemType.PROJECT,
           title: input.title,
           description: input.description,
-          status: tasks.length > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks,
+          status: ProjectStatus.in_progress,
           assigneeId: wantToOwn ? admin.id : null,
           creatorId: admin.id,
           isOrgProposed: true,
@@ -44,18 +49,16 @@ export const adminProjectsRouter = {
         })
       }
 
-      if (tasks.length > 0) {
-        await tx.workItem.createMany({
-          data: tasks.map((t) => ({
-            type: WorkItemType.TASK,
-            status: TaskStatus.open,
-            parentId: newProject.id,
-            title: t.title,
-            description: t.description ?? null,
-            creatorId: admin.id,
-          })),
-        })
-      }
+      await tx.workItem.createMany({
+        data: tasks.map((t) => ({
+          type: WorkItemType.TASK,
+          status: TaskStatus.open,
+          parentId: newProject.id,
+          title: t.title,
+          description: t.description ?? null,
+          creatorId: admin.id,
+        })),
+      })
 
       return newProject
     })

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -253,4 +253,22 @@ export const adminProjectsRouter = {
     })
     return projects.map((p) => withProjectExtras(p as EnrichedProject))
   }),
+
+  staleInProgress: adminProcedure.handler(async () => {
+    const projects = await prisma.workItem.findMany({
+      where: {
+        type: WorkItemType.PROJECT,
+        status: ProjectStatus.in_progress,
+        children: {
+          none: {
+            type: WorkItemType.TASK,
+            status: { not: TaskStatus.completed },
+          },
+        },
+      },
+      include: projectInclude,
+      orderBy: { updatedAt: 'asc' },
+    })
+    return projects.map((p) => withProjectExtras(p as EnrichedProject))
+  }),
 }


### PR DESCRIPTION
## Summary

- Project creation now requires at least one task on **both** paths: volunteer proposals (`Suggest a Project`) already enforced this server-side, but admin-created organisation projects did not and could start in a `needs_tasks` status. Admin org projects now require ≥1 task too, and always start `in_progress` — `needs_tasks` is no longer reachable at creation time on either path.
- The "at least one task" requirement is baked directly into `ProjectForm` (required-field styling + client-side validation) instead of being gated behind a `requireTasks` prop that every caller had to remember to pass — both call sites always needed it, so the prop was removed.
- Task completion never re-evaluates the parent project's status, so an `in_progress` project can end up with zero open tasks (last task completed or deleted) and just sit there. Added `admin.projects.staleInProgress` and a "No Open Tasks" tab on the triage page so admins can find these and close them out or add more work.

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` all pass
- [x] Full e2e suite (`npm test`) passes: 146 passed, 6 pre-existing skips, 0 failures
- [x] New e2e coverage added for the gate itself — UI and direct-API level, for both the volunteer and admin creation flows (`e2e/tests/06-project-lifecycle.spec.ts`)
- [x] Updated existing e2e specs/helpers that relied on admin projects being creatable with zero tasks (`e2e/tests/08-project-tasks.spec.ts`, `e2e/tests/20-task-management.spec.ts`, `e2e/tests/21-approval-gate.spec.ts`, `e2e/actions/projects.ts`)
- [ ] Manual check of the new "No Open Tasks" triage tab in the browser