### PR TITLE
fix: set Railway drainingSeconds to stop false crash alerts on deploy

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -6,6 +6,10 @@ buildCommand = "npm run build:railway"
 startCommand = "npm run migrate && exec npx next start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
+# Old container gets 0s by default between SIGTERM and SIGKILL, so it's
+# force-killed before it can exit(0) and gets marked CRASHED (false alert
+# email) on every rolling deploy. Give it time to shut down cleanly.
+drainingSeconds = 10
 
 [deploy.healthcheck]
 path = "/api/health"


### PR DESCRIPTION
Railway gives the old container 0 seconds by default between SIGTERM
and SIGKILL when a new deployment goes live. It gets force-killed
before it can exit cleanly, so Railway marks it CRASHED and sends an
alert email even though the new deployment is healthy. Setting
drainingSeconds gives the outgoing container time to shut down before
the SIGKILL lands.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TqhW6AhiEriP7nDAEithdw