### PR TITLE
Fix skill-match project alerts (fire on project going live)

### DIFF
--- a/lib/project-match.ts
+++ b/lib/project-match.ts
@@ -1,10 +1,15 @@
 import { prisma } from './prisma'
 import { sendDigestEmail, isEmailConfigured } from './email'
+import { calculateMatchScore, matchGradeLabel } from './matching'
 import { WorkItemType } from '@/generated/prisma/enums'
 
+// Grades below this ('Partial match' and no match) aren't worth interrupting someone for.
+const MIN_NOTIFIABLE_GRADE = 'Good match'
+const NOTIFIABLE_GRADES = new Set(['Excellent match', 'Great match', MIN_NOTIFIABLE_GRADE])
+
 // Emails volunteers who asked for immediate skill-match alerts (emailDigest: 'match')
-// as soon as a project they're a fit for goes live — either an admin approves a
-// volunteer-proposed project, or an admin publishes an org-proposed one directly.
+// as soon as a project they're at least a good fit for goes live — either an admin
+// approves a volunteer-proposed project, or an admin publishes an org-proposed one directly.
 export async function notifyMatchingVolunteers(projectId: number): Promise<void> {
   if (!isEmailConfigured()) return
 
@@ -14,6 +19,7 @@ export async function notifyMatchingVolunteers(projectId: number): Promise<void>
   })
   if (!project) return
 
+  const projectSkills = project.skills.map((ps) => ({ id: ps.skillId, isRequired: ps.isRequired }))
   const requiredSkillIds = project.skills.filter((ps) => ps.isRequired).map((ps) => ps.skillId)
   if (!requiredSkillIds.length) return
 
@@ -33,8 +39,10 @@ export async function notifyMatchingVolunteers(projectId: number): Promise<void>
   await Promise.all(
     volunteers.map((vol) => {
       const volSkillIds = new Set(vol.skills.map((vs) => vs.skillId))
-      const matched = requiredSkillIds.filter((id) => volSkillIds.has(id)).length
-      const match_percent = Math.round((matched / requiredSkillIds.length) * 100)
+      const score = calculateMatchScore(volSkillIds, projectSkills)
+      const grade = matchGradeLabel(score.matchedRequiredCount)
+      if (!grade || !NOTIFIABLE_GRADES.has(grade)) return
+
       return sendDigestEmail({
         to: vol.email!,
         name: vol.name,
@@ -44,7 +52,7 @@ export async function notifyMatchingVolunteers(projectId: number): Promise<void>
             title: project.title,
             description: project.description ?? '',
             skill_names: skillNames,
-            match_percent,
+            match_percent: score.requiredMatchPercent,
           },
         ],
         isMatch: true,

--- a/lib/project-match.ts
+++ b/lib/project-match.ts
@@ -1,0 +1,54 @@
+import { prisma } from './prisma'
+import { sendDigestEmail, isEmailConfigured } from './email'
+import { WorkItemType } from '@/generated/prisma/enums'
+
+// Emails volunteers who asked for immediate skill-match alerts (emailDigest: 'match')
+// as soon as a project they're a fit for goes live — either an admin approves a
+// volunteer-proposed project, or an admin publishes an org-proposed one directly.
+export async function notifyMatchingVolunteers(projectId: number): Promise<void> {
+  if (!isEmailConfigured()) return
+
+  const project = await prisma.workItem.findFirst({
+    where: { id: projectId, type: WorkItemType.PROJECT },
+    include: { skills: { include: { skill: true } } },
+  })
+  if (!project) return
+
+  const requiredSkillIds = project.skills.filter((ps) => ps.isRequired).map((ps) => ps.skillId)
+  if (!requiredSkillIds.length) return
+
+  const volunteers = await prisma.volunteer.findMany({
+    where: {
+      emailDigest: 'match',
+      email: { not: null },
+      deletedAt: null,
+      skills: { some: { skillId: { in: requiredSkillIds } } },
+    },
+    include: { skills: true },
+  })
+  if (!volunteers.length) return
+
+  const skillNames = project.skills.map((ps) => ps.skill.name)
+
+  await Promise.all(
+    volunteers.map((vol) => {
+      const volSkillIds = new Set(vol.skills.map((vs) => vs.skillId))
+      const matched = requiredSkillIds.filter((id) => volSkillIds.has(id)).length
+      const match_percent = Math.round((matched / requiredSkillIds.length) * 100)
+      return sendDigestEmail({
+        to: vol.email!,
+        name: vol.name,
+        projects: [
+          {
+            id: project.id,
+            title: project.title,
+            description: project.description ?? '',
+            skill_names: skillNames,
+            match_percent,
+          },
+        ],
+        isMatch: true,
+      }).catch((e) => console.error('[MATCH NOTIFY ERROR]', e))
+    }),
+  )
+}

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -3,6 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
 import { notifyUser } from '@/lib/notify'
+import { notifyMatchingVolunteers } from '@/lib/project-match'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
 import { ProjectStatus, TaskStatus, WorkItemType } from '@/generated/prisma/enums'
@@ -62,6 +63,8 @@ export const adminProjectsRouter = {
 
       return newProject
     })
+
+    notifyMatchingVolunteers(project.id).catch((e) => console.error('[MATCH NOTIFY]', e))
 
     return { id: project.id, message: 'Org project created' }
   }),
@@ -127,6 +130,8 @@ export const adminProjectsRouter = {
             },
           )
         }
+
+        notifyMatchingVolunteers(input.id).catch((e) => console.error('[MATCH NOTIFY]', e))
       } else {
         await prisma.workItem.update({
           where: { id: input.id },


### PR DESCRIPTION
## Summary
- Volunteers can opt into `email_digest: 'match'` ("email me when a project matches my skills"), but no job ever read that value — the alert never fired.
- Adds `lib/project-match.ts:notifyMatchingVolunteers()`, called the moment a project goes live: on org-project `create`, and on `review` when an admin sets `status: 'approved'`.
- Uses the same `calculateMatchScore` / `matchGradeLabel` from `lib/matching.ts` that powers the project-list match badges, and only emails a volunteer when the project is at least a **Good match** for them (i.e. ≥2 required skills matched) — partial matches don't trigger an email.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] `npm test` — CI will run the e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7LqHwh4oR1wbyKgRbhTiF