### PR TITLE
Add cron job audit trail and superadmin panel

### DIFF
--- a/app/admin/cron-runs/page.tsx
+++ b/app/admin/cron-runs/page.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useState } from 'react'
+import { useRequireSuperAdmin } from '@/lib/hooks/auth'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { orpc } from '@/lib/orpc'
+import { formatDateTime } from '@/lib/format-date'
+import { Badge, type BadgeVariant } from '@/components/Badge'
+import { useToast } from '@/lib/toast'
+import { CRON_JOB_NAMES, CRON_JOB_INFO } from '@/lib/cron-job-names'
+import Button from '@/components/Button'
+import Modal from '@/components/ui/Modal'
+
+type CronRun = {
+  id: number
+  jobName: string
+  status: string
+  startedAt: string | Date
+  finishedAt: string | Date | null
+  summary: string | null
+}
+
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+  running: 'info',
+  success: 'success',
+  error: 'danger',
+}
+
+function duration(startedAt: string | Date, finishedAt: string | Date | null): string {
+  if (!finishedAt) return '—'
+  const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime()
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+export default function AdminCronRunsPage() {
+  const { user, loading } = useRequireSuperAdmin()
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+  const [selectedRun, setSelectedRun] = useState<CronRun | null>(null)
+
+  const { data: runs = [], isLoading: loadingData } = useQuery({
+    ...orpc.admin.cronRuns.list.queryOptions({ input: {} }),
+    enabled: !!user?.isSuperAdmin,
+  })
+
+  const runMutation = useMutation({
+    ...orpc.admin.cronRuns.run.mutationOptions(),
+    onSuccess: (_data, variables) => {
+      showToast(`${variables.jobName} finished`, 'success')
+      void queryClient.invalidateQueries({ queryKey: orpc.admin.cronRuns.list.key() })
+    },
+    onError: (_error, variables) => showToast(`${variables.jobName} failed`, 'error'),
+  })
+
+  if (loading || !user?.isSuperAdmin) return null
+
+  return (
+    <main className="container py-5 pb-15">
+      <h1>Cron Job Runs</h1>
+
+      <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {CRON_JOB_NAMES.map((jobName) => {
+          const info = CRON_JOB_INFO[jobName]
+          return (
+            <div
+              key={jobName}
+              className="border border-brand-border rounded-lg p-4 flex flex-col gap-2"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-semibold">{jobName}</span>
+                <Badge variant={info.idempotent ? 'success' : 'warning'}>
+                  {info.idempotent ? 'idempotent' : 'not idempotent'}
+                </Badge>
+              </div>
+              <p className="text-sm text-text-light m-0 flex-1">{info.description}</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={runMutation.isPending}
+                onClick={() => runMutation.mutate({ jobName })}
+              >
+                {runMutation.isPending && runMutation.variables?.jobName === jobName
+                  ? 'Running…'
+                  : 'Run now'}
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+
+      {loadingData ? (
+        <div className="text-center py-10 text-text-light">Loading…</div>
+      ) : runs.length === 0 ? (
+        <p>No cron job runs recorded yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b-2 border-brand-border text-left">
+                <th className="p-3">Job</th>
+                <th className="p-3">Status</th>
+                <th className="p-3">Started</th>
+                <th className="p-3">Finished</th>
+                <th className="p-3">Duration</th>
+                <th className="p-3">Summary</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((run) => (
+                <tr
+                  key={run.id}
+                  className="border-b border-brand-border align-top cursor-pointer hover:bg-accent"
+                  onClick={() => setSelectedRun(run)}
+                >
+                  <td className="p-3 font-semibold whitespace-nowrap">{run.jobName}</td>
+                  <td className="p-3">
+                    <Badge variant={STATUS_VARIANT[run.status] ?? 'neutral'}>{run.status}</Badge>
+                  </td>
+                  <td className="p-3 whitespace-nowrap">{formatDateTime(run.startedAt)}</td>
+                  <td className="p-3 whitespace-nowrap">
+                    {run.finishedAt ? formatDateTime(run.finishedAt) : '—'}
+                  </td>
+                  <td className="p-3 whitespace-nowrap">
+                    {duration(run.startedAt, run.finishedAt)}
+                  </td>
+                  <td className="p-3 text-text-light wrap-break-word max-w-md truncate">
+                    {run.summary ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Modal
+        id="cron-run-detail"
+        title={selectedRun ? `${selectedRun.jobName} — ${selectedRun.status}` : ''}
+        isOpen={!!selectedRun}
+        onClose={() => setSelectedRun(null)}
+      >
+        {selectedRun && (
+          <div>
+            <p className="text-sm text-text-light mb-1">
+              Started: {formatDateTime(selectedRun.startedAt)}
+            </p>
+            <p className="text-sm text-text-light mb-3">
+              Finished:{' '}
+              {selectedRun.finishedAt ? formatDateTime(selectedRun.finishedAt) : 'still running'}
+            </p>
+            <pre className="whitespace-pre-wrap wrap-break-word text-xs bg-black/5 dark:bg-white/5 rounded-lg p-3 max-h-96 overflow-y-auto">
+              {selectedRun.summary ?? 'No summary recorded.'}
+            </pre>
+          </div>
+        )}
+      </Modal>
+    </main>
+  )
+}

--- a/app/api/cron/applications-anonymisation/route.ts
+++ b/app/api/cron/applications-anonymisation/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { checkCronAuth } from '@/lib/cron-auth'
-import { runApplicationsAnonymisationJob } from '@/jobs/applications'
+import { CRON_JOBS } from '@/lib/cron-jobs'
 
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const result = await runApplicationsAnonymisationJob()
+  const result = await CRON_JOBS['applications-anonymisation']()
   return NextResponse.json({ anonymisation: result })
 }

--- a/app/api/cron/applications-summary/route.ts
+++ b/app/api/cron/applications-summary/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { checkCronAuth } from '@/lib/cron-auth'
-import { runApplicationsSummaryJob } from '@/jobs/applications'
+import { CRON_JOBS } from '@/lib/cron-jobs'
 
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const result = await runApplicationsSummaryJob()
+  const result = await CRON_JOBS['applications-summary']()
   return NextResponse.json({ applications: result })
 }

--- a/app/api/cron/backup/route.ts
+++ b/app/api/cron/backup/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { checkCronAuth } from '@/lib/cron-auth'
-import { runBackupJob } from '@/jobs/backup'
+import { CRON_JOBS } from '@/lib/cron-jobs'
 
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const result = await runBackupJob()
+  const result = await CRON_JOBS.backup()
   return NextResponse.json({ backup: result })
 }

--- a/app/api/cron/daily/route.ts
+++ b/app/api/cron/daily/route.ts
@@ -1,29 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { checkCronAuth } from '@/lib/cron-auth'
-import { runBackupJob } from '@/jobs/backup'
-import { runDigestJob } from '@/jobs/digest'
-import { runNudgesJob } from '@/jobs/nudges'
-import { runApplicationsSummaryJob, runApplicationsAnonymisationJob } from '@/jobs/applications'
-
-const JOBS: { name: string; run: () => Promise<unknown> }[] = [
-  { name: 'backup', run: runBackupJob },
-  { name: 'digest', run: runDigestJob },
-  { name: 'nudges', run: runNudgesJob },
-  { name: 'applications', run: runApplicationsSummaryJob },
-  { name: 'anonymisation', run: runApplicationsAnonymisationJob },
-]
+import { CRON_JOBS, CRON_JOB_NAMES } from '@/lib/cron-jobs'
 
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const results = await Promise.allSettled(JOBS.map((j) => j.run()))
+  const results = await Promise.allSettled(CRON_JOB_NAMES.map((name) => CRON_JOBS[name]()))
 
   const body = Object.fromEntries(
-    JOBS.map((job, i) => {
+    CRON_JOB_NAMES.map((name, i) => {
       const r = results[i]
-      return [job.name, r.status === 'fulfilled' ? r.value : { error: String(r.reason) }]
+      return [name, r.status === 'fulfilled' ? r.value : { error: String(r.reason) }]
     }),
   )
 

--- a/app/api/cron/digest/route.ts
+++ b/app/api/cron/digest/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { checkCronAuth } from '@/lib/cron-auth'
-import { runDigestJob } from '@/jobs/digest'
+import { CRON_JOBS } from '@/lib/cron-jobs'
 
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const result = await runDigestJob()
+  const result = await CRON_JOBS.digest()
   return NextResponse.json({ digest: result })
 }

--- a/app/api/cron/nudges/route.ts
+++ b/app/api/cron/nudges/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { checkCronAuth } from '@/lib/cron-auth'
-import { runNudgesJob } from '@/jobs/nudges'
+import { CRON_JOBS } from '@/lib/cron-jobs'
 
 // Can be triggered manually: POST with Authorization: Bearer <CRON_SECRET>
 export async function POST(request: NextRequest) {
   const authError = checkCronAuth(request)
   if (authError) return authError
 
-  const result = await runNudgesJob()
+  const result = await CRON_JOBS.nudges()
   return NextResponse.json(result)
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -119,6 +119,7 @@ const ADMIN_NAV_ITEMS: { href: string; label: string; superAdminOnly?: boolean }
   { href: '/admin/stats', label: 'Platform Stats' },
   { href: '/admin/applications', label: 'Manage Applications', superAdminOnly: true },
   { href: '/admin/platform-settings', label: 'Platform Settings', superAdminOnly: true },
+  { href: '/admin/cron-runs', label: 'Cron Job Runs', superAdminOnly: true },
   { href: '/admin/local-groups', label: 'Manage Local Groups' },
 ]
 

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -89,7 +89,7 @@ export function ProjectCard({
   action?: React.ReactNode
 }) {
   return (
-    <div className="card bg-surface rounded-xl shadow px-5 pt-5 pb-4 overflow-hidden wrap-break-word grid grid-rows-subgrid row-span-6 gap-y-2 relative">
+    <div className="card bg-surface rounded-xl shadow px-5 pt-5 pb-4 overflow-hidden wrap-break-word grid grid-rows-subgrid row-span-6 gap-y-2 relative min-w-0">
       <div className="card-header row-start-1">
         <Link
           role="link"
@@ -117,7 +117,7 @@ export function ProjectCard({
         {p.timeCommitmentHoursPerWeek && <span>🕐 {p.timeCommitmentHoursPerWeek}h/week</span>}
         {p.urgency && <span>⚡ {p.urgency} priority</span>}
       </div>
-      <p className="row-start-4 text-text-light text-sm m-0">
+      <p className="row-start-4 min-w-0 text-text-light text-sm m-0 wrap-break-word">
         {p.description
           ? `${p.description.slice(0, 150)}${p.description.length > 150 ? '…' : ''}`
           : ''}

--- a/jobs/applications.ts
+++ b/jobs/applications.ts
@@ -5,7 +5,17 @@ import { sendPendingApplicationsSummaryEmail } from '@/lib/email'
 import { APPLICATION_ANONYMISATION_MS } from '@/lib/applications'
 import { ApprovalStatus } from '@/generated/prisma/enums'
 
+function startOfToday(): Date {
+  const now = new Date()
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+}
+
 export async function runApplicationsSummaryJob(): Promise<Record<string, unknown>> {
+  const sentToday = await prisma.applicationsSummaryRun.findFirst({
+    where: { sentAt: { gte: startOfToday() } },
+  })
+  if (sentToday) return { skipped: true, reason: 'already sent today' }
+
   const count = await prisma.volunteer.count({
     where: {
       approvalStatus: { in: [ApprovalStatus.pending, ApprovalStatus.under_review] },
@@ -32,6 +42,7 @@ export async function runApplicationsSummaryJob(): Promise<Record<string, unknow
     }
   }
 
+  await prisma.applicationsSummaryRun.create({ data: {} })
   return { sent, pending: count }
 }
 

--- a/lib/cron-audit.ts
+++ b/lib/cron-audit.ts
@@ -1,0 +1,37 @@
+import { prisma } from '@/lib/prisma'
+
+const SUMMARY_MAX_LENGTH = 2000
+
+function summarize(result: unknown): string {
+  try {
+    return JSON.stringify(result)?.slice(0, SUMMARY_MAX_LENGTH) ?? String(result)
+  } catch {
+    return String(result).slice(0, SUMMARY_MAX_LENGTH)
+  }
+}
+
+export async function recordCronRun<T>(jobName: string, fn: () => Promise<T>): Promise<T> {
+  const run = await prisma.cronJobRun.create({
+    data: { jobName, status: 'running' },
+  })
+
+  try {
+    const result = await fn()
+    await prisma.cronJobRun.update({
+      where: { id: run.id },
+      data: { finishedAt: new Date(), status: 'success', summary: summarize(result) },
+    })
+    return result
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    await prisma.cronJobRun.update({
+      where: { id: run.id },
+      data: {
+        finishedAt: new Date(),
+        status: 'error',
+        summary: message.slice(0, SUMMARY_MAX_LENGTH),
+      },
+    })
+    throw err
+  }
+}

--- a/lib/cron-job-names.ts
+++ b/lib/cron-job-names.ts
@@ -1,0 +1,33 @@
+export const CRON_JOB_NAMES = [
+  'backup',
+  'digest',
+  'nudges',
+  'applications-summary',
+  'applications-anonymisation',
+] as const
+
+export type CronJobName = (typeof CRON_JOB_NAMES)[number]
+
+export const CRON_JOB_INFO: Record<CronJobName, { description: string; idempotent: boolean }> = {
+  backup: {
+    description: 'Snapshots the database locally and uploads it to B2, then prunes old backups.',
+    idempotent: false,
+  },
+  digest: {
+    description: 'Emails volunteers a fortnightly digest of new matching projects.',
+    idempotent: true,
+  },
+  nudges: {
+    description:
+      'Emails nudges/warnings for stale in-progress tasks, and surrenders tasks inactive 28+ days.',
+    idempotent: true,
+  },
+  'applications-summary': {
+    description: 'Emails superadmins a count of pending volunteer applications.',
+    idempotent: true,
+  },
+  'applications-anonymisation': {
+    description: 'Anonymises rejected applications past the retention period.',
+    idempotent: true,
+  },
+}

--- a/lib/cron-jobs.ts
+++ b/lib/cron-jobs.ts
@@ -1,0 +1,17 @@
+import { recordCronRun } from '@/lib/cron-audit'
+import { runBackupJob } from '@/jobs/backup'
+import { runDigestJob } from '@/jobs/digest'
+import { runNudgesJob } from '@/jobs/nudges'
+import { runApplicationsSummaryJob, runApplicationsAnonymisationJob } from '@/jobs/applications'
+import { type CronJobName } from '@/lib/cron-job-names'
+
+export { CRON_JOB_NAMES, type CronJobName } from '@/lib/cron-job-names'
+
+export const CRON_JOBS: Record<CronJobName, () => Promise<unknown>> = {
+  backup: () => recordCronRun('backup', runBackupJob),
+  digest: () => recordCronRun('digest', runDigestJob),
+  nudges: () => recordCronRun('nudges', runNudgesJob),
+  'applications-summary': () => recordCronRun('applications-summary', runApplicationsSummaryJob),
+  'applications-anonymisation': () =>
+    recordCronRun('applications-anonymisation', runApplicationsAnonymisationJob),
+}

--- a/prisma/migrations/20260808112100_add_cron_job_runs/migration.sql
+++ b/prisma/migrations/20260808112100_add_cron_job_runs/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "cron_job_runs" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "job_name" TEXT NOT NULL,
+    "started_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finished_at" DATETIME,
+    "status" TEXT NOT NULL,
+    "summary" TEXT
+);
+
+-- CreateIndex
+CREATE INDEX "idx_cron_job_runs_job_name" ON "cron_job_runs"("job_name");
+

--- a/prisma/migrations/20260808115454_fix_digest_runs_sent_at_type/migration.sql
+++ b/prisma/migrations/20260808115454_fix_digest_runs_sent_at_type/migration.sql
@@ -1,0 +1,15 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_digest_runs" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "type" TEXT NOT NULL,
+    "sent_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_digest_runs" ("id", "sent_at", "type") SELECT "id", "sent_at", "type" FROM "digest_runs";
+DROP TABLE "digest_runs";
+ALTER TABLE "new_digest_runs" RENAME TO "digest_runs";
+CREATE INDEX "idx_digest_runs_type" ON "digest_runs"("type");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+

--- a/prisma/migrations/20260808120909_add_applications_summary_runs/migration.sql
+++ b/prisma/migrations/20260808120909_add_applications_summary_runs/migration.sql
@@ -1,0 +1,6 @@
+-- CreateTable
+CREATE TABLE "applications_summary_runs" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "sent_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -399,6 +399,25 @@ model DigestRun {
   @@map("digest_runs")
 }
 
+model ApplicationsSummaryRun {
+  id     Int      @id @default(autoincrement())
+  sentAt DateTime @default(now()) @map("sent_at")
+
+  @@map("applications_summary_runs")
+}
+
+model CronJobRun {
+  id         Int       @id @default(autoincrement())
+  jobName    String    @map("job_name")
+  startedAt  DateTime  @default(now()) @map("started_at")
+  finishedAt DateTime? @map("finished_at")
+  status     String // running | success | error
+  summary    String?
+
+  @@index([jobName], map: "idx_cron_job_runs_job_name")
+  @@map("cron_job_runs")
+}
+
 /// Not exposed via Prisma Client — no valid unique identifier.
 model SchemaMigration {
   filename  String?   @id

--- a/server/router.ts
+++ b/server/router.ts
@@ -29,6 +29,7 @@ import { adminTriageRouter } from './routers/admin/triage'
 import { adminInterestsRouter } from './routers/admin/interests'
 import { adminEmailPreviewRouter } from './routers/admin/emailPreview'
 import { adminRejectedApplicationsRouter } from './routers/admin/rejectedApplications'
+import { adminCronRunsRouter } from './routers/admin/cronRuns'
 import { versionRouter } from './routers/version'
 
 export const appRouter = {
@@ -65,6 +66,7 @@ export const appRouter = {
     interests: adminInterestsRouter,
     emailPreview: adminEmailPreviewRouter,
     rejectedApplications: adminRejectedApplicationsRouter,
+    cronRuns: adminCronRunsRouter,
   },
 }
 

--- a/server/routers/admin/cronRuns.ts
+++ b/server/routers/admin/cronRuns.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { CRON_JOBS } from '@/lib/cron-jobs'
+import { CRON_JOB_NAMES, type CronJobName } from '@/lib/cron-job-names'
+import { superAdminProcedure } from '../../procedures'
+
+export const adminCronRunsRouter = {
+  list: superAdminProcedure
+    .input(z.object({ jobName: z.string().optional(), status: z.string().optional() }))
+    .handler(async ({ input }) => {
+      return prisma.cronJobRun.findMany({
+        where: {
+          ...(input.jobName ? { jobName: input.jobName } : {}),
+          ...(input.status ? { status: input.status } : {}),
+        },
+        orderBy: { startedAt: 'desc' },
+        take: 200,
+      })
+    }),
+
+  run: superAdminProcedure
+    .input(z.object({ jobName: z.enum([...CRON_JOB_NAMES] as [CronJobName, ...CronJobName[]]) }))
+    .handler(async ({ input }) => {
+      const result = await CRON_JOBS[input.jobName]()
+      return { result }
+    }),
+}


### PR DESCRIPTION
## Summary
- New `cron_job_runs` table records start/finish/status/summary for every cron job run, via a shared `lib/cron-jobs.ts` registry used by all `/api/cron/*` routes.
- New superadmin panel at `/admin/cron-runs` — job descriptions/idempotency, run history table, click a row for the full summary, and a "Run now" button per job.
- Fix: `digest_runs.sent_at` was declared `TEXT` instead of `DATETIME`, which made Prisma unable to read back its own writes and was silently breaking the digest cron. New migration rebuilds the column with the correct type.
- Fix: `applications-summary` job now has a same-day guard (new `applications_summary_runs` table), so triggering the daily cron more than once a day can't double-email admins.
- Unrelated small fix: long unbroken URLs in project descriptions were overflowing card width (`ProjectCard.tsx`) — added `min-w-0` to fix grid-item wrapping.

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full test suite) green
- [x] Manually hit `/api/cron/daily` locally with the real `CRON_SECRET`; confirmed all 5 jobs run and audit rows are recorded
- [x] Confirmed `digest_runs` fix resolves the P2023 read error that was crashing the digest job
- [x] Verified applications-summary same-day guard skips on second same-day run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FafPq3ZtCj54mjiTTPWGaM