### PR TITLE
fix: show featured project tasks to admins on the Quick Tasks page

### DIFF
--- a/app/quick-tasks/page.tsx
+++ b/app/quick-tasks/page.tsx
@@ -41,10 +41,30 @@ interface Volunteer {
   name: string
 }
 
+interface FeaturedProjectTask {
+  id: number
+  projectId: number
+  projectTitle: string | null
+  title: string
+  status: string
+  assignedToId: number | null
+  assignedToName: string | null
+  estimatedHours: number | null
+  createdAt: string
+}
+
 const STATUS_VARIANTS: Record<string, BadgeVariant> = {
   open: 'warning',
   in_progress: 'info',
   under_review: 'caution',
+  completed: 'success',
+}
+
+// Project tasks use TaskStatus (open/in_progress/completed), not QuickTaskStatus —
+// no under_review here, since submitting for review is a quick-task-only concept.
+const PROJECT_TASK_STATUS_VARIANTS: Record<string, BadgeVariant> = {
+  open: 'warning',
+  in_progress: 'info',
   completed: 'success',
 }
 
@@ -349,6 +369,12 @@ function AdminQuickTasksView() {
     enabled: !!user?.isAdmin,
   })
   const tasks = tasksRaw as unknown as AdminQuickTask[]
+
+  const { data: featuredProjectTasksRaw = [] } = useQuery({
+    ...orpc.quickTasks.featuredProjectTasks.queryOptions(),
+    enabled: !!user?.isAdmin,
+  })
+  const featuredProjectTasks = featuredProjectTasksRaw as unknown as FeaturedProjectTask[]
 
   const { data: skillCats = [] } = useQuery({
     ...orpc.skills.list.queryOptions(),
@@ -745,6 +771,57 @@ function AdminQuickTasksView() {
               </div>
             )
           })
+        )}
+
+        {featuredProjectTasks.length > 0 && (
+          <>
+            <h2 className="mt-8">Featured project tasks</h2>
+            <p className="text-text-light mb-6">
+              Project tasks flagged to also appear on this page for volunteers. Manage them (edit,
+              assign, unassign) from their own project — this list is for visibility only.
+            </p>
+            {featuredProjectTasks.map((task) => (
+              <div
+                key={`project-task-${task.id}`}
+                role="article"
+                className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
+              >
+                <div className="flex justify-between items-start gap-3 min-w-0 mb-2">
+                  <div className="min-w-0">
+                    <h3 className="mb-1">
+                      <Link href={`/projects/${task.projectId}/tasks/${task.id}`}>
+                        {task.title}
+                      </Link>
+                    </h3>
+                    <div className="text-text-light flex gap-2 flex-wrap text-[0.8rem]">
+                      {task.projectTitle && (
+                        <span>
+                          Part of:{' '}
+                          <Link href={`/projects/${task.projectId}`}>{task.projectTitle}</Link>
+                        </span>
+                      )}
+                      {task.estimatedHours !== null && <span>~{task.estimatedHours}h</span>}
+                      {task.assignedToId && task.assignedToName && (
+                        <span>
+                          Assigned to:{' '}
+                          <Link href={`/admin/volunteers/${task.assignedToId}`}>
+                            {task.assignedToName}
+                          </Link>
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <Badge
+                    role="status"
+                    variant={PROJECT_TASK_STATUS_VARIANTS[task.status] ?? 'neutral'}
+                    className="whitespace-nowrap shrink-0"
+                  >
+                    {task.status}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </>
         )}
       </main>
 

--- a/e2e/tests/22-quick-tasks.spec.ts
+++ b/e2e/tests/22-quick-tasks.spec.ts
@@ -117,6 +117,56 @@ test.describe('Quick Tasks: self-serve', () => {
     expect(autoInterest?.message).toContain(taskTitle)
   })
 
+  test('A superadmin sees a featured project task on the Quick Tasks admin page', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const taskTitle = `Admin-visible-flagged ${Date.now()}`
+    const projectCreated = await adminApi.admin.projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'Admin visibility test project',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: true,
+        isSeekingOwner: false,
+        tasks: [{ title: 'Seed task' }],
+      },
+    })
+    const projectId = (projectCreated.body as { id: number }).id
+
+    const taskCreated = await adminApi.projects.createTask({
+      body: { projectId, title: taskTitle, featuredAsQuickTask: true },
+    })
+    const taskId = (taskCreated.body as { id: number }).id
+
+    // Regression: the admin Quick Tasks page only ever queried real QuickTask rows
+    // (quickTasks.list), never project tasks flagged featuredAsQuickTask — so a task
+    // flagged this way was invisible here even though it correctly appeared in the
+    // volunteer-facing browse pool.
+    await adminPage.goto(`${baseUrl}/quick-tasks`)
+    await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(
+      adminPage.getByRole('heading', { name: 'Featured project tasks', level: 2 }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    const card = adminPage.getByRole('article').filter({ hasText: taskTitle })
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    await expect(card.getByRole('link', { name: taskTitle })).toHaveAttribute(
+      'href',
+      `/projects/${projectId}/tasks/${taskId}`,
+    )
+    await expect(card.getByRole('status')).toContainText('open')
+  })
+
   test('Self-claim does not create a duplicate interest for a volunteer who already has one', async ({
     baseUrl,
   }) => {

--- a/server/routers/quickTasks.ts
+++ b/server/routers/quickTasks.ts
@@ -55,6 +55,36 @@ export const quickTasksRouter = {
       }))
     }),
 
+  // Project tasks flagged featuredAsQuickTask, regardless of status/assignee — so an admin
+  // checking this page can confirm a flag actually took effect and see who holds it,
+  // instead of only being able to see it once claimed via `available` (open+unclaimed only).
+  // Management (edit/assign/unassign) still happens on the task's own project page — these
+  // aren't WorkItemType.QUICK_TASK rows, so the quick-task-specific mutations don't apply.
+  featuredProjectTasks: adminProcedure.handler(async () => {
+    const tasks = await prisma.workItem.findMany({
+      where: { type: WorkItemType.TASK, featuredAsQuickTask: true },
+      include: {
+        parent: { select: { id: true, title: true } },
+        assignee: { select: { name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return tasks
+      .filter((t) => t.parentId !== null)
+      .map((t) => ({
+        id: t.id,
+        projectId: t.parentId as number,
+        projectTitle: t.parent?.title ?? null,
+        title: t.title,
+        status: t.status,
+        assignedToId: t.assigneeId,
+        assignedToName: t.assignee?.name ?? null,
+        estimatedHours: t.estimatedHours,
+        createdAt: t.createdAt,
+      }))
+  }),
+
   // The open, unclaimed browse pool: real quick tasks plus project tasks a
   // project owner/admin has flagged to also surface here (featuredAsQuickTask).
   available: approvedProcedure.handler(async ({ context }) => {


### PR DESCRIPTION
## Summary
Root cause of the report: a superadmin flags a project task as a Quick Task, then checks `/quick-tasks` and doesn't see it. The admin view of that page only ever queried real `QuickTask` rows (`quickTasks.list`) — it never looked at project tasks flagged `featuredAsQuickTask`. The volunteer-facing "Browse Quick Tasks" pool already handles both kinds correctly (`quickTasks.available`), so this was admin-only blind spot.

- `server/routers/quickTasks.ts`: new `featuredProjectTasks` admin query, returning all featured project tasks regardless of status/assignee (not just open+unclaimed like `available`) — an admin needs to see the full picture, including ones already claimed or completed.
- `app/quick-tasks/page.tsx`: new "Featured project tasks" read-only section on the admin view, linking each task back to its project page. Editing/assigning still happens there — these are project `TASK` rows, not `QUICK_TASK` rows, so the quick-task-specific mutations don't apply.
- `e2e/tests/22-quick-tasks.spec.ts`: regression test.

## Test plan
- [x] `npm run check-all` — typecheck, lint, format, full e2e suite: 179 passed, 5 skipped, 0 failed
- [x] New test: admin flags a project task, visits `/quick-tasks`, confirms it appears under "Featured project tasks" with a working link back to the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkp5UGb1ym3kw8FLj7275n