### PR TITLE
Merge remote-tracking branch 'origin/main' into claude/project-visibility-approval-38khhb

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -160,8 +160,8 @@ export default function DashboardPage() {
         {user.approvalStatus === ApprovalStatus.pending && (
           <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-yellow-100 text-yellow-800 border border-yellow-300 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-800">
             <span>
-              Your account is pending approval. You can browse the platform, but some actions are
-              restricted until an admin reviews your application.
+              Your account is pending approval. You&apos;ll be able to browse and join projects once
+              an admin reviews your application.
             </span>
           </div>
         )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRequireAuth } from '@/lib/hooks/auth'
+import { useRequireApproved } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
@@ -45,7 +45,7 @@ const SORT_OPTIONS = [
 ] as const
 
 export default function ProjectsPage() {
-  const { user, loading } = useRequireAuth()
+  const { user, loading } = useRequireApproved()
   const userSkillIds = new Set(user?.skills?.map((s) => s.id) ?? [])
   const [search, setSearch] = useState('')
   const { value: statusFilter, onChange: setStatusFilter } = useFilterOptions(STATUS_OPTIONS, '')

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { use, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useRequireAuth } from '@/lib/hooks/auth'
+import { useRequireApproved } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -212,7 +212,7 @@ function SortableTaskItem({
 export default function ProjectDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = use(params)
   const router = useRouter()
-  const { user, loading } = useRequireAuth()
+  const { user, loading } = useRequireApproved()
   const queryClient = useQueryClient()
 
   const showToast = useToast()

--- a/e2e/tests/10-project-discovery.spec.ts
+++ b/e2e/tests/10-project-discovery.spec.ts
@@ -1,13 +1,78 @@
-import { test, expect } from '../fixtures'
+import type { Browser } from '@playwright/test'
+import { test, expect, createPendingVolunteer } from '../fixtures'
 import { adminCreateProject } from '../actions/projects'
 import { fake } from '../fake'
 
-// Both the project list (index.html) and individual project pages redirect unauthenticated
-// visitors to /login via `if (!currentUser) { window.location.href = ... }`.
-// There is no public / unauthenticated view of projects.
+// Both the project list and individual project pages redirect unauthenticated
+// visitors to /login via `useRequireApproved`. There is no public / unauthenticated
+// view of projects — the underlying oRPC procedures require an approved, logged-in
+// volunteer too.
 test.describe('Unauthenticated Project Access', () => {
-  test.skip('Visitor browses the project list unauthenticated', async () => {})
-  test.skip('Visitor views a project detail page unauthenticated', async () => {})
+  test('Visitor browses the project list unauthenticated', async ({ page, baseUrl }) => {
+    await page.goto(`${baseUrl}/`)
+    await page.waitForURL(`${baseUrl}/login**`, { timeout: 10_000 })
+  })
+
+  test('Visitor views a project detail page unauthenticated', async ({
+    page,
+    adminPage,
+    baseUrl,
+  }) => {
+    const projectId = await adminCreateProject(
+      baseUrl,
+      adminPage,
+      fake.projectTitle(),
+      'A project for the unauthenticated access test',
+    )
+
+    await page.goto(`${baseUrl}/projects/${projectId}`)
+    await page.waitForURL(`${baseUrl}/login**`, { timeout: 10_000 })
+  })
+})
+
+// Unapproved volunteers can log in and reach their dashboard, but browsing projects
+// is gated behind approval — `useRequireApproved` bounces them back to /dashboard.
+test.describe('Pending Volunteer Project Access', () => {
+  async function pendingVolunteerPage(browser: Browser, baseUrl: string) {
+    const pending = await createPendingVolunteer(baseUrl)
+    const context = await browser.newContext()
+    await context.addInitScript((token: string) => {
+      localStorage.setItem('authToken', token)
+    }, pending.token)
+    const page = await context.newPage()
+    return { page, context }
+  }
+
+  test('Pending volunteer is redirected away from the project list', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const { page, context } = await pendingVolunteerPage(browser, baseUrl)
+
+    await page.goto(`${baseUrl}/`)
+    await page.waitForURL(`${baseUrl}/dashboard**`, { timeout: 10_000 })
+
+    await context.close()
+  })
+
+  test('Pending volunteer is redirected away from a project detail page', async ({
+    browser,
+    adminPage,
+    baseUrl,
+  }) => {
+    const projectId = await adminCreateProject(
+      baseUrl,
+      adminPage,
+      fake.projectTitle(),
+      'A project for the pending-volunteer access test',
+    )
+    const { page, context } = await pendingVolunteerPage(browser, baseUrl)
+
+    await page.goto(`${baseUrl}/projects/${projectId}`)
+    await page.waitForURL(`${baseUrl}/dashboard**`, { timeout: 10_000 })
+
+    await context.close()
+  })
 })
 
 test.describe('Project Discovery', () => {

--- a/lib/hooks/auth.ts
+++ b/lib/hooks/auth.ts
@@ -3,12 +3,30 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/lib/auth-context'
+import { ApprovalStatus } from '@/generated/prisma/enums'
 
 export function useRequireAuth() {
   const router = useRouter()
   const auth = useAuth()
   useEffect(() => {
     if (!auth.loading && !auth.user) router.replace('/login')
+  }, [auth.user, auth.loading, router])
+  return auth
+}
+
+export function useRequireApproved() {
+  const router = useRouter()
+  const auth = useAuth()
+  useEffect(() => {
+    if (!auth.loading && !auth.user) router.replace('/login')
+    if (
+      !auth.loading &&
+      auth.user &&
+      auth.user.approvalStatus !== ApprovalStatus.approved &&
+      !auth.user.isAdmin
+    ) {
+      router.replace('/dashboard')
+    }
   }, [auth.user, auth.loading, router])
   return auth
 }

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -11,7 +11,7 @@ import {
   CreateProjectTaskSchema,
   UpdateProjectTaskSchema,
 } from '@/lib/schemas'
-import { publicProcedure, authedProcedure, approvedProcedure, adminProcedure } from '../procedures'
+import { authedProcedure, approvedProcedure, adminProcedure } from '../procedures'
 import {
   ApprovalStatus,
   InterestStatus,
@@ -48,7 +48,7 @@ const TASK_ORDER: Record<string, number> = {
 }
 
 export const projectsRouter = {
-  list: publicProcedure
+  list: approvedProcedure
     .input(
       z.object({
         status: z.string().optional(),
@@ -70,24 +70,17 @@ export const projectsRouter = {
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
 
-      if (volunteer && !volunteer.emailConfirmed && !volunteer.isAdmin) {
+      if (!volunteer.emailConfirmed && !volunteer.isAdmin) {
         throw new ORPCError('FORBIDDEN', {
           message: 'Please confirm your email address to browse projects',
         })
       }
 
-      const isPending = Boolean(
-        volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
-      )
-
-      let volunteerSkillIds: Set<number> | undefined
-      if (volunteer) {
-        const v = await prisma.volunteer.findUnique({
-          where: { id: volunteer.id },
-          select: { skills: { select: { skillId: true } } },
-        })
-        volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
-      }
+      const v = await prisma.volunteer.findUnique({
+        where: { id: volunteer.id },
+        select: { skills: { select: { skillId: true } } },
+      })
+      const volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
 
       const conditions: Prisma.Sql[] = [Prisma.sql`type = ${WorkItemType.PROJECT}`]
 
@@ -163,19 +156,7 @@ export const projectsRouter = {
       const projects = ids
         .map((id) => projectMap.get(id))
         .filter((p): p is NonNullable<typeof p> => p !== undefined)
-        .map((p) => {
-          const serialized = withProjectExtras(p as EnrichedProject, volunteerSkillIds)
-          if (isPending) {
-            return {
-              ...serialized,
-              owner: null,
-              ownerId: null,
-              proposedBy: null,
-              proposedById: null,
-            }
-          }
-          return serialized
-        })
+        .map((p) => withProjectExtras(p as EnrichedProject, volunteerSkillIds))
 
       if (input.sortBy === 'match' && volunteerSkillIds && volunteerSkillIds.size > 0) {
         projects.sort((a, b) => (b.match?.overallScore ?? 0) - (a.match?.overallScore ?? 0))
@@ -255,13 +236,10 @@ export const projectsRouter = {
     return { id: project.id, message: 'Project submitted for review' }
   }),
 
-  getById: publicProcedure
+  getById: approvedProcedure
     .input(z.object({ id: z.number().int() }))
     .handler(async ({ input, context }) => {
       const volunteer = context.volunteer
-      const isPending = Boolean(
-        volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
-      )
 
       const project = await prisma.workItem.findFirst({
         where: { id: input.id, type: WorkItemType.PROJECT },
@@ -275,20 +253,16 @@ export const projectsRouter = {
         ProjectStatus.needs_discussion,
       ]
       if (hiddenStatuses.includes(project.status)) {
-        if (!volunteer) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
         const isCreator = project.creatorId === volunteer.id
         if (!isCreator && !volunteer.isAdmin)
           throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
       }
 
-      let volunteerSkillIds: Set<number> | undefined
-      if (volunteer) {
-        const v = await prisma.volunteer.findUnique({
-          where: { id: volunteer.id },
-          select: { skills: { select: { skillId: true } } },
-        })
-        volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
-      }
+      const v = await prisma.volunteer.findUnique({
+        where: { id: volunteer.id },
+        select: { skills: { select: { skillId: true } } },
+      })
+      const volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
 
       const base = withProjectExtras(project as EnrichedProject, volunteerSkillIds)
 
@@ -313,10 +287,10 @@ export const projectsRouter = {
         projectId: t.parentId,
         title: t.title,
         description: t.description,
-        assignedToId: isPending ? null : t.assigneeId,
-        assignedToName: isPending ? null : (t.assignee?.name ?? null),
-        createdById: isPending ? null : t.creatorId,
-        createdByName: isPending ? null : (t.creator?.name ?? null),
+        assignedToId: t.assigneeId,
+        assignedToName: t.assignee?.name ?? null,
+        createdById: t.creatorId,
+        createdByName: t.creator?.name ?? null,
         status: t.status,
         sortOrder: t.sortOrder,
         estimatedHours: t.estimatedHours,
@@ -347,84 +321,67 @@ export const projectsRouter = {
             }>
           }>
         | undefined
-      let myInterest:
-        | {
-            id: number
-            volunteerId: number
-            projectId: number
-            interestType: string
-            message: string | null
-            status: string
-            responseMessage: string | null
-            createdAt: Date | null
-            respondedAt: Date | null
-          }
-        | null
-        | undefined
 
-      if (volunteer) {
-        const isAssignee = project.assigneeId === volunteer.id
-        if (isAssignee || volunteer.isAdmin) {
-          const rawInterests = await prisma.workItemInterest.findMany({
-            where: { workItemId: input.id },
-            include: {
-              volunteer: {
-                select: {
-                  id: true,
-                  name: true,
-                  bio: true,
-                  skills: { include: { skill: { include: { category: true } } } },
-                },
+      const isAssignee = project.assigneeId === volunteer.id
+      if (isAssignee || volunteer.isAdmin) {
+        const rawInterests = await prisma.workItemInterest.findMany({
+          where: { workItemId: input.id },
+          include: {
+            volunteer: {
+              select: {
+                id: true,
+                name: true,
+                bio: true,
+                skills: { include: { skill: { include: { category: true } } } },
               },
             },
-            orderBy: { createdAt: 'desc' },
-          })
-          interests = rawInterests.map((i) => ({
-            id: i.id,
-            volunteerId: i.volunteerId,
-            projectId: i.workItemId,
-            interestType: i.interestType,
-            message: i.message,
-            status: i.status,
-            responseMessage: i.responseMessage,
-            createdAt: i.createdAt,
-            respondedAt: i.respondedAt,
-            volunteerName: i.volunteer.name,
-            volunteerBio: i.volunteer.bio,
-            volunteerSkills: i.volunteer.skills.map((vs) => ({
-              id: vs.skill.id,
-              name: vs.skill.name,
-              categoryName: vs.skill.category.name,
-              proficiencyLevel: vs.proficiencyLevel,
-            })),
-          }))
-        }
-
-        const rawMyInterest = await prisma.workItemInterest.findFirst({
-          where: {
-            workItemId: input.id,
-            volunteerId: volunteer.id,
-            status: { not: InterestStatus.withdrawn },
           },
+          orderBy: { createdAt: 'desc' },
         })
-        myInterest = rawMyInterest
-          ? {
-              id: rawMyInterest.id,
-              volunteerId: rawMyInterest.volunteerId,
-              projectId: rawMyInterest.workItemId,
-              interestType: rawMyInterest.interestType,
-              message: rawMyInterest.message,
-              status: rawMyInterest.status,
-              responseMessage: rawMyInterest.responseMessage,
-              createdAt: rawMyInterest.createdAt,
-              respondedAt: rawMyInterest.respondedAt,
-            }
-          : null
+        interests = rawInterests.map((i) => ({
+          id: i.id,
+          volunteerId: i.volunteerId,
+          projectId: i.workItemId,
+          interestType: i.interestType,
+          message: i.message,
+          status: i.status,
+          responseMessage: i.responseMessage,
+          createdAt: i.createdAt,
+          respondedAt: i.respondedAt,
+          volunteerName: i.volunteer.name,
+          volunteerBio: i.volunteer.bio,
+          volunteerSkills: i.volunteer.skills.map((vs) => ({
+            id: vs.skill.id,
+            name: vs.skill.name,
+            categoryName: vs.skill.category.name,
+            proficiencyLevel: vs.proficiencyLevel,
+          })),
+        }))
       }
+
+      const rawMyInterest = await prisma.workItemInterest.findFirst({
+        where: {
+          workItemId: input.id,
+          volunteerId: volunteer.id,
+          status: { not: InterestStatus.withdrawn },
+        },
+      })
+      const myInterest = rawMyInterest
+        ? {
+            id: rawMyInterest.id,
+            volunteerId: rawMyInterest.volunteerId,
+            projectId: rawMyInterest.workItemId,
+            interestType: rawMyInterest.interestType,
+            message: rawMyInterest.message,
+            status: rawMyInterest.status,
+            responseMessage: rawMyInterest.responseMessage,
+            createdAt: rawMyInterest.createdAt,
+            respondedAt: rawMyInterest.respondedAt,
+          }
+        : null
 
       return {
         ...base,
-        ...(isPending && { owner: null, ownerId: null, proposedBy: null, proposedById: null }),
         tasks: mappedTasks,
         interests,
         myInterest,
@@ -831,14 +788,9 @@ export const projectsRouter = {
       return { message: 'Volunteer assigned to project' }
     }),
 
-  listTasks: publicProcedure
+  listTasks: approvedProcedure
     .input(z.object({ projectId: z.number().int() }))
-    .handler(async ({ input, context }) => {
-      const volunteer = context.volunteer
-      const isPending = Boolean(
-        volunteer && volunteer.approvalStatus !== ApprovalStatus.approved && !volunteer.isAdmin,
-      )
-
+    .handler(async ({ input }) => {
       const tasks = await prisma.workItem.findMany({
         where: { parentId: input.projectId, type: WorkItemType.TASK },
         include: {
@@ -860,10 +812,10 @@ export const projectsRouter = {
         projectId: t.parentId,
         title: t.title,
         description: t.description,
-        assignedToId: isPending ? null : t.assigneeId,
-        assignedToName: isPending ? null : (t.assignee?.name ?? null),
-        createdById: isPending ? null : t.creatorId,
-        createdByName: isPending ? null : (t.creator?.name ?? null),
+        assignedToId: t.assigneeId,
+        assignedToName: t.assignee?.name ?? null,
+        createdById: t.creatorId,
+        createdByName: t.creator?.name ?? null,
         status: t.status,
         sortOrder: t.sortOrder,
         estimatedHours: t.estimatedHours,


### PR DESCRIPTION
## Summary
- Restrict project browsing to approved volunteers: `projects.list`, `projects.getById`, and `projects.listTasks` move from `publicProcedure` to `approvedProcedure`, closing a gap where anyone (even without a session) could call these endpoints directly and see full project data, including owner/assignee details that were previously only masked (not blocked) for pending volunteers.
- Add a `useRequireApproved` hook (`lib/hooks/auth.ts`) and wire it into the project list (`app/page.tsx`) and project detail (`app/projects/[id]/page.tsx`) pages, so logged-out visitors are redirected to `/login` and pending/rejected volunteers are redirected to `/dashboard`.
- Update the dashboard's pending-approval banner copy, since "you can browse the platform" is no longer accurate.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Playwright e2e: implemented the previously-skipped "unauthenticated project access" tests and added new "pending volunteer project access" tests in `e2e/tests/10-project-discovery.spec.ts`; ran project discovery, approval-gate, task, interest, and dashboard suites locally (40 tests, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
