### PR TITLE
refactor: extract useUrlParam and useUrlSearchInput hooks

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useState, Suspense } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { useState, Suspense } from 'react'
+import { useRouter } from 'next/navigation'
 import { useRequireApproved } from '@/lib/hooks/auth'
+import { useUrlParam, useUrlSearchInput } from '@/lib/hooks/url-filters'
 import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
@@ -49,47 +50,20 @@ type ApprovedUser = NonNullable<ReturnType<typeof useRequireApproved>['user']>
 
 function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   const userSkillIds = new Set(user.skills.map((s) => s.id))
-  const searchParams = useSearchParams()
+
+  const [searchInput, setSearchInput, urlSearch] = useUrlSearchInput('q')
+  const [statusFilter, setStatusFilter] = useUrlParam('status')
+  const [needsFilter, setNeedsFilter] = useUrlParam('needs')
+  const [urgencyFilter, setUrgencyFilter] = useUrlParam('urgency')
+  const [locationFilter, setLocationFilter] = useUrlParam('location')
+  const [sortBy, setSortBy] = useUrlParam('sort')
   const router = useRouter()
-
-  const urlSearch = searchParams.get('q') ?? ''
-  const statusFilter = searchParams.get('status') ?? ''
-  const needsFilter = searchParams.get('needs') ?? ''
-  const urgencyFilter = searchParams.get('urgency') ?? ''
-  const locationFilter = searchParams.get('location') ?? ''
-  const sortBy = searchParams.get('sort') ?? ''
-
-  const [searchInput, setSearchInput] = useState(urlSearch)
-  const [completedOpen, setCompletedOpen] = useState(false)
-
-  function setParam(key: string, value: string) {
-    const params = new URLSearchParams(searchParams.toString())
-    if (value) params.set(key, value)
-    else params.delete(key)
-    router.replace(`?${params.toString()}`, { scroll: false })
-  }
-
-  // Debounce search input -> URL. Guard skips the update when searchInput
-  // already matches the URL (on mount or after a URL-driven reset), preventing
-  // a spurious router.replace that races against auth redirects.
-  // searchParams in deps ensures stale filter state is not clobbered if a
-  // dropdown fires during the debounce window.
-  useEffect(() => {
-    if (searchInput === urlSearch) return
-    const t = setTimeout(() => {
-      const params = new URLSearchParams(searchParams.toString())
-      if (searchInput) params.set('q', searchInput)
-      else params.delete('q')
-      router.replace(`?${params.toString()}`, { scroll: false })
-    }, 300)
-    return () => clearTimeout(t)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchInput, searchParams])
-
   function clearFilters() {
     setSearchInput('')
     router.replace('?', { scroll: false })
   }
+
+  const [completedOpen, setCompletedOpen] = useState(false)
 
   const { data: pendingTriageList = [] } = useQuery({
     ...orpc.admin.triage.list.queryOptions(),
@@ -245,7 +219,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
               ariaLabel="Status filter"
               value={statusFilter}
               options={STATUS_OPTIONS}
-              onChange={(v) => setParam('status', v)}
+              onChange={setStatusFilter}
             />
             <FilterDropdown
               id="needs-filter"
@@ -253,7 +227,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
               ariaLabel="Needs filter"
               value={needsFilter}
               options={NEEDS_OPTIONS}
-              onChange={(v) => setParam('needs', v)}
+              onChange={setNeedsFilter}
             />
             <FilterDropdown
               id="urgency-filter"
@@ -261,7 +235,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
               ariaLabel="Urgency filter"
               value={urgencyFilter}
               options={URGENCY_OPTIONS}
-              onChange={(v) => setParam('urgency', v)}
+              onChange={setUrgencyFilter}
             />
 
             <FilterDropdown
@@ -270,7 +244,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
               ariaLabel="Country/Group filter"
               value={locationFilter}
               options={buildLocationOptions(localGroups)}
-              onChange={(v) => setParam('location', v)}
+              onChange={setLocationFilter}
               searchable
             />
 
@@ -280,7 +254,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
               ariaLabel="Sort filter"
               value={sortBy}
               options={SORT_OPTIONS}
-              onChange={(v) => setParam('sort', v)}
+              onChange={setSortBy}
             />
 
             {hasFilters && (

--- a/app/volunteers/page.tsx
+++ b/app/volunteers/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useState, Suspense } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { Suspense } from 'react'
+import { useRouter } from 'next/navigation'
 import { useRequireAuth } from '@/lib/hooks/auth'
+import { useUrlParam, useUrlSearchInput } from '@/lib/hooks/url-filters'
 import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
@@ -21,39 +22,10 @@ type Volunteer = InferRouterOutputs<AppRouter>['volunteers']['list']['volunteers
 type AuthUser = NonNullable<ReturnType<typeof useRequireAuth>['user']>
 
 function VolunteersPageContent({ user }: { user: AuthUser }) {
-  const searchParams = useSearchParams()
+  const [searchInput, setSearchInput, urlSearch] = useUrlSearchInput('q')
+  const [skillFilter, setSkillFilter] = useUrlParam('skill')
+  const [locationFilter, setLocationFilter] = useUrlParam('location')
   const router = useRouter()
-
-  const urlSearch = searchParams.get('q') ?? ''
-  const skillFilter = searchParams.get('skill') ?? ''
-  const locationFilter = searchParams.get('location') ?? ''
-
-  const [searchInput, setSearchInput] = useState(urlSearch)
-
-  function setParam(key: string, value: string) {
-    const params = new URLSearchParams(searchParams.toString())
-    if (value) params.set(key, value)
-    else params.delete(key)
-    router.replace(`?${params.toString()}`, { scroll: false })
-  }
-
-  // Debounce search input -> URL. Guard skips the update when searchInput
-  // already matches the URL (on mount or after a URL-driven reset), preventing
-  // a spurious router.replace that races against auth redirects.
-  // searchParams in deps ensures stale filter state is not clobbered if a
-  // dropdown fires during the debounce window.
-  useEffect(() => {
-    if (searchInput === urlSearch) return
-    const t = setTimeout(() => {
-      const params = new URLSearchParams(searchParams.toString())
-      if (searchInput) params.set('q', searchInput)
-      else params.delete('q')
-      router.replace(`?${params.toString()}`, { scroll: false })
-    }, 300)
-    return () => clearTimeout(t)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchInput, searchParams])
-
   function clearFilters() {
     setSearchInput('')
     router.replace('?', { scroll: false })
@@ -117,7 +89,7 @@ function VolunteersPageContent({ user }: { user: AuthUser }) {
                 { value: '', label: 'All skills' },
                 ...allSkills.map((s) => ({ value: String(s.id), label: s.name })),
               ]}
-              onChange={(v) => setParam('skill', v)}
+              onChange={setSkillFilter}
               searchable
             />
 
@@ -127,7 +99,7 @@ function VolunteersPageContent({ user }: { user: AuthUser }) {
               ariaLabel="Country/Group filter"
               value={locationFilter}
               options={buildLocationOptions(localGroups)}
-              onChange={(v) => setParam('location', v)}
+              onChange={setLocationFilter}
               searchable
             />
 

--- a/lib/hooks/url-filters.ts
+++ b/lib/hooks/url-filters.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+
+function useSetParam() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  return useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value) params.set(key, value)
+      else params.delete(key)
+      router.replace(`?${params.toString()}`, { scroll: false })
+    },
+    [searchParams, router],
+  )
+}
+
+/**
+ * Reads a URL search param and returns an immediate setter (no debounce).
+ * Suitable for dropdown filters.
+ */
+export function useUrlParam(key: string): [string, (value: string) => void] {
+  const searchParams = useSearchParams()
+  const setParam = useSetParam()
+  const value = searchParams.get(key) ?? ''
+  const setValue = useCallback((v: string) => setParam(key, v), [key, setParam])
+  return [value, setValue]
+}
+
+/**
+ * Manages a text search input with a debounced URL write.
+ *
+ * Returns [inputValue, setInputValue, urlValue] where:
+ * - inputValue / setInputValue drive the <input> element directly
+ * - urlValue is the committed (debounced) value to pass to API queries
+ *
+ * The effect is skipped when inputValue already matches the URL to prevent
+ * a spurious router.replace on mount that would race auth redirects.
+ */
+export function useUrlSearchInput(
+  key: string,
+  delayMs = 300,
+): [string, (value: string) => void, string] {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const urlValue = searchParams.get(key) ?? ''
+  const [input, setInput] = useState(urlValue)
+
+  useEffect(() => {
+    if (input === urlValue) return
+    const t = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (input) params.set(key, input)
+      else params.delete(key)
+      router.replace(`?${params.toString()}`, { scroll: false })
+    }, delayMs)
+    return () => clearTimeout(t)
+  }, [input, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return [input, setInput, urlValue]
+}


### PR DESCRIPTION
## Summary

Extracts shared URL filter logic from `/projects` and `/volunteers` pages into two reusable hooks in `lib/hooks/url-filters.ts`:

- **`useUrlParam(key)`** — reads a URL param, returns an immediate setter. For dropdown filters.
- **`useUrlSearchInput(key)`** — local input state with a debounced URL write. Returns `[input, setInput, urlValue]` where `urlValue` is the committed value for API queries.

Stacks on #195.

## Why

Each page had identical inline logic for debouncing, stale-params protection, and `router.replace`. Any future filtered list page can now reach for these hooks directly.

## Test plan

- [x] All checks pass (typecheck, lint, format, e2e)
- Behaviour unchanged — this is a pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016moySCBt7gqS4rQnVMnuWi