### PR TITLE
Add a public landing page at /

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,7 +35,7 @@ const sairaCondensed = Saira_Condensed({
 export const metadata: Metadata = {
   title: {
     template: 'Catalyse | %s',
-    default: 'Catalyse | All Projects',
+    default: 'Catalyse | PauseAI UK Volunteer Platform',
   },
   description: 'PauseAI UK volunteer platform',
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,10 +127,11 @@ export default async function LandingPage() {
       <section className="border-b border-brand-border bg-surface">
         <div className="container py-14 md:py-20">
           <div className="max-w-3xl mx-auto md:text-center">
-            <p className="font-heading text-sm font-bold uppercase tracking-widest text-primary-dark mb-3">
-              PauseAI UK
-            </p>
-            <h1 className="text-3xl md:text-5xl">Find the work that needs you</h1>
+            {/*
+              No size utilities here: globals.css styles `h1` outside a cascade
+              layer, so `text-*` classes on a heading are silently ignored.
+            */}
+            <h1>Find the work that needs you</h1>
             <p className="text-lg text-text-light mb-8">
               Catalyse is the volunteer platform for PauseAI UK. It connects the people who want to
               help with the projects that need them, matching what you can do to what the movement
@@ -273,8 +274,8 @@ export default async function LandingPage() {
             <li>
               Catalyse is for coordinating work. For events, the newsletter and the wider community,
               start at{' '}
-              <a href="https://pauseai.uk" target="_blank" rel="noopener noreferrer">
-                pauseai.uk
+              <a href="https://pauseai.info" target="_blank" rel="noopener noreferrer">
+                pauseai.info
               </a>
               .
             </li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,6 +78,27 @@ const WORK_AREAS: { title: string; body: string }[] = [
   },
 ]
 
+/**
+ * Dated, historical wins from https://pauseai.uk/track-record, chosen because each
+ * one runs from an ordinary volunteer task to a political or press outcome. They
+ * are past events rather than live counts, so they do not go stale. Phrased as
+ * sequence rather than causation where the track record only establishes order.
+ */
+const TRACK_RECORD: { when: string; body: string }[] = [
+  {
+    when: 'August 2025',
+    body: 'Volunteers gathered signatures from over 60 UK politicians on an open letter about Google DeepMind’s safety commitments. TIME broke the story, and Google went on to give the UK AI Safety Institute pre-deployment access to its next frontier model.',
+  },
+  {
+    when: 'December 2025',
+    body: 'Volunteers proposed and helped organise a Westminster Hall debate on AI safety, putting the question in front of Parliament directly.',
+  },
+  {
+    when: 'February 2026',
+    body: 'Volunteers co-organised the March for AI Safety, the largest protest yet focused solely on AI risk, covered by MIT Technology Review and the Wall Street Journal.',
+  },
+]
+
 const STEPS: { title: string; body: string }[] = [
   {
     title: 'Apply',
@@ -136,6 +157,12 @@ export default async function LandingPage() {
             campaigning, political engagement and local organising across the UK.
           </p>
           <p className="text-text-light">
+            Campaigning works as a chain. Someone drafts a briefing, someone else gets it in front
+            of an MP, and months later there is a debate in Parliament or a commitment from a lab
+            that was not there before. Almost everything below started as an ordinary task that a
+            volunteer picked up.
+          </p>
+          <p className="text-text-light">
             We are a small staff supported by a large number of volunteers
             {localGroupList ? `, with local groups in ${localGroupList}` : ''}. You do not need a
             technical background, and you do not need to be an expert on AI.
@@ -172,63 +199,91 @@ export default async function LandingPage() {
         </div>
       </section>
 
-      {/* How it works */}
+      {/* Track record. Answers the "will any of this make a difference?" objection. */}
       <section className="container py-12 md:py-16">
         <div className="max-w-3xl mb-8">
-          <h2>How Catalyse works</h2>
+          <h2>Where that work has led</h2>
+          <p className="text-text-light mb-0">
+            A few things volunteers have done, and what came of them.
+          </p>
         </div>
-        <ol className="grid grid-cols-1 md:grid-cols-3 gap-5 list-none p-0 m-0">
-          {STEPS.map((step, i) => (
-            <li key={step.title} className="bg-surface border border-brand-border rounded-xl p-6">
-              <span
-                className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-primary text-[#111827] font-bold mb-3"
-                aria-hidden="true"
-              >
-                {i + 1}
-              </span>
-              <h3 className="text-lg mb-2">
-                <span className="sr-only">Step {i + 1}: </span>
-                {step.title}
-              </h3>
-              <p className="text-sm text-text-light mb-0">{step.body}</p>
+        <ul className="grid grid-cols-1 md:grid-cols-3 gap-5 list-none p-0 m-0 mb-6">
+          {TRACK_RECORD.map((item) => (
+            <li key={item.when} className="bg-surface border border-brand-border rounded-xl p-6">
+              <p className="font-heading text-xs font-bold uppercase tracking-widest text-primary-dark mb-2">
+                {item.when}
+              </p>
+              <p className="text-sm text-text-light mb-0">{item.body}</p>
             </li>
           ))}
-        </ol>
+        </ul>
+        <p className="mb-0">
+          <a href="https://pauseai.uk/track-record" target="_blank" rel="noopener noreferrer">
+            See the full track record →
+          </a>
+        </p>
+      </section>
+
+      {/* How it works */}
+      <section className="bg-surface border-y border-brand-border">
+        <div className="container py-12 md:py-16">
+          <div className="max-w-3xl mb-8">
+            <h2>How Catalyse works</h2>
+          </div>
+          <ol className="grid grid-cols-1 md:grid-cols-3 gap-5 list-none p-0 m-0">
+            {STEPS.map((step, i) => (
+              <li
+                key={step.title}
+                className="bg-brand-bg border border-brand-border rounded-xl p-6"
+              >
+                <span
+                  className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-primary text-[#111827] font-bold mb-3"
+                  aria-hidden="true"
+                >
+                  {i + 1}
+                </span>
+                <h3 className="text-lg mb-2">
+                  <span className="sr-only">Step {i + 1}: </span>
+                  {step.title}
+                </h3>
+                <p className="text-sm text-text-light mb-0">{step.body}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
       </section>
 
       {/* Expectations */}
-      <section className="bg-surface border-y border-brand-border">
-        <div className="container py-12 md:py-16">
-          <div className="max-w-3xl">
-            <h2>Before you apply</h2>
-            <ul className="text-text-light space-y-2 pl-5 list-disc marker:text-primary">
-              <li>
-                Applications are reviewed by our team, so there is a short wait before you can see
-                open projects. We will email you either way.
-              </li>
-              <li>
-                There is no minimum commitment. Plenty of volunteers contribute an hour here and
-                there, and that is genuinely useful.
-              </li>
-              <li>
-                You control what other volunteers can see. Your profile can stay out of the
-                directory entirely, and your contact details are never shared without your say-so.
-              </li>
-              <li>
-                Catalyse is for coordinating work. For events, the newsletter and the wider
-                community, start at{' '}
-                <a href="https://pauseai.uk" target="_blank" rel="noopener noreferrer">
-                  pauseai.uk
-                </a>
-                .
-              </li>
-            </ul>
-          </div>
+      <section className="container py-12 md:py-16">
+        <div className="max-w-3xl">
+          <h2>Before you apply</h2>
+          <ul className="text-text-light space-y-2 pl-5 list-disc marker:text-primary">
+            <li>
+              Applications are reviewed by our team, so there is a short wait before you can see
+              open projects. We will email you either way.
+            </li>
+            <li>
+              There is no minimum commitment. Plenty of volunteers contribute an hour here and
+              there, and that is genuinely useful.
+            </li>
+            <li>
+              You control what other volunteers can see. Your profile can stay out of the directory
+              entirely, and your contact details are never shared without your say-so.
+            </li>
+            <li>
+              Catalyse is for coordinating work. For events, the newsletter and the wider community,
+              start at{' '}
+              <a href="https://pauseai.uk" target="_blank" rel="noopener noreferrer">
+                pauseai.uk
+              </a>
+              .
+            </li>
+          </ul>
         </div>
       </section>
 
       {/* Closing CTA */}
-      <section className="container py-14 md:py-20">
+      <section className="container border-t border-brand-border py-14 md:py-20">
         <div className="max-w-2xl">
           <h2>Ready to start?</h2>
           <p className="text-text-light mb-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import LandingCTA from '@/components/LandingCTA'
+import { prisma } from '@/lib/prisma'
 
 export const metadata: Metadata = {
   title: 'Volunteer with PauseAI UK',
   description:
-    'Catalyse is the volunteer platform for PauseAI UK — find campaign, policy, organising and creative work that matches your skills.',
+    'Catalyse is the volunteer platform for PauseAI UK. Find campaign, policy, organising and creative work that matches your skills.',
 }
+
+// The local group list is the only dynamic thing on the page, and it changes
+// rarely, so rebuild hourly rather than per request.
+export const revalidate = 3600
 
 /**
  * Public landing page.
@@ -16,45 +21,67 @@ export const metadata: Metadata = {
  * the movement does so a prospective volunteer can decide whether to apply.
  */
 
+/**
+ * UK local group names, straight from the table the rest of the app filters on.
+ * The same rows are already served publicly by the `localGroups.list` procedure,
+ * so nothing new is exposed here.
+ *
+ * Failures are swallowed: the DB may not be reachable when the page is
+ * prerendered at build time, and a missing sentence clause is a much better
+ * outcome than a failed build. The next revalidation picks the names up.
+ */
+async function fetchUkLocalGroupNames(): Promise<string[]> {
+  try {
+    const groups = await prisma.localGroup.findMany({
+      where: { country: 'UK' },
+      orderBy: { name: 'asc' },
+      select: { name: true },
+    })
+    return groups.map((g) => g.name)
+  } catch {
+    return []
+  }
+}
+
 const WORK_AREAS: { title: string; body: string }[] = [
   {
     title: 'Campaigns & protests',
-    body: 'Organising demonstrations, planning actions, stewarding on the day, and the logistics that hold a public campaign together.',
+    body: 'Organising demonstrations, planning actions, stewarding on the day and the logistics that hold a public campaign together.',
   },
   {
     title: 'Political engagement',
-    body: 'Writing to MPs, preparing briefings for lawmakers, drafting policy proposals, and following up after meetings.',
+    body: 'Writing to MPs, preparing briefings for lawmakers, drafting policy proposals and following up after meetings.',
   },
   {
     title: 'Local chapters',
-    body: 'Running regular meetups, welcoming new volunteers, and starting a chapter where there isn’t one yet.',
+    body: 'Running regular meetups, welcoming new volunteers and starting a chapter where there isn’t one yet.',
   },
   {
     title: 'Events',
-    body: 'Conferences, workshops, film screenings, book launches and socials — from finding a venue to running the door.',
+    body: 'Conferences, workshops, film screenings, book launches and socials, from finding a venue to running the door.',
   },
   {
     title: 'Communications & media',
-    body: 'Social media, newsletters, press outreach, and helping people tell their own stories about why this matters to them.',
+    body: 'Social media, newsletters, press outreach and helping people tell their own stories about why this matters to them.',
   },
   {
     title: 'Design & creative',
-    body: 'Graphics, placards, video, photography, merchandise, and the visual identity that makes a campaign recognisable.',
+    body: 'Graphics, placards, video, photography, merchandise and the visual identity that makes a campaign recognisable.',
   },
   {
     title: 'Research & writing',
-    body: 'Explainers, fact-checking, literature summaries, and turning dense technical material into something a non-specialist can act on.',
+    body: 'Explainers, fact-checking, literature summaries and turning dense technical material into something a non-specialist can act on.',
   },
   {
     title: 'Software & operations',
-    body: 'Internal tools, data and analysis, web work, and the unglamorous admin that keeps a volunteer organisation running.',
+    body: 'Internal tools, data and analysis, web work and the unglamorous admin that keeps a volunteer organisation running.',
   },
 ]
 
 const STEPS: { title: string; body: string }[] = [
   {
     title: 'Apply',
-    body: 'Tell us about your connection to PauseAI, what you’re good at, and how much time you have. Applications are read by a person, not a filter.',
+    body: 'Tell us about your connection to PauseAI, what you’re good at and how much time you have. Applications are read by a person, not a filter.',
   },
   {
     title: 'Get matched',
@@ -62,11 +89,17 @@ const STEPS: { title: string; body: string }[] = [
   },
   {
     title: 'Contribute',
-    body: 'Take on a single task, join a project team, or lead a project of your own. If you have an idea we aren’t working on yet, you can propose it.',
+    body: 'Take on a single task, join a project team or lead a project of your own. If you have an idea we aren’t working on yet, you can propose it.',
   },
 ]
 
-export default function LandingPage() {
+export default async function LandingPage() {
+  const localGroupNames = await fetchUkLocalGroupNames()
+  const localGroupList =
+    localGroupNames.length > 0
+      ? new Intl.ListFormat('en-GB', { style: 'long', type: 'conjunction' }).format(localGroupNames)
+      : null
+
   return (
     <main>
       {/* Hero */}
@@ -79,7 +112,7 @@ export default function LandingPage() {
             <h1 className="text-3xl md:text-5xl">Find the work that needs you</h1>
             <p className="text-lg text-text-light mb-8">
               Catalyse is the volunteer platform for PauseAI UK. It connects the people who want to
-              help with the projects that need them — matching what you can do to what the movement
+              help with the projects that need them, matching what you can do to what the movement
               is actually working on right now.
             </p>
             <div className="md:flex md:justify-center">
@@ -99,13 +132,13 @@ export default function LandingPage() {
           <p className="text-text-light">
             PauseAI UK is a civic movement working to avert the risks of superhuman artificial
             intelligence. We campaign for binding limits on the development of the most powerful AI
-            systems until there is a credible way to make them safe — through public campaigning,
-            political engagement, and local organising across the UK.
+            systems until there is a credible way to make them safe. We do that through public
+            campaigning, political engagement and local organising across the UK.
           </p>
           <p className="text-text-light">
-            We are a small staff supported by a large number of volunteers, with chapters in cities
-            including London, Glasgow, Oxford, Leicester, Manchester and the West of England. You do
-            not need a technical background, and you do not need to be an expert on AI.
+            We are a small staff supported by a large number of volunteers
+            {localGroupList ? `, with local groups in ${localGroupList}` : ''}. You do not need a
+            technical background, and you do not need to be an expert on AI.
           </p>
           <p className="mb-0">
             <a href="https://pauseai.uk" target="_blank" rel="noopener noreferrer">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,390 +1,209 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import { useRequireApproved } from '@/lib/hooks/auth'
+import type { Metadata } from 'next'
 import Link from 'next/link'
-import { useQuery } from '@tanstack/react-query'
-import Button from '@/components/Button'
-import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
-import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
-import { InferRouterInputs } from '@orpc/server'
-import { ORPCError } from '@orpc/client'
-import { orpc } from '@/lib/orpc'
-import { AppRouter } from '@/server/router'
-import { type Project, ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
-import { ProjectStatus } from '@/generated/prisma/enums'
+import LandingCTA from '@/components/LandingCTA'
 
-const STATUS_OPTIONS = [
-  { value: '', label: 'All Active' },
-  { value: 'in_progress', label: 'In Progress' },
-  { value: 'on_hold', label: 'On Hold' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'archived', label: 'Archived' },
-] as const
+export const metadata: Metadata = {
+  title: 'Volunteer with PauseAI UK',
+  description:
+    'Catalyse is the volunteer platform for PauseAI UK — find campaign, policy, organising and creative work that matches your skills.',
+}
 
-const NEEDS_OPTIONS = [
-  { value: '', label: 'Any' },
-  { value: 'looking_for_people', label: 'Looking for People' },
-  { value: 'seeking_help', label: 'Seeking Help', indent: true },
-  { value: 'seeking_owner', label: 'Seeking Owner', indent: true },
-  { value: 'not_seeking', label: 'Not Seeking' },
-] as const
+/**
+ * Public landing page.
+ *
+ * Deliberately contains no project data. Individual projects are only visible
+ * to approved volunteers at /projects; this page describes the *kinds* of work
+ * the movement does so a prospective volunteer can decide whether to apply.
+ */
 
-const URGENCY_OPTIONS = [
-  { value: '', label: 'Any urgency' },
-  { value: 'high', label: 'High' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'low', label: 'Low' },
-] as const
+const WORK_AREAS: { title: string; body: string }[] = [
+  {
+    title: 'Campaigns & protests',
+    body: 'Organising demonstrations, planning actions, stewarding on the day, and the logistics that hold a public campaign together.',
+  },
+  {
+    title: 'Political engagement',
+    body: 'Writing to MPs, preparing briefings for lawmakers, drafting policy proposals, and following up after meetings.',
+  },
+  {
+    title: 'Local chapters',
+    body: 'Running regular meetups, welcoming new volunteers, and starting a chapter where there isn’t one yet.',
+  },
+  {
+    title: 'Events',
+    body: 'Conferences, workshops, film screenings, book launches and socials — from finding a venue to running the door.',
+  },
+  {
+    title: 'Communications & media',
+    body: 'Social media, newsletters, press outreach, and helping people tell their own stories about why this matters to them.',
+  },
+  {
+    title: 'Design & creative',
+    body: 'Graphics, placards, video, photography, merchandise, and the visual identity that makes a campaign recognisable.',
+  },
+  {
+    title: 'Research & writing',
+    body: 'Explainers, fact-checking, literature summaries, and turning dense technical material into something a non-specialist can act on.',
+  },
+  {
+    title: 'Software & operations',
+    body: 'Internal tools, data and analysis, web work, and the unglamorous admin that keeps a volunteer organisation running.',
+  },
+]
 
-const SORT_OPTIONS = [
-  { value: '', label: 'Default sort' },
-  { value: 'created_at', label: 'Newest first' },
-  { value: 'match', label: 'Best match' },
-  { value: 'urgency', label: 'Most urgent' },
-] as const
+const STEPS: { title: string; body: string }[] = [
+  {
+    title: 'Apply',
+    body: 'Tell us about your connection to PauseAI, what you’re good at, and how much time you have. Applications are read by a person, not a filter.',
+  },
+  {
+    title: 'Get matched',
+    body: 'Once you’re approved you can see every open project. We highlight the ones that need the skills you listed, so you don’t have to guess where you’re useful.',
+  },
+  {
+    title: 'Contribute',
+    body: 'Take on a single task, join a project team, or lead a project of your own. If you have an idea we aren’t working on yet, you can propose it.',
+  },
+]
 
-export default function ProjectsPage() {
-  const { user, loading } = useRequireApproved()
-  const userSkillIds = new Set(user?.skills?.map((s) => s.id) ?? [])
-  const [search, setSearch] = useState('')
-  const { value: statusFilter, onChange: setStatusFilter } = useFilterOptions(STATUS_OPTIONS, '')
-  const { value: needsFilter, onChange: setNeedsFilter } = useFilterOptions(NEEDS_OPTIONS, '')
-  const { value: urgencyFilter, onChange: setUrgencyFilter } = useFilterOptions(URGENCY_OPTIONS, '')
-  const [locationFilter, setLocationFilter] = useState('')
-  const { value: sortBy, onChange: setSortBy } = useFilterOptions(SORT_OPTIONS, '')
-  const [completedOpen, setCompletedOpen] = useState(false)
-  const [debouncedSearch, setDebouncedSearch] = useState('')
-  const [debouncedLocationFilter, setDebouncedLocationFilter] = useState('')
-
-  useEffect(() => {
-    const t = setTimeout(
-      () => {
-        setDebouncedSearch(search)
-        setDebouncedLocationFilter(locationFilter)
-      },
-      search || locationFilter ? 300 : 0,
-    )
-    return () => clearTimeout(t)
-  }, [search, locationFilter])
-
-  const { data: pendingTriageList = [] } = useQuery({
-    ...orpc.admin.triage.list.queryOptions(),
-    enabled: !!user?.isAdmin,
-  })
-  const pendingCount = pendingTriageList.length
-
-  const { data: pendingApplicationsList = [] } = useQuery({
-    ...orpc.admin.applications.list.queryOptions({ input: { filter: 'mine' } }),
-    enabled: !!user?.isAdmin,
-  })
-  const pendingApplicationsCount = pendingApplicationsList.length
-
-  const { data: localGroupsData } = useQuery({
-    ...orpc.localGroups.list.queryOptions({ input: {} }),
-    enabled: true,
-  })
-  const localGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
-
-  const projectsInput: InferRouterInputs<AppRouter>['projects']['list'] = {}
-  if (debouncedSearch) projectsInput.search = debouncedSearch
-  if (statusFilter) projectsInput.status = statusFilter
-  if (needsFilter === 'looking_for_people') projectsInput.isSeekingAny = true
-  else if (needsFilter === 'seeking_help') projectsInput.isSeekingHelp = true
-  else if (needsFilter === 'seeking_owner') projectsInput.isSeekingOwner = true
-  else if (needsFilter === 'not_seeking') projectsInput.notSeeking = true
-  if (urgencyFilter) projectsInput.urgency = urgencyFilter
-  if (debouncedLocationFilter) {
-    const [country, localGroup] = debouncedLocationFilter.split(':')
-    projectsInput.country = country
-    if (localGroup) projectsInput.localGroup = localGroup
-  }
-  if (sortBy) projectsInput.sortBy = sortBy
-
-  const {
-    data: projectsData,
-    isPending: loadingProjects,
-    error: projectsError,
-  } = useQuery({
-    ...orpc.projects.list.queryOptions({ input: projectsInput }),
-    enabled: !!user,
-  })
-  const projects = projectsData?.projects ?? []
-
-  const hasFilters =
-    search || statusFilter || needsFilter || urgencyFilter || locationFilter || sortBy
-
-  function clearFilters() {
-    setSearch('')
-    setStatusFilter('')
-    setNeedsFilter('')
-    setUrgencyFilter('')
-    setLocationFilter('')
-    setSortBy('')
-  }
-
-  function byMatchScore(a: Project, b: Project) {
-    const scoreA = a.match?.matchedRequiredCount ?? 0
-    const scoreB = b.match?.matchedRequiredCount ?? 0
-    return scoreB - scoreA
-  }
-  const sortGroup = (list: Project[]) =>
-    userSkillIds.size > 0 ? [...list].sort(byMatchScore) : list
-
-  const seeking = sortGroup(projects.filter((p) => p.isSeekingHelp || p.isSeekingOwner))
-  const inProgress = sortGroup(
-    projects.filter(
-      (p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === ProjectStatus.in_progress,
-    ),
-  )
-  const onHold = sortGroup(
-    projects.filter(
-      (p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === ProjectStatus.on_hold,
-    ),
-  )
-  const completed = sortGroup(projects.filter((p) => p.status === ProjectStatus.completed))
-  const other = sortGroup(
-    projects.filter(
-      (p) =>
-        !p.isSeekingHelp &&
-        !p.isSeekingOwner &&
-        !['in_progress', 'on_hold', 'completed'].includes(p.status),
-    ),
-  )
-
-  const groups = [
-    {
-      key: 'seeking',
-      projects: seeking,
-      label: 'Looking for People',
-      desc: 'These projects need your help',
-      color: 'text-orange-600 dark:text-orange-400',
-    },
-    {
-      key: 'in_progress',
-      projects: inProgress,
-      label: 'In Progress',
-      desc: 'Actively being worked on',
-      color: 'text-blue-600 dark:text-blue-400',
-    },
-    { key: 'other', projects: other, label: 'Other Active', desc: '', color: 'text-text-light' },
-    {
-      key: 'on_hold',
-      projects: onHold,
-      label: 'On Hold',
-      desc: '',
-      color: 'text-red-600 dark:text-red-400',
-    },
-    {
-      key: 'completed',
-      projects: completed,
-      label: 'Completed',
-      desc: '',
-      color: 'text-green-600 dark:text-green-400',
-    },
-  ]
-
-  if (loading || !user) return null
-
+export default function LandingPage() {
   return (
-    <>
-      <main className="container py-5 pb-15">
-        <h1 role="heading">Projects</h1>
-
-        {user.isAdmin && pendingCount > 0 && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-amber-100 text-amber-800 border border-amber-300 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-600">
-            <strong>
-              {pendingCount} project{pendingCount !== 1 ? 's' : ''} pending review.
-            </strong>{' '}
-            <Link href="/admin/triage" className="underline">
-              Go to triage →
-            </Link>
-          </div>
-        )}
-        {user.isAdmin && pendingApplicationsCount > 0 && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-violet-100 text-violet-800 border border-violet-300 dark:bg-violet-950 dark:text-violet-300 dark:border-violet-600">
-            <strong>
-              {pendingApplicationsCount} application{pendingApplicationsCount !== 1 ? 's' : ''}{' '}
-              pending review.
-            </strong>{' '}
-            <Link href="/admin/applications" className="underline">
-              Review applications →
-            </Link>
-          </div>
-        )}
-
-        {/* Filters */}
-        <div className="mb-5">
-          <div className="mb-3">
-            <label htmlFor="search-projects">Search</label>
-            <input
-              id="search-projects"
-              type="search"
-              aria-label="Search"
-              placeholder="Search projects…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-          </div>
-          <div className="flex gap-3 flex-wrap items-end">
-            <FilterDropdown
-              id="status-filter"
-              label="Status"
-              ariaLabel="Status filter"
-              value={statusFilter}
-              options={STATUS_OPTIONS}
-              onChange={setStatusFilter}
-            />
-            <FilterDropdown
-              id="needs-filter"
-              label="Needs"
-              ariaLabel="Needs filter"
-              value={needsFilter}
-              options={NEEDS_OPTIONS}
-              onChange={setNeedsFilter}
-            />
-            <FilterDropdown
-              id="urgency-filter"
-              label="Urgency"
-              ariaLabel="Urgency filter"
-              value={urgencyFilter}
-              options={URGENCY_OPTIONS}
-              onChange={setUrgencyFilter}
-            />
-
-            <FilterDropdown
-              id="location-filter"
-              label="Country/Group"
-              ariaLabel="Country/Group filter"
-              value={locationFilter}
-              options={buildLocationOptions(localGroups)}
-              onChange={setLocationFilter}
-              searchable
-            />
-
-            <FilterDropdown
-              id="sort-filter"
-              label="Sort by"
-              ariaLabel="Sort filter"
-              value={sortBy}
-              options={SORT_OPTIONS}
-              onChange={setSortBy}
-            />
-
-            {hasFilters && (
-              <Button variant="outline" size="lg" onClick={clearFilters}>
-                Clear filters
-              </Button>
-            )}
+    <main>
+      {/* Hero */}
+      <section className="border-b border-brand-border bg-surface">
+        <div className="container py-14 md:py-20">
+          <div className="max-w-3xl mx-auto md:text-center">
+            <p className="font-heading text-sm font-bold uppercase tracking-widest text-primary-dark mb-3">
+              PauseAI UK
+            </p>
+            <h1 className="text-3xl md:text-5xl">Find the work that needs you</h1>
+            <p className="text-lg text-text-light mb-8">
+              Catalyse is the volunteer platform for PauseAI UK. It connects the people who want to
+              help with the projects that need them — matching what you can do to what the movement
+              is actually working on right now.
+            </p>
+            <div className="md:flex md:justify-center">
+              <LandingCTA />
+            </div>
+            <p className="text-sm text-text-light mt-4 mb-0">
+              Already applied? <Link href="/login">Log in to check your application status</Link>.
+            </p>
           </div>
         </div>
+      </section>
 
-        {loadingProjects ? (
-          <div className="text-center py-10 text-text-light">Loading projects…</div>
-        ) : projectsError ? (
-          <div className="text-center py-15 px-5 text-text-light">
-            <h3>Couldn’t load projects</h3>
-            <p>
-              {projectsError instanceof Error
-                ? projectsError.message
-                : 'Something went wrong loading projects.'}
+      {/* What PauseAI UK is */}
+      <section className="container py-12 md:py-16">
+        <div className="max-w-3xl">
+          <h2>Who we are</h2>
+          <p className="text-text-light">
+            PauseAI UK is a civic movement working to avert the risks of superhuman artificial
+            intelligence. We campaign for binding limits on the development of the most powerful AI
+            systems until there is a credible way to make them safe — through public campaigning,
+            political engagement, and local organising across the UK.
+          </p>
+          <p className="text-text-light">
+            We are a small staff supported by a large number of volunteers, with chapters in cities
+            including London, Glasgow, Oxford, Leicester, Manchester and the West of England. You do
+            not need a technical background, and you do not need to be an expert on AI.
+          </p>
+          <p className="mb-0">
+            <a href="https://pauseai.uk" target="_blank" rel="noopener noreferrer">
+              Read more about PauseAI UK →
+            </a>
+          </p>
+        </div>
+      </section>
+
+      {/* Kinds of work */}
+      <section className="bg-surface border-y border-brand-border">
+        <div className="container py-12 md:py-16">
+          <div className="max-w-3xl mb-8">
+            <h2>The kinds of things we do</h2>
+            <p className="text-text-light mb-0">
+              Projects on Catalyse change constantly, but they tend to fall into these areas. Some
+              need a few hours once; others need someone to take ownership for months.
             </p>
-            {projectsError instanceof ORPCError && projectsError.code === 'FORBIDDEN' && (
-              <p className="mt-2">
-                <Link href="/verify-email" className="underline">
-                  Confirm your email
-                </Link>
-              </p>
-            )}
           </div>
-        ) : projects.length === 0 ? (
-          <div className="text-center py-15 px-5 text-text-light">
-            <h3>No projects found</h3>
-            <p>
-              Try adjusting your filters or{' '}
-              <Link href="/suggest" className="underline">
-                suggest a new project
-              </Link>
-              .
-            </p>
-          </div>
-        ) : (
-          <>
-            {/* Status summary bar */}
-            {!statusFilter && !needsFilter && projects.length > 1 && (
-              <div className="flex flex-wrap gap-2 mb-6">
-                {seeking.length > 0 && (
-                  <span className={statusBadgeClasses('seeking_help')}>
-                    Looking for People: {seeking.length}
-                  </span>
-                )}
-                {inProgress.length > 0 && (
-                  <span className={statusBadgeClasses('in_progress')}>
-                    In Progress: {inProgress.length}
-                  </span>
-                )}
-                <span className="text-sm text-text-light self-center">{projects.length} total</span>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5">
+            {WORK_AREAS.map((area) => (
+              <div
+                key={area.title}
+                className="bg-brand-bg border border-brand-border rounded-xl p-5"
+              >
+                <h3 className="text-base mb-2">{area.title}</h3>
+                <p className="text-sm text-text-light mb-0">{area.body}</p>
               </div>
-            )}
+            ))}
+          </div>
+        </div>
+      </section>
 
-            {/* Grouped project cards */}
-            {statusFilter || needsFilter ? (
-              <ProjectList projects={projects} userSkillIds={userSkillIds} />
-            ) : (
-              groups
-                .filter((g) => g.projects.length > 0)
-                .map((g) => {
-                  const isCompleted = g.key === 'completed'
-                  const isOpen = !isCompleted || completedOpen
-                  return (
-                    <div key={g.key} className="mb-8">
-                      {isCompleted ? (
-                        <h2
-                          className="text-lg mb-1 flex items-center gap-2 cursor-pointer select-none"
-                          onClick={() => setCompletedOpen((o) => !o)}
-                          role="button"
-                          aria-expanded={completedOpen}
-                          tabIndex={0}
-                          onKeyDown={(e) => e.key === 'Enter' && setCompletedOpen((o) => !o)}
-                        >
-                          {g.label} — {g.projects.length} project
-                          {g.projects.length !== 1 ? 's' : ''}
-                          <svg
-                            className={`text-text-light shrink-0 transition-transform ${completedOpen ? 'rotate-180' : 'rotate-0'}`}
-                            width="32"
-                            height="32"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          >
-                            <polyline points="6 9 12 15 18 9" />
-                          </svg>
-                        </h2>
-                      ) : (
-                        <h2 className={`text-lg mb-1 ${g.color}`}>
-                          {g.label} — {g.projects.length} project
-                          {g.projects.length !== 1 ? 's' : ''}
-                        </h2>
-                      )}
-                      {g.desc && <p className="text-text-light text-sm mb-3">{g.desc}</p>}
-                      {isOpen && (
-                        <div
-                          key={String(completedOpen)}
-                          className={isCompleted ? 'animate-fade-slide-in' : undefined}
-                        >
-                          <ProjectList projects={g.projects} userSkillIds={userSkillIds} />
-                        </div>
-                      )}
-                    </div>
-                  )
-                })
-            )}
-          </>
-        )}
-      </main>
-    </>
+      {/* How it works */}
+      <section className="container py-12 md:py-16">
+        <div className="max-w-3xl mb-8">
+          <h2>How Catalyse works</h2>
+        </div>
+        <ol className="grid grid-cols-1 md:grid-cols-3 gap-5 list-none p-0 m-0">
+          {STEPS.map((step, i) => (
+            <li key={step.title} className="bg-surface border border-brand-border rounded-xl p-6">
+              <span
+                className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-primary text-[#111827] font-bold mb-3"
+                aria-hidden="true"
+              >
+                {i + 1}
+              </span>
+              <h3 className="text-lg mb-2">
+                <span className="sr-only">Step {i + 1}: </span>
+                {step.title}
+              </h3>
+              <p className="text-sm text-text-light mb-0">{step.body}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Expectations */}
+      <section className="bg-surface border-y border-brand-border">
+        <div className="container py-12 md:py-16">
+          <div className="max-w-3xl">
+            <h2>Before you apply</h2>
+            <ul className="text-text-light space-y-2 pl-5 list-disc marker:text-primary">
+              <li>
+                Applications are reviewed by our team, so there is a short wait before you can see
+                open projects. We will email you either way.
+              </li>
+              <li>
+                There is no minimum commitment. Plenty of volunteers contribute an hour here and
+                there, and that is genuinely useful.
+              </li>
+              <li>
+                You control what other volunteers can see. Your profile can stay out of the
+                directory entirely, and your contact details are never shared without your say-so.
+              </li>
+              <li>
+                Catalyse is for coordinating work. For events, the newsletter and the wider
+                community, start at{' '}
+                <a href="https://pauseai.uk" target="_blank" rel="noopener noreferrer">
+                  pauseai.uk
+                </a>
+                .
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* Closing CTA */}
+      <section className="container py-14 md:py-20">
+        <div className="max-w-2xl">
+          <h2>Ready to start?</h2>
+          <p className="text-text-light mb-6">
+            Tell us what you are good at and we will show you where it is needed.
+          </p>
+          <LandingCTA />
+        </div>
+      </section>
+    </main>
   )
 }

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -97,7 +97,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
 
   const deleteMutation = useMutation({
     ...orpc.projects.delete.mutationOptions(),
-    onSuccess: () => router.push('/'),
+    onSuccess: () => router.push('/projects'),
     onError: (err: unknown) => {
       showToast(err instanceof Error ? err.message : 'Failed to delete project', 'error')
     },

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -299,10 +299,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     }
   }, [project?.status])
 
-  // Redirect to home if project not found
+  // Redirect to the project list if project not found
   useEffect(() => {
     if (!loadingProject && !project && user) {
-      router.replace('/')
+      router.replace('/projects')
     }
   }, [loadingProject, project, user, router])
 

--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'All Projects' }
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,390 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRequireApproved } from '@/lib/hooks/auth'
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import Button from '@/components/Button'
+import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
+import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
+import { InferRouterInputs } from '@orpc/server'
+import { ORPCError } from '@orpc/client'
+import { orpc } from '@/lib/orpc'
+import { AppRouter } from '@/server/router'
+import { type Project, ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
+import { ProjectStatus } from '@/generated/prisma/enums'
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All Active' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'on_hold', label: 'On Hold' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'archived', label: 'Archived' },
+] as const
+
+const NEEDS_OPTIONS = [
+  { value: '', label: 'Any' },
+  { value: 'looking_for_people', label: 'Looking for People' },
+  { value: 'seeking_help', label: 'Seeking Help', indent: true },
+  { value: 'seeking_owner', label: 'Seeking Owner', indent: true },
+  { value: 'not_seeking', label: 'Not Seeking' },
+] as const
+
+const URGENCY_OPTIONS = [
+  { value: '', label: 'Any urgency' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+] as const
+
+const SORT_OPTIONS = [
+  { value: '', label: 'Default sort' },
+  { value: 'created_at', label: 'Newest first' },
+  { value: 'match', label: 'Best match' },
+  { value: 'urgency', label: 'Most urgent' },
+] as const
+
+export default function ProjectsPage() {
+  const { user, loading } = useRequireApproved()
+  const userSkillIds = new Set(user?.skills?.map((s) => s.id) ?? [])
+  const [search, setSearch] = useState('')
+  const { value: statusFilter, onChange: setStatusFilter } = useFilterOptions(STATUS_OPTIONS, '')
+  const { value: needsFilter, onChange: setNeedsFilter } = useFilterOptions(NEEDS_OPTIONS, '')
+  const { value: urgencyFilter, onChange: setUrgencyFilter } = useFilterOptions(URGENCY_OPTIONS, '')
+  const [locationFilter, setLocationFilter] = useState('')
+  const { value: sortBy, onChange: setSortBy } = useFilterOptions(SORT_OPTIONS, '')
+  const [completedOpen, setCompletedOpen] = useState(false)
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [debouncedLocationFilter, setDebouncedLocationFilter] = useState('')
+
+  useEffect(() => {
+    const t = setTimeout(
+      () => {
+        setDebouncedSearch(search)
+        setDebouncedLocationFilter(locationFilter)
+      },
+      search || locationFilter ? 300 : 0,
+    )
+    return () => clearTimeout(t)
+  }, [search, locationFilter])
+
+  const { data: pendingTriageList = [] } = useQuery({
+    ...orpc.admin.triage.list.queryOptions(),
+    enabled: !!user?.isAdmin,
+  })
+  const pendingCount = pendingTriageList.length
+
+  const { data: pendingApplicationsList = [] } = useQuery({
+    ...orpc.admin.applications.list.queryOptions({ input: { filter: 'mine' } }),
+    enabled: !!user?.isAdmin,
+  })
+  const pendingApplicationsCount = pendingApplicationsList.length
+
+  const { data: localGroupsData } = useQuery({
+    ...orpc.localGroups.list.queryOptions({ input: {} }),
+    enabled: true,
+  })
+  const localGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
+
+  const projectsInput: InferRouterInputs<AppRouter>['projects']['list'] = {}
+  if (debouncedSearch) projectsInput.search = debouncedSearch
+  if (statusFilter) projectsInput.status = statusFilter
+  if (needsFilter === 'looking_for_people') projectsInput.isSeekingAny = true
+  else if (needsFilter === 'seeking_help') projectsInput.isSeekingHelp = true
+  else if (needsFilter === 'seeking_owner') projectsInput.isSeekingOwner = true
+  else if (needsFilter === 'not_seeking') projectsInput.notSeeking = true
+  if (urgencyFilter) projectsInput.urgency = urgencyFilter
+  if (debouncedLocationFilter) {
+    const [country, localGroup] = debouncedLocationFilter.split(':')
+    projectsInput.country = country
+    if (localGroup) projectsInput.localGroup = localGroup
+  }
+  if (sortBy) projectsInput.sortBy = sortBy
+
+  const {
+    data: projectsData,
+    isPending: loadingProjects,
+    error: projectsError,
+  } = useQuery({
+    ...orpc.projects.list.queryOptions({ input: projectsInput }),
+    enabled: !!user,
+  })
+  const projects = projectsData?.projects ?? []
+
+  const hasFilters =
+    search || statusFilter || needsFilter || urgencyFilter || locationFilter || sortBy
+
+  function clearFilters() {
+    setSearch('')
+    setStatusFilter('')
+    setNeedsFilter('')
+    setUrgencyFilter('')
+    setLocationFilter('')
+    setSortBy('')
+  }
+
+  function byMatchScore(a: Project, b: Project) {
+    const scoreA = a.match?.matchedRequiredCount ?? 0
+    const scoreB = b.match?.matchedRequiredCount ?? 0
+    return scoreB - scoreA
+  }
+  const sortGroup = (list: Project[]) =>
+    userSkillIds.size > 0 ? [...list].sort(byMatchScore) : list
+
+  const seeking = sortGroup(projects.filter((p) => p.isSeekingHelp || p.isSeekingOwner))
+  const inProgress = sortGroup(
+    projects.filter(
+      (p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === ProjectStatus.in_progress,
+    ),
+  )
+  const onHold = sortGroup(
+    projects.filter(
+      (p) => !p.isSeekingHelp && !p.isSeekingOwner && p.status === ProjectStatus.on_hold,
+    ),
+  )
+  const completed = sortGroup(projects.filter((p) => p.status === ProjectStatus.completed))
+  const other = sortGroup(
+    projects.filter(
+      (p) =>
+        !p.isSeekingHelp &&
+        !p.isSeekingOwner &&
+        !['in_progress', 'on_hold', 'completed'].includes(p.status),
+    ),
+  )
+
+  const groups = [
+    {
+      key: 'seeking',
+      projects: seeking,
+      label: 'Looking for People',
+      desc: 'These projects need your help',
+      color: 'text-orange-600 dark:text-orange-400',
+    },
+    {
+      key: 'in_progress',
+      projects: inProgress,
+      label: 'In Progress',
+      desc: 'Actively being worked on',
+      color: 'text-blue-600 dark:text-blue-400',
+    },
+    { key: 'other', projects: other, label: 'Other Active', desc: '', color: 'text-text-light' },
+    {
+      key: 'on_hold',
+      projects: onHold,
+      label: 'On Hold',
+      desc: '',
+      color: 'text-red-600 dark:text-red-400',
+    },
+    {
+      key: 'completed',
+      projects: completed,
+      label: 'Completed',
+      desc: '',
+      color: 'text-green-600 dark:text-green-400',
+    },
+  ]
+
+  if (loading || !user) return null
+
+  return (
+    <>
+      <main className="container py-5 pb-15">
+        <h1 role="heading">Projects</h1>
+
+        {user.isAdmin && pendingCount > 0 && (
+          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-amber-100 text-amber-800 border border-amber-300 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-600">
+            <strong>
+              {pendingCount} project{pendingCount !== 1 ? 's' : ''} pending review.
+            </strong>{' '}
+            <Link href="/admin/triage" className="underline">
+              Go to triage →
+            </Link>
+          </div>
+        )}
+        {user.isAdmin && pendingApplicationsCount > 0 && (
+          <div className="flex items-center gap-3 p-4 rounded-lg mb-4 bg-violet-100 text-violet-800 border border-violet-300 dark:bg-violet-950 dark:text-violet-300 dark:border-violet-600">
+            <strong>
+              {pendingApplicationsCount} application{pendingApplicationsCount !== 1 ? 's' : ''}{' '}
+              pending review.
+            </strong>{' '}
+            <Link href="/admin/applications" className="underline">
+              Review applications →
+            </Link>
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="mb-5">
+          <div className="mb-3">
+            <label htmlFor="search-projects">Search</label>
+            <input
+              id="search-projects"
+              type="search"
+              aria-label="Search"
+              placeholder="Search projects…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <div className="flex gap-3 flex-wrap items-end">
+            <FilterDropdown
+              id="status-filter"
+              label="Status"
+              ariaLabel="Status filter"
+              value={statusFilter}
+              options={STATUS_OPTIONS}
+              onChange={setStatusFilter}
+            />
+            <FilterDropdown
+              id="needs-filter"
+              label="Needs"
+              ariaLabel="Needs filter"
+              value={needsFilter}
+              options={NEEDS_OPTIONS}
+              onChange={setNeedsFilter}
+            />
+            <FilterDropdown
+              id="urgency-filter"
+              label="Urgency"
+              ariaLabel="Urgency filter"
+              value={urgencyFilter}
+              options={URGENCY_OPTIONS}
+              onChange={setUrgencyFilter}
+            />
+
+            <FilterDropdown
+              id="location-filter"
+              label="Country/Group"
+              ariaLabel="Country/Group filter"
+              value={locationFilter}
+              options={buildLocationOptions(localGroups)}
+              onChange={setLocationFilter}
+              searchable
+            />
+
+            <FilterDropdown
+              id="sort-filter"
+              label="Sort by"
+              ariaLabel="Sort filter"
+              value={sortBy}
+              options={SORT_OPTIONS}
+              onChange={setSortBy}
+            />
+
+            {hasFilters && (
+              <Button variant="outline" size="lg" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {loadingProjects ? (
+          <div className="text-center py-10 text-text-light">Loading projects…</div>
+        ) : projectsError ? (
+          <div className="text-center py-15 px-5 text-text-light">
+            <h3>Couldn’t load projects</h3>
+            <p>
+              {projectsError instanceof Error
+                ? projectsError.message
+                : 'Something went wrong loading projects.'}
+            </p>
+            {projectsError instanceof ORPCError && projectsError.code === 'FORBIDDEN' && (
+              <p className="mt-2">
+                <Link href="/verify-email" className="underline">
+                  Confirm your email
+                </Link>
+              </p>
+            )}
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="text-center py-15 px-5 text-text-light">
+            <h3>No projects found</h3>
+            <p>
+              Try adjusting your filters or{' '}
+              <Link href="/suggest" className="underline">
+                suggest a new project
+              </Link>
+              .
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Status summary bar */}
+            {!statusFilter && !needsFilter && projects.length > 1 && (
+              <div className="flex flex-wrap gap-2 mb-6">
+                {seeking.length > 0 && (
+                  <span className={statusBadgeClasses('seeking_help')}>
+                    Looking for People: {seeking.length}
+                  </span>
+                )}
+                {inProgress.length > 0 && (
+                  <span className={statusBadgeClasses('in_progress')}>
+                    In Progress: {inProgress.length}
+                  </span>
+                )}
+                <span className="text-sm text-text-light self-center">{projects.length} total</span>
+              </div>
+            )}
+
+            {/* Grouped project cards */}
+            {statusFilter || needsFilter ? (
+              <ProjectList projects={projects} userSkillIds={userSkillIds} />
+            ) : (
+              groups
+                .filter((g) => g.projects.length > 0)
+                .map((g) => {
+                  const isCompleted = g.key === 'completed'
+                  const isOpen = !isCompleted || completedOpen
+                  return (
+                    <div key={g.key} className="mb-8">
+                      {isCompleted ? (
+                        <h2
+                          className="text-lg mb-1 flex items-center gap-2 cursor-pointer select-none"
+                          onClick={() => setCompletedOpen((o) => !o)}
+                          role="button"
+                          aria-expanded={completedOpen}
+                          tabIndex={0}
+                          onKeyDown={(e) => e.key === 'Enter' && setCompletedOpen((o) => !o)}
+                        >
+                          {g.label} — {g.projects.length} project
+                          {g.projects.length !== 1 ? 's' : ''}
+                          <svg
+                            className={`text-text-light shrink-0 transition-transform ${completedOpen ? 'rotate-180' : 'rotate-0'}`}
+                            width="32"
+                            height="32"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                        </h2>
+                      ) : (
+                        <h2 className={`text-lg mb-1 ${g.color}`}>
+                          {g.label} — {g.projects.length} project
+                          {g.projects.length !== 1 ? 's' : ''}
+                        </h2>
+                      )}
+                      {g.desc && <p className="text-text-light text-sm mb-3">{g.desc}</p>}
+                      {isOpen && (
+                        <div
+                          key={String(completedOpen)}
+                          className={isCompleted ? 'animate-fade-slide-in' : undefined}
+                        >
+                          <ProjectList projects={g.projects} userSkillIds={userSkillIds} />
+                        </div>
+                      )}
+                    </div>
+                  )
+                })
+            )}
+          </>
+        )}
+      </main>
+    </>
+  )
+}

--- a/app/starter-tasks/page.tsx
+++ b/app/starter-tasks/page.tsx
@@ -53,8 +53,8 @@ export default function StarterTasksPage() {
           <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word text-center">
             <h3>No tasks assigned yet</h3>
             <p className="text-text-light">
-              Check back soon, or browse <Link href="/">projects</Link> to find other ways to
-              contribute.
+              Check back soon, or browse <Link href="/projects">projects</Link> to find other ways
+              to contribute.
             </p>
           </div>
         ) : (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -169,18 +169,22 @@ export default function Header() {
   }, [pathname])
 
   const navLinks = [
-    { href: '/', label: 'Projects' },
+    { href: '/projects', label: 'Projects' },
     { href: '/volunteers', label: 'Volunteers' },
     { href: '/suggest', label: 'Suggest' },
     { href: '/starter-tasks', label: 'Quick Tasks' },
   ]
+
+  // Signed-in volunteers expect the wordmark to take them into the app; signed-out
+  // visitors should land on the public explainer at /.
+  const homeHref = user ? '/projects' : '/'
 
   return (
     <>
       <header className="bg-surface border-b border-brand-border py-4 sticky top-0 z-[100]">
         <div className="container flex justify-between items-center gap-2 flex-nowrap xl:gap-4">
           <Link
-            href="/"
+            href={homeHref}
             className="font-display text-2xl font-black text-primary no-underline flex items-center gap-2"
           >
             Catalyse
@@ -360,7 +364,10 @@ export default function Header() {
           {/* Panel header */}
           <div className="border-b border-brand-border bg-surface shrink-0">
             <div className="container flex items-center justify-between py-4">
-              <Link href="/" className="font-display text-2xl font-black text-primary no-underline">
+              <Link
+                href={homeHref}
+                className="font-display text-2xl font-black text-primary no-underline"
+              >
                 Catalyse
               </Link>
               <Button

--- a/components/LandingCTA.tsx
+++ b/components/LandingCTA.tsx
@@ -10,11 +10,14 @@ import { useAuth } from '@/lib/auth-context'
  * logged-out visitors; only these buttons need to know who is looking.
  */
 export default function LandingCTA({ size = 'lg' }: { size?: 'md' | 'lg' }) {
-  const { user, loading } = useAuth()
+  const { user } = useAuth()
 
-  // Reserve the row height while auth resolves so the hero doesn't jump.
-  if (loading) return <div className={size === 'lg' ? 'h-12' : 'h-10'} aria-hidden="true" />
-
+  // Deliberately no `loading` branch. `AuthProvider` seeds `loading` from
+  // localStorage, so it is false on the server and true on the client whenever a
+  // token exists — branching on it here would hydrate differently to the
+  // prerendered HTML. `user` is null in both renders, so the signed-out CTA is a
+  // stable match; signed-in visitors swap over once auth resolves. Both branches
+  // are the same height, so nothing shifts.
   if (user) {
     return (
       <div className="flex flex-wrap gap-3">

--- a/components/LandingCTA.tsx
+++ b/components/LandingCTA.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import Button from '@/components/Button'
+import { useAuth } from '@/lib/auth-context'
+
+/**
+ * Auth-aware call to action for the public landing page.
+ *
+ * The landing page itself is a server component so it renders instantly for
+ * logged-out visitors; only these buttons need to know who is looking.
+ */
+export default function LandingCTA({ size = 'lg' }: { size?: 'md' | 'lg' }) {
+  const { user, loading } = useAuth()
+
+  // Reserve the row height while auth resolves so the hero doesn't jump.
+  if (loading) return <div className={size === 'lg' ? 'h-12' : 'h-10'} aria-hidden="true" />
+
+  if (user) {
+    return (
+      <div className="flex flex-wrap gap-3">
+        <Button href="/projects" size={size}>
+          Browse projects
+        </Button>
+        <Button href="/dashboard" variant="outline" size={size}>
+          Go to my dashboard
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button href="/signup" size={size}>
+        Apply to join
+      </Button>
+      <Button href="/login" variant="outline" size={size}>
+        Log in
+      </Button>
+    </div>
+  )
+}

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -152,7 +152,7 @@ test.describe('Project Lifecycle', () => {
     await setProjectStatus(baseUrl, volunteer.page, projectId, 'completed')
 
     // Project appears in the completed tab on the projects index
-    await volunteer.page.goto(`${baseUrl}/`)
+    await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(
       volunteer.page.getByRole('heading', { name: 'Projects', exact: true }),
     ).toBeVisible({ timeout: 10_000 })

--- a/e2e/tests/10-project-discovery.spec.ts
+++ b/e2e/tests/10-project-discovery.spec.ts
@@ -33,6 +33,36 @@ test.describe('Unauthenticated Project Access', () => {
     await expect(page).toHaveURL(`${baseUrl}/`)
   })
 
+  // `/` is statically prerendered, so anything on it that branches on
+  // AuthProvider's `loading` hydrates differently to the server HTML — `loading`
+  // is seeded from localStorage, making it false on the server and true on the
+  // client whenever a token is present. Regression guard for that mismatch.
+  test('Landing page hydrates cleanly with a token in localStorage', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    await context.addInitScript(() => localStorage.setItem('authToken', 'not-a-real-token'))
+    const page = await context.newPage()
+    const errors: string[] = []
+    page.on('console', (m) => {
+      if (m.type() === 'error') errors.push(m.text())
+    })
+    page.on('pageerror', (e) => errors.push(String(e)))
+
+    try {
+      await page.goto(`${baseUrl}/`)
+      await expect(page.getByRole('heading', { name: 'Find the work that needs you' })).toBeVisible(
+        { timeout: 10_000 },
+      )
+      await page.waitForLoadState('networkidle')
+
+      expect(errors.filter((e) => /hydrat/i.test(e))).toEqual([])
+    } finally {
+      await context.close()
+    }
+  })
+
   test('Visitor views a project detail page unauthenticated', async ({
     page,
     adminPage,

--- a/e2e/tests/10-project-discovery.spec.ts
+++ b/e2e/tests/10-project-discovery.spec.ts
@@ -6,11 +6,31 @@ import { fake } from '../fake'
 // Both the project list and individual project pages redirect unauthenticated
 // visitors to /login via `useRequireApproved`. There is no public / unauthenticated
 // view of projects — the underlying oRPC procedures require an approved, logged-in
-// volunteer too.
+// volunteer too. `/` is the public landing page and deliberately shows no project data.
 test.describe('Unauthenticated Project Access', () => {
   test('Visitor browses the project list unauthenticated', async ({ page, baseUrl }) => {
-    await page.goto(`${baseUrl}/`)
+    await page.goto(`${baseUrl}/projects`)
     await page.waitForURL(`${baseUrl}/login**`, { timeout: 10_000 })
+  })
+
+  test('Visitor sees the public landing page and no project data', async ({
+    page,
+    adminPage,
+    baseUrl,
+  }) => {
+    const title = fake.projectTitle()
+    await adminCreateProject(baseUrl, adminPage, title, 'A project that must not leak to visitors')
+
+    await page.goto(`${baseUrl}/`)
+
+    await expect(page.getByRole('heading', { name: 'Find the work that needs you' })).toBeVisible({
+      timeout: 10_000,
+    })
+    // The CTA appears in both the hero and the closing section
+    await expect(page.getByRole('link', { name: 'Apply to join' }).first()).toBeVisible()
+    await expect(page.getByText(title)).toHaveCount(0)
+    // Still on the landing page — no redirect to /login
+    await expect(page).toHaveURL(`${baseUrl}/`)
   })
 
   test('Visitor views a project detail page unauthenticated', async ({
@@ -49,7 +69,7 @@ test.describe('Pending Volunteer Project Access', () => {
   }) => {
     const { page, context } = await pendingVolunteerPage(browser, baseUrl)
 
-    await page.goto(`${baseUrl}/`)
+    await page.goto(`${baseUrl}/projects`)
     await page.waitForURL(`${baseUrl}/dashboard**`, { timeout: 10_000 })
 
     await context.close()
@@ -80,7 +100,7 @@ test.describe('Project Discovery', () => {
     const title = fake.projectTitle()
     await adminCreateProject(baseUrl, adminPage, title, 'A searchable project for discovery tests')
 
-    await volunteer.page.goto(`${baseUrl}/`)
+    await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(
       volunteer.page.getByRole('heading', { name: 'Projects', exact: true }),
     ).toBeVisible({ timeout: 10_000 })
@@ -99,7 +119,7 @@ test.describe('Project Discovery', () => {
     // Admin-created projects have is_seeking_help = true by default
     await adminCreateProject(baseUrl, adminPage, title, 'Project for seeking-filter discovery test')
 
-    await volunteer.page.goto(`${baseUrl}/`)
+    await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(
       volunteer.page.getByRole('heading', { name: 'Projects', exact: true }),
     ).toBeVisible({ timeout: 10_000 })

--- a/e2e/tests/17-access-control.spec.ts
+++ b/e2e/tests/17-access-control.spec.ts
@@ -17,7 +17,7 @@ test.describe('Access Control', () => {
 
   test('Non-admin cannot access admin triage', async ({ volunteer, baseUrl }) => {
     await volunteer.page.goto(`${baseUrl}/admin/triage`)
-    await volunteer.page.waitForURL(`${baseUrl}/`, { timeout: 10_000 })
+    await volunteer.page.waitForURL(`${baseUrl}/projects`, { timeout: 10_000 })
   })
 
   test("Non-owner cannot update another volunteer's project", async ({

--- a/e2e/tests/19-local-group-suggestions.spec.ts
+++ b/e2e/tests/19-local-group-suggestions.spec.ts
@@ -68,7 +68,7 @@ test.describe('Local Group Suggestions', () => {
 
     await expect(getAlert(adminPage)).toContainText('accepted', { timeout: 10_000 })
 
-    await volunteer.page.goto(`${baseUrl}/`)
+    await volunteer.page.goto(`${baseUrl}/projects`)
     await volunteer.page.waitForLoadState('networkidle', { timeout: 15_000 })
     await selectFilterDropdown(volunteer.page, 'Country/Group filter', `UK - ${groupName}`)
     await expect(volunteer.page.getByLabel('Country/Group filter', { exact: true })).toContainText(
@@ -90,7 +90,7 @@ test.describe('Local Group Suggestions', () => {
 
     await expect(getAlert(adminPage)).toContainText('accepted', { timeout: 10_000 })
 
-    await volunteer.page.goto(`${baseUrl}/`)
+    await volunteer.page.goto(`${baseUrl}/projects`)
     await volunteer.page.waitForLoadState('networkidle', { timeout: 15_000 })
     await selectFilterDropdown(volunteer.page, 'Country/Group filter', `UK - ${adjusted}`)
     await expect(volunteer.page.getByLabel('Country/Group filter', { exact: true })).toContainText(

--- a/lib/hooks/auth.ts
+++ b/lib/hooks/auth.ts
@@ -36,7 +36,7 @@ export function useRequireAdmin() {
   const auth = useAuth()
   useEffect(() => {
     if (!auth.loading && !auth.user) router.replace('/login')
-    if (!auth.loading && auth.user && !auth.user.isAdmin) router.replace('/')
+    if (!auth.loading && auth.user && !auth.user.isAdmin) router.replace('/projects')
   }, [auth.user, auth.loading, router])
   return auth
 }
@@ -46,7 +46,7 @@ export function useRequireSuperAdmin() {
   const auth = useAuth()
   useEffect(() => {
     if (!auth.loading && !auth.user) router.replace('/login')
-    if (!auth.loading && auth.user && !auth.user.isSuperAdmin) router.replace('/')
+    if (!auth.loading && auth.user && !auth.user.isSuperAdmin) router.replace('/projects')
   }, [auth.user, auth.loading, router])
   return auth
 }


### PR DESCRIPTION
## What

`/` was the gated project list, so a logged-out visitor saw a blank page and a redirect to `/login` with no explanation of what Catalyse is or why to join. This adds a real public landing page and moves the project list to `/projects`.

Closes #106

## The page

- **Explains PauseAI UK and the platform**, then the eight areas volunteers work in (campaigns, political engagement, local chapters, events, comms, design, research, software/ops).
- **Answers "will this make a difference?"** with a bridging paragraph framing campaigning as a chain from an ordinary task to a result months later, plus a "Where that work has led" section: three dated wins from [pauseai.uk/track-record](https://pauseai.uk/track-record), each running task through to a political or press outcome.
- **Shows no project data at all.** It fetches nothing about projects, so nothing leaks to unauthenticated visitors. There is an e2e test asserting a real project title never appears on the page.
- **Local group names come from the `local_groups` table**, not a hardcoded list. The hardcoded version was already wrong: it said Glasgow and Oxford, where the actual groups are Scotland and Oxfordshire.

## Routing

- Project list moves to `/projects`, unchanged and still behind `useRequireApproved`.
- Header wordmark points at `/projects` when signed in and `/` when not, preserving the existing "logo goes to the app" behaviour.
- Redirect targets that meant "the project list" (admin guards, project not-found, post-delete) now point at `/projects`.

## Notes for review

- **Copy claims.** The track record items are dated past events rather than live counts, so they do not go stale. The Google DeepMind item is deliberately phrased as sequence, not causation ("Google went on to give…"), because the track record only establishes order. Worth a second opinion from whoever owns the comms line if you want it stronger.
- **`revalidate = 3600`** rather than per-request, since the group list changes rarely. The query is wrapped in try/catch because the database may not be reachable during prerender, and a dropped sentence clause beats a failed build.
- **Hydration.** `AuthProvider` seeds `loading` from `localStorage`, so it is false on the server and true on the client whenever a token exists. `LandingCTA` must not branch on it. There is a regression test that loads `/` with a token and asserts no hydration errors reach the console.
- **Found but not fixed:** `globals.css` styles `h1`/`h2`/`h3` outside a cascade layer, so Tailwind `text-*` utilities on headings are silently ignored sitewide. Same cascade trap as #180. I removed the dead classes from the hero rather than fix it here, since wrapping those rules in `@layer base` would change heading sizes anywhere that currently relies on the override.

## Verification

`npm run check-all`: typecheck, lint and format clean; 152 e2e passed, 4 skipped. Landing page screenshotted at 1440 and 390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017h27AycPWy7HenkinNsNuv