### PR TITLE
Scope match alerts by location; make project status a lifecycle

### DIFF
--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -14,6 +14,7 @@ import {
   CARD_GRID_CLASSES,
 } from '@/components/ProjectCard'
 import Tabs from '@/components/Tabs'
+import { badgeClasses } from '@/components/Badge'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
@@ -201,12 +202,12 @@ export default function TriagePage() {
                         </p>
                       </div>
                       <span
-                        className={statusBadgeClasses(
+                        className={badgeClasses(
                           i.status === InterestStatus.pending
-                            ? 'seeking_help'
+                            ? 'caution'
                             : i.status === InterestStatus.accepted
-                              ? 'completed'
-                              : 'on_hold',
+                              ? 'success'
+                              : 'neutral',
                         )}
                       >
                         {i.status}

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -58,7 +58,6 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [remoteEligibility, setRemoteEligibility] = useState<'NONE' | 'COUNTRY' | 'GLOBAL'>('NONE')
   const [estimatedDuration, setEstimatedDuration] = useState('')
   const [seekingHelp, setSeekingHelp] = useState(true)
-  const [seekingOwner, setSeekingOwner] = useState(true)
 
   const { data: localGroupsData } = useQuery({
     ...orpc.localGroups.list.queryOptions({ input: {} }),
@@ -89,7 +88,6 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     setRemoteEligibility(data.remoteEligibility ?? 'NONE')
     setEstimatedDuration(data.estimatedDuration ?? '')
     setSeekingHelp(data.isSeekingHelp ?? false)
-    setSeekingOwner(data.isSeekingOwner ?? false)
     const isOwner = data.ownerId === user?.id || data.proposedById === user?.id
     setCanEdit(isOwner || (user?.isAdmin ?? false))
     setPermissionChecked(true)
@@ -129,7 +127,6 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
       remoteEligibility,
       estimatedDuration: estimatedDuration.trim() || null,
       isSeekingHelp: seekingHelp,
-      isSeekingOwner: seekingOwner,
     })
   }
 
@@ -289,6 +286,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             <SkillPicker value={skills} onChange={canEdit ? setSkills : () => {}} />
           </div>
 
+          {/* There is no "needs an owner" checkbox: a project needs one exactly when it
+              hasn't got one, so it's derived rather than asked for. Ownership is changed
+              from the project page's owner menu. */}
           <div className="mb-5">
             <p className="font-medium mb-2">This project needs:</p>
             <div className="flex flex-col gap-2">
@@ -298,13 +298,6 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
                 disabled={!canEdit}
               >
                 Help / contributors
-              </Checkbox>
-              <Checkbox
-                checked={seekingOwner}
-                onChange={(e) => setSeekingOwner(e.target.checked)}
-                disabled={!canEdit}
-              >
-                An owner / lead
               </Checkbox>
             </div>
           </div>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -31,6 +31,12 @@ const PROJECT_TYPES = [
   { value: 'one_off', label: 'One-off task' },
 ] as const
 
+const REMOTE_ELIGIBILITY_OPTIONS = [
+  { value: 'NONE', label: 'No - in-person / local only' },
+  { value: 'COUNTRY', label: 'Yes - remote OK, within the same country' },
+  { value: 'GLOBAL', label: 'Yes - remote OK, from any country' },
+] as const
+
 export default function EditProjectPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = use(params)
   const router = useRouter()
@@ -49,6 +55,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [hoursPerWeek, setHoursPerWeek] = useState('')
   const [urgency, setUrgency] = useState('medium')
   const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
+  const [remoteEligibility, setRemoteEligibility] = useState<'NONE' | 'COUNTRY' | 'GLOBAL'>('NONE')
   const [estimatedDuration, setEstimatedDuration] = useState('')
   const [seekingHelp, setSeekingHelp] = useState(true)
   const [seekingOwner, setSeekingOwner] = useState(true)
@@ -79,6 +86,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     const country = data.country ?? ''
     const localGroup = data.localGroup ?? ''
     setLocationValue(country && localGroup ? `${country}:${localGroup}` : country)
+    setRemoteEligibility(data.remoteEligibility ?? 'NONE')
     setEstimatedDuration(data.estimatedDuration ?? '')
     setSeekingHelp(data.isSeekingHelp ?? false)
     setSeekingOwner(data.isSeekingOwner ?? false)
@@ -118,6 +126,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
       urgency,
       country: country || null,
       localGroup: localGroup || null,
+      remoteEligibility,
       estimatedDuration: estimatedDuration.trim() || null,
       isSeekingHelp: seekingHelp,
       isSeekingOwner: seekingOwner,
@@ -246,6 +255,20 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             />
             <p className="text-sm text-text-light mt-1">
               Local groups appear indented under their country.
+            </p>
+          </div>
+
+          <div className="mb-5">
+            <FilterDropdown
+              id="remote-eligibility"
+              label="Can this be done remotely?"
+              ariaLabel="Select remote eligibility"
+              value={remoteEligibility}
+              options={REMOTE_ELIGIBILITY_OPTIONS}
+              onChange={setRemoteEligibility}
+            />
+            <p className="text-sm text-text-light mt-1">
+              Controls who gets project-match alerts outside the country above.
             </p>
           </div>
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -21,6 +21,7 @@ import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
+import { projectLocationParts } from '@/lib/filter-options'
 import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 import type { InferRouterOutputs } from '@orpc/server'
 import type { AppRouter } from '@/server/router'
@@ -724,6 +725,18 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           <Badge variant={projectStatusVariant(project.status)} aria-label="project status">
             {STATUS_LABELS[project.status] ?? project.status}
           </Badge>
+          {(() => {
+            const parts = projectLocationParts(
+              project.country,
+              project.localGroup,
+              project.remoteEligibility,
+            )
+            return (
+              parts.length > 0 && (
+                <span className="text-sm text-text-light">📍 {parts.join(' · ')}</span>
+              )
+            )
+          })()}
           {isOwnerOrAdmin && (
             <Button href={`/projects/${idParam}/edit`} variant="secondary" size="sm">
               Edit

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -45,10 +45,11 @@ import { CSS } from '@dnd-kit/utilities'
 
 type ProjectTask = InferRouterOutputs<AppRouter>['projects']['getById']['tasks'][number]
 
+// 'needs_tasks' is deliberately excluded — it's a system-derived state (an assigned
+// project with zero open tasks), never a status someone should pick from a menu.
+// The server auto-promotes it back to 'in_progress' as soon as a task is added.
 const OWNER_STATUSES = [
   { value: 'seeking_owner', label: 'Seeking Owner' },
-  { value: 'seeking_help', label: 'Seeking Help' },
-  { value: 'needs_tasks', label: 'Needs Tasks' },
   { value: 'in_progress', label: 'In Progress' },
   { value: 'on_hold', label: 'On Hold' },
   { value: 'completed', label: 'Completed' },
@@ -539,7 +540,16 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     (project.isSeekingHelp || project.isSeekingOwner) &&
     !['completed', 'archived'].includes(project.status)
 
-  const statusOptions = isAdmin ? [...OWNER_STATUSES, ...ADMIN_EXTRA_STATUSES] : OWNER_STATUSES
+  const pickableStatuses = isAdmin ? [...OWNER_STATUSES, ...ADMIN_EXTRA_STATUSES] : OWNER_STATUSES
+  // If the project is currently sitting in a non-pickable derived status (e.g.
+  // 'needs_tasks'), still surface it so the control displays the real current value —
+  // it just isn't offered as something to switch *to* from any other status.
+  const statusOptions = pickableStatuses.some((o) => o.value === project.status)
+    ? pickableStatuses
+    : [
+        { value: project.status, label: STATUS_LABELS[project.status] ?? project.status },
+        ...pickableStatuses,
+      ]
 
   // Excludes the current owner — they're already shown in the Owner box above.
   const volunteerInterests = (project.interests ?? []).filter(
@@ -1093,7 +1103,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
           <div className="lg:col-span-1 min-w-0 flex flex-col gap-4">
             {/* Status */}
             <div className={card}>
-              <h2>Status</h2>
+              <div className="flex items-center justify-between gap-2 mb-3">
+                <h2 className="m-0">Status</h2>
+                {isOwnerOrAdmin && (
+                  <Button href={`/projects/${idParam}/edit`} variant="secondary" size="sm">
+                    Edit Project
+                  </Button>
+                )}
+              </div>
               {isOwnerOrAdmin ? (
                 <FilterDropdown
                   id="change-status"
@@ -1127,16 +1144,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                   )
                 )
               })()}
-              {isOwnerOrAdmin && (
-                <Button
-                  href={`/projects/${idParam}/edit`}
-                  variant="secondary"
-                  size="sm"
-                  className="mt-3"
-                >
-                  Edit
-                </Button>
-              )}
               <Modal
                 id="confirm-status-change"
                 title="Change project status?"

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -10,11 +10,7 @@ import Button from '@/components/Button'
 import Checkbox from '@/components/Checkbox'
 import { Badge, badgeClasses, badgeColorClasses } from '@/components/Badge'
 import Tooltip from '@/components/Tooltip'
-import {
-  STATUS_LABELS,
-  INTEREST_STATUS_LABELS,
-  projectStatusVariant,
-} from '@/components/ProjectCard'
+import { INTEREST_STATUS_LABELS, projectStatusVariant } from '@/components/ProjectCard'
 import CommentThread from '@/components/CommentThread'
 import Modal from '@/components/ui/Modal'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
@@ -22,6 +18,12 @@ import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
 import { projectLocationParts } from '@/lib/filter-options'
+import {
+  ADMIN_ONLY_STATUSES,
+  OWNER_ALLOWED_STATUSES,
+  TERMINAL_STATUSES,
+  projectStatusLabel,
+} from '@/lib/project-status'
 import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 import type { InferRouterOutputs } from '@orpc/server'
 import type { AppRouter } from '@/server/router'
@@ -45,21 +47,12 @@ import { CSS } from '@dnd-kit/utilities'
 
 type ProjectTask = InferRouterOutputs<AppRouter>['projects']['getById']['tasks'][number]
 
-// 'needs_tasks' is deliberately excluded — it's a system-derived state (an assigned
-// project with zero open tasks), never a status someone should pick from a menu.
-// The server auto-promotes it back to 'in_progress' as soon as a task is added.
-const OWNER_STATUSES = [
-  { value: 'seeking_owner', label: 'Seeking Owner' },
-  { value: 'in_progress', label: 'In Progress' },
-  { value: 'on_hold', label: 'On Hold' },
-  { value: 'completed', label: 'Completed' },
-]
-
-const ADMIN_EXTRA_STATUSES = [
-  { value: 'archived', label: 'Archived' },
-  { value: 'pending_review', label: 'Pending Review' },
-  { value: 'needs_discussion', label: 'Needs Discussion' },
-]
+// Both lists come from lib/project-status.ts, which the server's permission check reads
+// too — they used to be hand-synced copies.
+const toOptions = (statuses: string[]) =>
+  statuses.map((value) => ({ value, label: projectStatusLabel(value) }))
+const OWNER_STATUSES = toOptions(OWNER_ALLOWED_STATUSES)
+const ADMIN_EXTRA_STATUSES = toOptions(ADMIN_ONLY_STATUSES)
 
 // ── Tailwind class constants ──────────────────────────────────────────────────
 
@@ -538,18 +531,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   const canSeeInterest =
     !isOwnerOrAdmin &&
     (project.isSeekingHelp || project.isSeekingOwner) &&
-    !['completed', 'archived'].includes(project.status)
+    !TERMINAL_STATUSES.includes(project.status)
 
   const pickableStatuses = isAdmin ? [...OWNER_STATUSES, ...ADMIN_EXTRA_STATUSES] : OWNER_STATUSES
-  // If the project is currently sitting in a non-pickable derived status (e.g.
-  // 'needs_tasks'), still surface it so the control displays the real current value —
-  // it just isn't offered as something to switch *to* from any other status.
+  // Every status is pickable by someone now, but an owner viewing a project an admin put
+  // into an admin-only status still needs the control to show its real current value.
   const statusOptions = pickableStatuses.some((o) => o.value === project.status)
     ? pickableStatuses
-    : [
-        { value: project.status, label: STATUS_LABELS[project.status] ?? project.status },
-        ...pickableStatuses,
-      ]
+    : [{ value: project.status, label: projectStatusLabel(project.status) }, ...pickableStatuses]
 
   // Excludes the current owner — they're already shown in the Owner box above.
   const volunteerInterests = (project.interests ?? []).filter(
@@ -1129,9 +1118,16 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                 />
               ) : (
                 <Badge variant={projectStatusVariant(project.status)} aria-label="project status">
-                  {STATUS_LABELS[project.status] ?? project.status}
+                  {projectStatusLabel(project.status)}
                 </Badge>
               )}
+              <div className="flex gap-1 flex-wrap mt-2">
+                {project.isSeekingOwner && project.status !== ProjectStatus.ready && (
+                  <Badge variant="caution">Seeking Owner</Badge>
+                )}
+                {project.isSeekingHelp && <Badge variant="caution">Seeking Help</Badge>}
+                {project.needsTasks && <Badge variant="warning">Needs Tasks</Badge>}
+              </div>
               {(() => {
                 const parts = projectLocationParts(
                   project.country,
@@ -1151,11 +1147,8 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                 onClose={() => setPendingStatus(null)}
               >
                 <p>
-                  Change status from <strong>{STATUS_LABELS[newStatus] ?? newStatus}</strong> to{' '}
-                  <strong>
-                    {pendingStatus ? (STATUS_LABELS[pendingStatus] ?? pendingStatus) : ''}
-                  </strong>
-                  ?
+                  Change status from <strong>{projectStatusLabel(newStatus)}</strong> to{' '}
+                  <strong>{pendingStatus ? projectStatusLabel(pendingStatus) : ''}</strong>?
                 </p>
                 <div className="mt-4 flex justify-end gap-2">
                   <Button variant="secondary" onClick={() => setPendingStatus(null)}>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1122,9 +1122,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                 </Badge>
               )}
               <div className="flex gap-1 flex-wrap mt-2">
-                {project.isSeekingOwner && project.status !== ProjectStatus.ready && (
-                  <Badge variant="caution">Seeking Owner</Badge>
-                )}
+                {project.isSeekingOwner && <Badge variant="caution">Seeking Owner</Badge>}
                 {project.isSeekingHelp && <Badge variant="caution">Seeking Help</Badge>}
                 {project.needsTasks && <Badge variant="warning">Needs Tasks</Badge>}
               </div>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Checkbox from '@/components/Checkbox'
-import { Badge } from '@/components/Badge'
+import { Badge, badgeClasses, badgeColorClasses } from '@/components/Badge'
 import Tooltip from '@/components/Tooltip'
 import {
   STATUS_LABELS,
@@ -63,6 +63,11 @@ const ADMIN_EXTRA_STATUSES = [
 // ── Tailwind class constants ──────────────────────────────────────────────────
 
 const card = 'bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word'
+
+// The status select's trigger is colored like a Badge, but as a full-width, clickable pill.
+function statusTriggerClasses(status: string) {
+  return `w-full flex items-center justify-between gap-2 px-3 py-2 rounded-full text-sm font-semibold cursor-pointer focus:outline-none focus:ring-2 focus:ring-secondary transition-colors ${badgeColorClasses(projectStatusVariant(status))}`
+}
 
 // ── Task list item ──────────────────────────────────────────────────────────
 
@@ -721,30 +726,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     <>
       <main className="container py-5 pb-15">
         {/* [test hook] projectContent id used by action helpers to confirm page has loaded */}
-        <div id="projectContent" className="flex items-center gap-3 flex-wrap mb-2">
-          <Badge variant={projectStatusVariant(project.status)} aria-label="project status">
-            {STATUS_LABELS[project.status] ?? project.status}
-          </Badge>
-          {(() => {
-            const parts = projectLocationParts(
-              project.country,
-              project.localGroup,
-              project.remoteEligibility,
-            )
-            return (
-              parts.length > 0 && (
-                <span className="text-sm text-text-light">📍 {parts.join(' · ')}</span>
-              )
-            )
-          })()}
-          {isOwnerOrAdmin && (
-            <Button href={`/projects/${idParam}/edit`} variant="secondary" size="sm">
-              Edit
-            </Button>
-          )}
-        </div>
-
-        <h1 role="heading" aria-level={1}>
+        <h1 id="projectContent" role="heading" aria-level={1}>
           {project.title}
         </h1>
 
@@ -1109,6 +1091,76 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
           {/* Sidebar */}
           <div className="lg:col-span-1 min-w-0 flex flex-col gap-4">
+            {/* Status */}
+            <div className={card}>
+              <h2>Status</h2>
+              {isOwnerOrAdmin ? (
+                <FilterDropdown
+                  id="change-status"
+                  label="Status"
+                  ariaLabel="project status"
+                  value={newStatus}
+                  options={statusOptions}
+                  onChange={handleSelectStatus}
+                  triggerClassName={statusTriggerClasses(newStatus)}
+                  renderOption={(opt) => (
+                    <span className={badgeClasses(projectStatusVariant(opt.value))}>
+                      {opt.label}
+                    </span>
+                  )}
+                  hideLabel
+                />
+              ) : (
+                <Badge variant={projectStatusVariant(project.status)} aria-label="project status">
+                  {STATUS_LABELS[project.status] ?? project.status}
+                </Badge>
+              )}
+              {(() => {
+                const parts = projectLocationParts(
+                  project.country,
+                  project.localGroup,
+                  project.remoteEligibility,
+                )
+                return (
+                  parts.length > 0 && (
+                    <p className="text-sm text-text-light mt-3 mb-0">📍 {parts.join(' · ')}</p>
+                  )
+                )
+              })()}
+              {isOwnerOrAdmin && (
+                <Button
+                  href={`/projects/${idParam}/edit`}
+                  variant="secondary"
+                  size="sm"
+                  className="mt-3"
+                >
+                  Edit
+                </Button>
+              )}
+              <Modal
+                id="confirm-status-change"
+                title="Change project status?"
+                isOpen={pendingStatus !== null}
+                onClose={() => setPendingStatus(null)}
+              >
+                <p>
+                  Change status from <strong>{STATUS_LABELS[newStatus] ?? newStatus}</strong> to{' '}
+                  <strong>
+                    {pendingStatus ? (STATUS_LABELS[pendingStatus] ?? pendingStatus) : ''}
+                  </strong>
+                  ?
+                </p>
+                <div className="mt-4 flex justify-end gap-2">
+                  <Button variant="secondary" onClick={() => setPendingStatus(null)}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleConfirmStatus} disabled={updateProjectMutation.isPending}>
+                    {updateProjectMutation.isPending ? 'Updating…' : 'Confirm'}
+                  </Button>
+                </div>
+              </Modal>
+            </div>
+
             {/* Admin triage */}
             {isAdmin &&
               (project.status === ProjectStatus.pending_review ||
@@ -1189,46 +1241,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                     {setOutcomeMutation.isPending ? 'Recording…' : 'Record Outcome'}
                   </Button>
                 </form>
-              </div>
-            )}
-
-            {/* Manage status */}
-            {isOwnerOrAdmin && (
-              <div className={card}>
-                <h2>Manage Project Status</h2>
-                <FilterDropdown
-                  id="change-status"
-                  label="Change Status"
-                  ariaLabel="Change Status"
-                  value={newStatus}
-                  options={statusOptions}
-                  onChange={handleSelectStatus}
-                />
-                <Modal
-                  id="confirm-status-change"
-                  title="Change project status?"
-                  isOpen={pendingStatus !== null}
-                  onClose={() => setPendingStatus(null)}
-                >
-                  <p>
-                    Change status from <strong>{STATUS_LABELS[newStatus] ?? newStatus}</strong> to{' '}
-                    <strong>
-                      {pendingStatus ? (STATUS_LABELS[pendingStatus] ?? pendingStatus) : ''}
-                    </strong>
-                    ?
-                  </p>
-                  <div className="mt-4 flex justify-end gap-2">
-                    <Button variant="secondary" onClick={() => setPendingStatus(null)}>
-                      Cancel
-                    </Button>
-                    <Button
-                      onClick={handleConfirmStatus}
-                      disabled={updateProjectMutation.isPending}
-                    >
-                      {updateProjectMutation.isPending ? 'Updating…' : 'Confirm'}
-                    </Button>
-                  </div>
-                </Modal>
               </div>
             )}
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -19,6 +19,7 @@ import { ProjectStatus } from '@/generated/prisma/enums'
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All Active' },
+  { value: 'ready', label: 'Ready' },
   { value: 'in_progress', label: 'In Progress' },
   { value: 'on_hold', label: 'On Hold' },
   { value: 'completed', label: 'Completed' },
@@ -143,7 +144,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
       (p) =>
         !p.isSeekingHelp &&
         !p.isSeekingOwner &&
-        !['in_progress', 'on_hold', 'completed'].includes(p.status),
+        !['ready', 'in_progress', 'on_hold', 'completed'].includes(p.status),
     ),
   )
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -14,6 +14,7 @@ import { ORPCError } from '@orpc/client'
 import { orpc } from '@/lib/orpc'
 import { AppRouter } from '@/server/router'
 import { type Project, ProjectList, statusBadgeClasses } from '@/components/ProjectCard'
+import { badgeClasses } from '@/components/Badge'
 import { ProjectStatus } from '@/generated/prisma/enums'
 
 const STATUS_OPTIONS = [
@@ -306,7 +307,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
             {!statusFilter && !needsFilter && projects.length > 1 && (
               <div className="flex flex-wrap gap-2 mb-6">
                 {seeking.length > 0 && (
-                  <span className={statusBadgeClasses('seeking_help')}>
+                  <span className={badgeClasses('caution')}>
                     Looking for People: {seeking.length}
                   </span>
                 )}

--- a/app/quick-tasks/page.tsx
+++ b/app/quick-tasks/page.tsx
@@ -46,6 +46,7 @@ interface FeaturedProjectTask {
   projectId: number
   projectTitle: string | null
   title: string
+  description: string
   status: string
   assignedToId: number | null
   assignedToName: string | null
@@ -333,7 +334,6 @@ function AdminQuickTasksView() {
     '',
   )
   const toast = useToast()
-  const [expandedCards, setExpandedCards] = useState<Set<number>>(new Set())
   // useRef so the hash is captured client-side in a useEffect (useState initializer runs on server)
   const deepLinkHash = useRef('')
 
@@ -353,6 +353,12 @@ function AdminQuickTasksView() {
 
   // Assign — inline dropdown per task, matching the project-task assign pattern
   const [taskAssignSelections, setTaskAssignSelections] = useState<Record<number, string>>({})
+
+  // Assign for featured project tasks — same inline dropdown, backed by the project
+  // task mutations (these rows are WorkItemType.TASK, not QUICK_TASK).
+  const [projectTaskAssignSelections, setProjectTaskAssignSelections] = useState<
+    Record<number, string>
+  >({})
 
   // Review modal
   const [reviewModal, setReviewModal] = useState<AdminQuickTask | null>(null)
@@ -390,18 +396,17 @@ function AdminQuickTasksView() {
   })
   const volunteers: Volunteer[] = (volunteersData?.volunteers ?? []) as Volunteer[]
 
+  // Cards are always fully expanded now, so a deep link just needs to scroll to the
+  // right card rather than toggle anything open.
   useEffect(() => {
-    function expandFromHash(hash: string) {
+    function scrollToHash(hash: string) {
       if (!hash.startsWith('#task-')) return
-      const taskId = parseInt(hash.slice('#task-'.length), 10)
-      if (isNaN(taskId)) return
-      setExpandedCards((prev) => new Set(prev).add(taskId))
+      document.getElementById(hash.slice(1))?.scrollIntoView({ block: 'start' })
     }
     deepLinkHash.current = window.location.hash
     const onHashChange = () => {
       deepLinkHash.current = window.location.hash
-      // Tasks are already loaded when a hashchange fires mid-session
-      expandFromHash(deepLinkHash.current)
+      scrollToHash(deepLinkHash.current)
     }
     window.addEventListener('hashchange', onHashChange)
     return () => window.removeEventListener('hashchange', onHashChange)
@@ -411,19 +416,8 @@ function AdminQuickTasksView() {
   useEffect(() => {
     const hash = deepLinkHash.current
     if (!hash.startsWith('#task-') || tasks.length === 0) return
-    const taskId = parseInt(hash.slice('#task-'.length), 10)
-    if (isNaN(taskId)) return
-    setExpandedCards((prev) => new Set(prev).add(taskId))
+    document.getElementById(hash.slice(1))?.scrollIntoView({ block: 'start' })
   }, [tasks])
-
-  function toggleCard(id: number) {
-    setExpandedCards((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
 
   const createTaskMutation = useMutation({
     ...orpc.quickTasks.create.mutationOptions(),
@@ -471,6 +465,31 @@ function AdminQuickTasksView() {
     onSuccess: () => {
       toast('Assignee removed', 'success')
       void queryClient.invalidateQueries({ queryKey: orpc.quickTasks.list.key() })
+    },
+    onError: (err: unknown) =>
+      toast(err instanceof Error ? err.message : 'Failed to unassign', 'error'),
+  })
+
+  const assignProjectTaskMutation = useMutation({
+    ...orpc.projects.assignTask.mutationOptions(),
+    onSuccess: (_data, variables) => {
+      toast('Task assigned!', 'success')
+      setProjectTaskAssignSelections((s) => {
+        const next = { ...s }
+        delete next[variables.taskId]
+        return next
+      })
+      void queryClient.invalidateQueries({ queryKey: orpc.quickTasks.featuredProjectTasks.key() })
+    },
+    onError: (err: unknown) =>
+      toast(err instanceof Error ? err.message : 'Failed to assign', 'error'),
+  })
+
+  const unassignProjectTaskMutation = useMutation({
+    ...orpc.projects.updateTask.mutationOptions(),
+    onSuccess: () => {
+      toast('Assignee removed', 'success')
+      void queryClient.invalidateQueries({ queryKey: orpc.quickTasks.featuredProjectTasks.key() })
     },
     onError: (err: unknown) =>
       toast(err instanceof Error ? err.message : 'Failed to unassign', 'error'),
@@ -537,6 +556,24 @@ function AdminQuickTasksView() {
     unassignTaskMutation.mutate({ id: taskId })
   }
 
+  function handleAssignProjectTask(task: FeaturedProjectTask) {
+    const selected = projectTaskAssignSelections[task.id]
+    if (!selected) return
+    assignProjectTaskMutation.mutate({
+      projectId: task.projectId,
+      taskId: task.id,
+      assigneeId: parseInt(selected, 10),
+    })
+  }
+
+  function handleUnassignProjectTask(task: FeaturedProjectTask) {
+    unassignProjectTaskMutation.mutate({
+      projectId: task.projectId,
+      taskId: task.id,
+      data: { status: TaskStatus.open },
+    })
+  }
+
   function deleteTask(task: AdminQuickTask) {
     if (!confirm(`Delete "${task.title}"? This cannot be undone.`)) return
     deleteTaskMutation.mutate({ id: task.id })
@@ -598,219 +635,146 @@ function AdminQuickTasksView() {
             </p>
           </div>
         ) : (
-          tasks.map((task) => {
-            const expanded = expandedCards.has(task.id)
-            return (
-              <div
-                key={task.id}
-                role="article"
-                id={`task-${task.id}`}
-                className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
-              >
-                <div
-                  className={`card-header flex justify-between items-start gap-3 min-w-0 cursor-pointer ${expanded ? 'mb-3' : 'mb-0'}`}
-                  onClick={() => toggleCard(task.id)}
+          tasks.map((task) => (
+            <div
+              key={task.id}
+              role="article"
+              id={`task-${task.id}`}
+              className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
+            >
+              <div className="flex justify-between items-start gap-3 mb-2">
+                <h3 className="m-0">{task.title}</h3>
+                <Badge
+                  role="status"
+                  variant={STATUS_VARIANTS[task.status] ?? 'neutral'}
+                  className="whitespace-nowrap shrink-0"
                 >
-                  <div className="flex items-start gap-2 min-w-0">
-                    <span
-                      className="inline-block transition-transform shrink-0 mt-1 text-text-light text-xs"
-                      // dynamic: transform rotates based on expanded state
-                      style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
-                    >
-                      ▶
-                    </span>
-                    <div className="min-w-0">
-                      <h3 className="mb-1">{task.title}</h3>
-                      <div className="text-text-light flex gap-2 flex-wrap text-[0.8rem]">
-                        {task.skillName && <span>Skill: {task.skillName}</span>}
-                        {task.estimatedHours !== null && <span>~{task.estimatedHours}h</span>}
-                        {task.assignedToId && task.assignedToName && (
-                          <span>
-                            Assigned to:{' '}
-                            <Link
-                              href={`/admin/volunteers/${task.assignedToId}`}
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              {task.assignedToName}
-                            </Link>
-                          </span>
-                        )}
-                        {task.reviewRating && (
-                          <span className={RATING_CLASSES[task.reviewRating]}>
-                            {RATING_LABELS[task.reviewRating]}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                  <Badge
-                    role="status"
-                    variant={STATUS_VARIANTS[task.status] ?? 'neutral'}
-                    className="whitespace-nowrap shrink-0"
-                  >
-                    {task.status}
-                  </Badge>
-                </div>
+                  {task.status}
+                </Badge>
+              </div>
 
-                {expanded && (
-                  <>
-                    <p className="whitespace-pre-wrap mb-3 text-[0.9rem]">{task.description}</p>
-
-                    {task.reviewRating && (
-                      <p className={`mb-2 font-medium ${RATING_CLASSES[task.reviewRating]}`}>
-                        Rating: {RATING_LABELS[task.reviewRating]}
-                      </p>
-                    )}
-                    {task.reviewNotes && (
-                      <p className="text-sm text-text-light mb-2">Notes: {task.reviewNotes}</p>
-                    )}
-
-                    <div className="mb-3">
-                      <strong className="text-sm">Comments</strong>
-                      <CommentThread workItemId={task.id} />
-                    </div>
-
-                    {task.status === QuickTaskStatus.open && (
-                      <div
-                        className="flex gap-2 items-end mb-3"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <div className="flex-1 max-w-75">
-                          <FilterDropdown
-                            id={`assign-task-${task.id}`}
-                            label="Assign to"
-                            ariaLabel={`Assign volunteer to ${task.title}`}
-                            value={taskAssignSelections[task.id] ?? ''}
-                            options={[
-                              { value: '', label: 'Select volunteer…' },
-                              ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                            ]}
-                            onChange={(v) =>
-                              setTaskAssignSelections((s) => ({ ...s, [task.id]: v }))
-                            }
-                            searchable
-                          />
-                        </div>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          disabled={!taskAssignSelections[task.id] || assignTaskMutation.isPending}
-                          onClick={() => handleAssignTask(task.id)}
-                        >
-                          Assign
-                        </Button>
-                      </div>
-                    )}
-
-                    <div className="flex justify-between items-center mt-3 pt-3 border-t border-brand-border">
-                      <span className="text-sm text-text-light">
-                        Created {formatDate(task.createdAt)}
-                      </span>
-                      <div className="flex gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            void copyLink(task.id)
-                          }}
-                        >
-                          Copy share link
-                        </Button>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            openEdit(task)
-                          }}
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          variant="danger"
-                          size="sm"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            deleteTask(task)
-                          }}
-                        >
-                          Delete
-                        </Button>
-                        {task.assignedToId && (
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            disabled={unassignTaskMutation.isPending}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              handleUnassignTask(task.id)
-                            }}
-                          >
-                            Unassign
-                          </Button>
-                        )}
-                        {task.status === QuickTaskStatus.under_review && (
-                          <Button
-                            size="sm"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setReviewModal(task)
-                              setReviewRating('good')
-                              setReviewFeedback('')
-                              setReviewNotes('')
-                            }}
-                          >
-                            Review
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  </>
+              <div className="flex gap-2 mb-3 flex-wrap items-center">
+                {task.skillName && (
+                  <span className="inline-flex items-center px-3 py-1 bg-accent text-secondary-dark rounded-full text-sm font-medium dark:bg-gray-700 dark:text-gray-300">
+                    {task.skillName}
+                  </span>
+                )}
+                {task.estimatedHours !== null && (
+                  <span className="text-text-light text-sm">~{task.estimatedHours}h</span>
+                )}
+                {task.assignedToId && task.assignedToName && (
+                  <span className="text-text-light text-sm">
+                    Assigned to:{' '}
+                    <Link href={`/admin/volunteers/${task.assignedToId}`}>
+                      {task.assignedToName}
+                    </Link>
+                  </span>
+                )}
+                {task.reviewRating && (
+                  <span className={`text-sm ${RATING_CLASSES[task.reviewRating]}`}>
+                    {RATING_LABELS[task.reviewRating]}
+                  </span>
                 )}
               </div>
-            )
-          })
+
+              <p className="whitespace-pre-wrap mb-4">{task.description}</p>
+
+              {task.reviewNotes && (
+                <p className="text-sm text-text-light mb-3">Notes: {task.reviewNotes}</p>
+              )}
+
+              <div className="mb-3">
+                <strong className="text-sm">Comments</strong>
+                <CommentThread workItemId={task.id} />
+              </div>
+
+              {task.status === QuickTaskStatus.open && (
+                <div className="flex gap-2 items-end mb-3">
+                  <div className="flex-1 max-w-75">
+                    <FilterDropdown
+                      id={`assign-task-${task.id}`}
+                      label="Assign to"
+                      ariaLabel={`Assign volunteer to ${task.title}`}
+                      value={taskAssignSelections[task.id] ?? ''}
+                      options={[
+                        { value: '', label: 'Select volunteer…' },
+                        ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
+                      ]}
+                      onChange={(v) => setTaskAssignSelections((s) => ({ ...s, [task.id]: v }))}
+                      searchable
+                    />
+                  </div>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={!taskAssignSelections[task.id] || assignTaskMutation.isPending}
+                    onClick={() => handleAssignTask(task.id)}
+                  >
+                    Assign
+                  </Button>
+                </div>
+              )}
+
+              <div className="flex justify-between items-center mt-3 pt-3 border-t border-brand-border">
+                <span className="text-sm text-text-light">
+                  Created {formatDate(task.createdAt)}
+                </span>
+                <div className="flex gap-2">
+                  <Button variant="ghost" size="sm" onClick={() => void copyLink(task.id)}>
+                    Copy share link
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={() => openEdit(task)}>
+                    Edit
+                  </Button>
+                  <Button variant="danger" size="sm" onClick={() => deleteTask(task)}>
+                    Delete
+                  </Button>
+                  {task.assignedToId && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={unassignTaskMutation.isPending}
+                      onClick={() => handleUnassignTask(task.id)}
+                    >
+                      Unassign
+                    </Button>
+                  )}
+                  {task.status === QuickTaskStatus.under_review && (
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        setReviewModal(task)
+                        setReviewRating('good')
+                        setReviewFeedback('')
+                        setReviewNotes('')
+                      }}
+                    >
+                      Review
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))
         )}
 
         {featuredProjectTasks.length > 0 && (
           <>
             <h2 className="mt-8">Featured project tasks</h2>
             <p className="text-text-light mb-6">
-              Project tasks flagged to also appear on this page for volunteers. Manage them (edit,
-              assign, unassign) from their own project — this list is for visibility only.
+              Project tasks flagged to also appear on this page for volunteers. Assign or unassign
+              them here, or edit them from their own project.
             </p>
             {featuredProjectTasks.map((task) => (
               <div
                 key={`project-task-${task.id}`}
                 role="article"
-                className="card bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
+                className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
               >
-                <div className="flex justify-between items-start gap-3 min-w-0 mb-2">
-                  <div className="min-w-0">
-                    <h3 className="mb-1">
-                      <Link href={`/projects/${task.projectId}/tasks/${task.id}`}>
-                        {task.title}
-                      </Link>
-                    </h3>
-                    <div className="text-text-light flex gap-2 flex-wrap text-[0.8rem]">
-                      {task.projectTitle && (
-                        <span>
-                          Part of:{' '}
-                          <Link href={`/projects/${task.projectId}`}>{task.projectTitle}</Link>
-                        </span>
-                      )}
-                      {task.estimatedHours !== null && <span>~{task.estimatedHours}h</span>}
-                      {task.assignedToId && task.assignedToName && (
-                        <span>
-                          Assigned to:{' '}
-                          <Link href={`/admin/volunteers/${task.assignedToId}`}>
-                            {task.assignedToName}
-                          </Link>
-                        </span>
-                      )}
-                    </div>
-                  </div>
+                <div className="flex justify-between items-start gap-3 mb-2">
+                  <h3 className="m-0">
+                    <Link href={`/projects/${task.projectId}/tasks/${task.id}`}>{task.title}</Link>
+                  </h3>
                   <Badge
                     role="status"
                     variant={PROJECT_TASK_STATUS_VARIANTS[task.status] ?? 'neutral'}
@@ -819,6 +783,70 @@ function AdminQuickTasksView() {
                     {task.status}
                   </Badge>
                 </div>
+
+                <div className="flex gap-2 mb-3 flex-wrap items-center">
+                  {task.projectTitle && (
+                    <span className="text-text-light text-sm">
+                      Part of: <Link href={`/projects/${task.projectId}`}>{task.projectTitle}</Link>
+                    </span>
+                  )}
+                  {task.estimatedHours !== null && (
+                    <span className="text-text-light text-sm">~{task.estimatedHours}h</span>
+                  )}
+                  {task.assignedToId && task.assignedToName && (
+                    <span className="text-text-light text-sm">
+                      Assigned to:{' '}
+                      <Link href={`/admin/volunteers/${task.assignedToId}`}>
+                        {task.assignedToName}
+                      </Link>
+                    </span>
+                  )}
+                </div>
+
+                {task.description && <p className="whitespace-pre-wrap mb-4">{task.description}</p>}
+
+                {task.status === TaskStatus.open && (
+                  <div className="flex gap-2 items-end mt-3">
+                    <div className="flex-1 max-w-75">
+                      <FilterDropdown
+                        id={`assign-project-task-${task.id}`}
+                        label="Assign to"
+                        ariaLabel={`Assign volunteer to ${task.title}`}
+                        value={projectTaskAssignSelections[task.id] ?? ''}
+                        options={[
+                          { value: '', label: 'Select volunteer…' },
+                          ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
+                        ]}
+                        onChange={(v) =>
+                          setProjectTaskAssignSelections((s) => ({ ...s, [task.id]: v }))
+                        }
+                        searchable
+                      />
+                    </div>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={
+                        !projectTaskAssignSelections[task.id] || assignProjectTaskMutation.isPending
+                      }
+                      onClick={() => handleAssignProjectTask(task)}
+                    >
+                      Assign
+                    </Button>
+                  </div>
+                )}
+                {task.assignedToId && (
+                  <div className="mt-3">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={unassignProjectTaskMutation.isPending}
+                      onClick={() => handleUnassignProjectTask(task)}
+                    >
+                      Unassign
+                    </Button>
+                  </div>
+                )}
               </div>
             ))}
           </>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -89,6 +89,7 @@ function SettingsPageContent() {
     ],
     'none',
   )
+  const [notifyRemoteProjects, setNotifyRemoteProjects] = useState(false)
   const [consentMakeProfileVisibleInDirectory, setConsentMakeProfileVisibleInDirectory] =
     useState(true)
   const [consentContactableByProjectOwners, setConsentContactableByProjectOwners] = useState(true)
@@ -169,6 +170,7 @@ function SettingsPageContent() {
     setContactPreference(me.contactPreference ?? '')
     setContactNotes(me.contactNotes ?? '')
     setEmailDigest(me.emailDigest ?? 'none')
+    setNotifyRemoteProjects(!!me.notifyRemoteProjects)
     setOtherSkills(me.otherSkills ?? '')
     setConsentMakeProfileVisibleInDirectory(!!me.consentMakeProfileVisibleInDirectory)
     setConsentContactableByProjectOwners(!!me.consentContactableByProjectOwners)
@@ -275,6 +277,7 @@ function SettingsPageContent() {
       contactPreference: contactPreference || null,
       contactNotes: contactNotes.trim() || null,
       emailDigest,
+      notifyRemoteProjects,
       otherSkills: otherSkills.trim() || null,
       skillIds: skills.map((s) => s.skillId),
       consentMakeProfileVisibleInDirectory,
@@ -658,6 +661,19 @@ function SettingsPageContent() {
               options={emailDigestOptions}
               onChange={setEmailDigest}
             />
+          </div>
+          <div className="mb-5">
+            <Checkbox
+              id="notify_remote_projects"
+              checked={notifyRemoteProjects}
+              onChange={(e) => setNotifyRemoteProjects(e.target.checked)}
+            >
+              Also alert me about remote-friendly projects outside my own country
+            </Checkbox>
+            <p className="text-sm text-text-light mt-1 ml-7">
+              By default you only hear about projects based in your own country. Turn this on to
+              also get alerts for projects elsewhere that are marked remote-friendly worldwide.
+            </p>
           </div>
           {saveButton}
         </form>

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -16,6 +16,12 @@ export function badgeClasses(variant: BadgeVariant, className = '') {
   return `status-badge inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${BADGE_VARIANTS[variant]} ${className}`.trim()
 }
 
+// Just the color classes, with none of badgeClasses' layout utilities — for
+// callers building their own pill-shaped control (e.g. a colored select trigger).
+export function badgeColorClasses(variant: BadgeVariant) {
+  return BADGE_VARIANTS[variant]
+}
+
 export function Badge({
   variant = 'neutral',
   className = '',

--- a/components/FilterDropdown.tsx
+++ b/components/FilterDropdown.tsx
@@ -35,6 +35,16 @@ interface Props<T extends string = string> {
   onChange: (value: T) => void
   searchable?: boolean
   required?: boolean
+  // Full override of the trigger button's classes, for callers that need a
+  // custom look (e.g. a colored pill) instead of the default bordered box.
+  triggerClassName?: string
+  // Full override of an option's rendered content, for a custom look per option
+  // (e.g. a colored pill matching that option's own color). Selection/focus
+  // highlighting on the row itself still applies underneath.
+  renderOption?: (opt: FilterOption<T>) => React.ReactNode
+  // Visually hides the <label> above the trigger (still rendered for a11y) —
+  // for use inside a card that already has its own heading for the field.
+  hideLabel?: boolean
 }
 
 export default function FilterDropdown<T extends string>({
@@ -46,6 +56,9 @@ export default function FilterDropdown<T extends string>({
   onChange,
   searchable,
   required,
+  triggerClassName,
+  renderOption,
+  hideLabel,
 }: Props<T>) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -166,12 +179,16 @@ export default function FilterDropdown<T extends string>({
   }
 
   const triggerClass =
+    triggerClassName ??
     'w-full flex items-center justify-between p-3 bg-surface text-brand-text border-2 border-brand-border rounded-lg text-base font-body cursor-pointer focus:outline-none focus:border-secondary transition-colors'
 
   // min-w-[200px]: deliberate minimum to prevent dropdown from collapsing on short labels
   return (
     <div ref={ref} className="min-w-[200px]">
-      <label htmlFor={id} className={required ? 'required' : undefined}>
+      <label
+        htmlFor={id}
+        className={[required && 'required', hideLabel && 'sr-only'].filter(Boolean).join(' ')}
+      >
         {label}
       </label>
       <div className="relative">
@@ -196,7 +213,11 @@ export default function FilterDropdown<T extends string>({
           tabIndex={searchable && open ? -1 : 0}
         >
           <span className="flex-1 text-left">{selectedLabel}</span>
-          <span className="ml-2 text-text-light">▾</span>
+          <span
+            className={`ml-2 ${triggerClassName ? 'text-current opacity-70' : 'text-text-light'}`}
+          >
+            ▾
+          </span>
         </button>
         {searchable && open && (
           <input
@@ -249,7 +270,7 @@ export default function FilterDropdown<T extends string>({
                     onClick={() => select(opt)}
                     className={`px-3 py-2 cursor-pointer rounded-md hover:bg-accent transition-colors text-sm ${value === opt.value || i === focusedIndex ? 'bg-accent' : ''} ${opt.indent ? 'pl-6' : ''}`}
                   >
-                    {opt.label}
+                    {renderOption ? renderOption(opt) : opt.label}
                   </div>
                 ),
               )}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -99,15 +99,13 @@ export function ProjectCard({
           {p.title}
         </Link>
       </div>
-      {/* Status is always shown. `Ready` and `Seeking Owner` used to be the same fact
-          wearing two badges, so the status badge had to be suppressed to avoid printing
-          it twice; now the status is the lifecycle position and the overlay badges are
-          genuinely separate facts. */}
+      {/* Status is the lifecycle position; Seeking Owner/Help/Tasks are separate,
+          independently-derived facts and can co-occur with any status, including Ready. */}
       <div className="row-start-2 flex gap-1 flex-wrap self-start">
         <Badge variant={projectStatusVariant(p.status)}>
           {STATUS_LABELS[p.status] ?? p.status.replace(/_/g, ' ')}
         </Badge>
-        {p.isSeekingOwner && p.status !== 'ready' && <Badge variant="caution">Seeking Owner</Badge>}
+        {p.isSeekingOwner && <Badge variant="caution">Seeking Owner</Badge>}
         {p.isSeekingHelp && <Badge variant="caution">Seeking Help</Badge>}
         {p.needsTasks && <Badge variant="warning">Needs Tasks</Badge>}
       </div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import Button from '@/components/Button'
 import { Badge, badgeClasses, type BadgeVariant } from '@/components/Badge'
 import { matchGradeLabel } from '@/lib/matching'
-import { countryLabel } from '@/lib/filter-options'
+import { projectLocationParts } from '@/lib/filter-options'
 
 export interface Project {
   id: number
@@ -18,6 +18,7 @@ export interface Project {
   projectType?: string | null
   country?: string | null
   localGroup?: string | null
+  remoteEligibility?: string | null
   timeCommitmentHoursPerWeek?: number | null
   urgency?: string | null
   owner?: { name: string } | null
@@ -110,9 +111,10 @@ export function ProjectCard({
       </div>
       <div className="row-start-3 flex items-center gap-3 flex-wrap text-xs text-text-light self-start">
         <span>👤 {p.owner ? p.owner.name : 'No owner yet'}</span>
-        {(p.localGroup || p.country) && (
-          <span>📍 {[countryLabel(p.country), p.localGroup].filter(Boolean).join(' · ')}</span>
-        )}
+        {(() => {
+          const parts = projectLocationParts(p.country, p.localGroup, p.remoteEligibility)
+          return parts.length > 0 && <span>📍 {parts.join(' · ')}</span>
+        })()}
         {p.projectType && <span>📋 {PROJECT_TYPE_LABELS[p.projectType] ?? p.projectType}</span>}
         {p.timeCommitmentHoursPerWeek && <span>🕐 {p.timeCommitmentHoursPerWeek}h/week</span>}
         {p.urgency && <span>⚡ {p.urgency} priority</span>}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -34,7 +34,6 @@ export interface Project {
 
 export const PROJECT_STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
   seeking_owner: { label: 'Seeking Owner', variant: 'caution' },
-  seeking_help: { label: 'Seeking Help', variant: 'caution' },
   needs_tasks: { label: 'Needs Tasks', variant: 'warning' },
   in_progress: { label: 'In Progress', variant: 'info' },
   on_hold: { label: 'On Hold', variant: 'neutral' },
@@ -101,7 +100,7 @@ export function ProjectCard({
         </Link>
       </div>
       <div className="row-start-2 flex gap-1 flex-wrap self-start">
-        {!['seeking_owner', 'seeking_help'].includes(p.status) && (
+        {p.status !== 'seeking_owner' && (
           <Badge variant={projectStatusVariant(p.status)}>
             {STATUS_LABELS[p.status] ?? p.status.replace(/_/g, ' ')}
           </Badge>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/Button'
 import { Badge, badgeClasses, type BadgeVariant } from '@/components/Badge'
 import { matchGradeLabel } from '@/lib/matching'
 import { projectLocationParts } from '@/lib/filter-options'
+import { PROJECT_STATUS_CONFIG as PROJECT_LIFECYCLE_CONFIG } from '@/lib/project-status'
 
 export interface Project {
   id: number
@@ -13,7 +14,10 @@ export interface Project {
   updatedAt?: string | Date | null
   pendingInterestCount?: number
   isSeekingHelp?: boolean | null
+  /** Derived server-side: live but ownerless. */
   isSeekingOwner?: boolean | null
+  /** Derived server-side: owned, but no open tasks. */
+  needsTasks?: boolean | null
   isOrgProposed?: boolean | null
   projectType?: string | null
   country?: string | null
@@ -32,15 +36,11 @@ export interface Project {
   } | null
 }
 
+// Project lifecycle statuses come from lib/project-status.ts (shared with the server and
+// e2e helpers); the interest statuses below are badged by the same helpers, so they're
+// merged in here rather than kept in the lifecycle map.
 export const PROJECT_STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
-  seeking_owner: { label: 'Seeking Owner', variant: 'caution' },
-  needs_tasks: { label: 'Needs Tasks', variant: 'warning' },
-  in_progress: { label: 'In Progress', variant: 'info' },
-  on_hold: { label: 'On Hold', variant: 'neutral' },
-  completed: { label: 'Completed', variant: 'success' },
-  archived: { label: 'Archived', variant: 'neutral' },
-  needs_discussion: { label: 'Needs Discussion', variant: 'neutral' },
-  pending_review: { label: 'Pending Review', variant: 'warning' },
+  ...PROJECT_LIFECYCLE_CONFIG,
   accepted: { label: 'Accepted', variant: 'success' },
   declined: { label: 'Declined', variant: 'neutral' },
   withdrawn: { label: 'Withdrawn', variant: 'neutral' },
@@ -99,14 +99,17 @@ export function ProjectCard({
           {p.title}
         </Link>
       </div>
+      {/* Status is always shown. `Ready` and `Seeking Owner` used to be the same fact
+          wearing two badges, so the status badge had to be suppressed to avoid printing
+          it twice; now the status is the lifecycle position and the overlay badges are
+          genuinely separate facts. */}
       <div className="row-start-2 flex gap-1 flex-wrap self-start">
-        {p.status !== 'seeking_owner' && (
-          <Badge variant={projectStatusVariant(p.status)}>
-            {STATUS_LABELS[p.status] ?? p.status.replace(/_/g, ' ')}
-          </Badge>
-        )}
+        <Badge variant={projectStatusVariant(p.status)}>
+          {STATUS_LABELS[p.status] ?? p.status.replace(/_/g, ' ')}
+        </Badge>
+        {p.isSeekingOwner && p.status !== 'ready' && <Badge variant="caution">Seeking Owner</Badge>}
         {p.isSeekingHelp && <Badge variant="caution">Seeking Help</Badge>}
-        {p.isSeekingOwner && <Badge variant="caution">Seeking Owner</Badge>}
+        {p.needsTasks && <Badge variant="warning">Needs Tasks</Badge>}
       </div>
       <div className="row-start-3 flex items-center gap-3 flex-wrap text-xs text-text-light self-start">
         <span>👤 {p.owner ? p.owner.name : 'No owner yet'}</span>

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -38,6 +38,12 @@ const PROJECT_TYPES = [
   { value: 'one_off', label: 'One-off task - Single deliverable, minimal coordination' },
 ]
 
+const REMOTE_ELIGIBILITY_OPTIONS = [
+  { value: 'NONE', label: 'No - in-person / local only' },
+  { value: 'COUNTRY', label: 'Yes - remote OK, within the same country' },
+  { value: 'GLOBAL', label: 'Yes - remote OK, from any country' },
+]
+
 type ProjectCreateInput = InferRouterInputs<AppRouter>['projects']['create']
 
 interface ProjectFormProps {
@@ -63,6 +69,7 @@ export default function ProjectForm({
   const [hoursPerWeek, setHoursPerWeek] = useState('')
   const [urgency, setUrgency] = useState('medium')
   const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
+  const [remoteEligibility, setRemoteEligibility] = useState('NONE')
   const [duration, setDuration] = useState('')
   const [collaborationLink, setCollaborationLink] = useState('')
   const [skills, setSkills] = useState<SelectedSkill[]>([])
@@ -118,6 +125,7 @@ export default function ProjectForm({
         urgency,
         country: country || null,
         localGroup: localGroup || null,
+        remoteEligibility: remoteEligibility as ProjectCreateInput['remoteEligibility'],
         estimatedDuration: duration.trim() || null,
         collaborationLink: collaborationLink.trim() || null,
         skillIds: skills.map((s) => s.skillId),
@@ -298,6 +306,20 @@ export default function ProjectForm({
             </a>
           </p>
         )}
+      </div>
+
+      <div className="mb-5">
+        <FilterDropdown
+          id="remote-eligibility"
+          label="Can this be done remotely?"
+          ariaLabel="Select remote eligibility"
+          value={remoteEligibility}
+          options={REMOTE_ELIGIBILITY_OPTIONS}
+          onChange={setRemoteEligibility}
+        />
+        <p className="text-sm text-text-light mt-1">
+          Controls who gets project-match alerts outside the country above.
+        </p>
       </div>
 
       <div className="mb-5">

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -131,7 +131,8 @@ export default function ProjectForm({
         skillIds: skills.map((s) => s.skillId),
         skillRequiredMap: Object.fromEntries(skills.map((s) => [s.skillId, true])),
         isSeekingHelp: seekingHelp,
-        isSeekingOwner: !wantToOwn,
+        // No isSeekingOwner: `wantToOwn` decides whether an owner is set, and "needs an
+        // owner" is derived from that.
         wantToOwn,
         tasks: validTasks.map((t) => ({
           title: t.title.trim(),

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -4,7 +4,6 @@ import { selectFilterDropdown } from './ui'
 
 const PROJECT_STATUS_LABELS: Record<string, string> = {
   seeking_owner: 'Seeking Owner',
-  seeking_help: 'Seeking Help',
   needs_tasks: 'Needs Tasks',
   in_progress: 'In Progress',
   on_hold: 'On Hold',

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -2,16 +2,7 @@ import { Page, expect } from '@playwright/test'
 import { getAlert } from '../fixtures'
 import { selectFilterDropdown } from './ui'
 
-const PROJECT_STATUS_LABELS: Record<string, string> = {
-  seeking_owner: 'Seeking Owner',
-  needs_tasks: 'Needs Tasks',
-  in_progress: 'In Progress',
-  on_hold: 'On Hold',
-  completed: 'Completed',
-  archived: 'Archived',
-  pending_review: 'Pending Review',
-  needs_discussion: 'Needs Discussion',
-}
+import { PROJECT_STATUS_LABELS } from '../../lib/project-status'
 
 const OUTCOME_LABELS: Record<string, string> = {
   successful: 'Successful',
@@ -136,6 +127,20 @@ export async function transferProjectOwnership(
   await selectFilterDropdown(adminPage, 'Transfer to', volunteerName)
   adminPage.once('dialog', (dialog) => dialog.accept())
   await adminPage.getByRole('menu').getByRole('button', { name: 'Transfer', exact: true }).click()
+  await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
+}
+
+export async function removeProjectOwner(
+  baseUrl: string,
+  adminPage: Page,
+  projectId: number,
+): Promise<void> {
+  if (!adminPage.url().includes(`/projects/${projectId}`)) {
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+  }
+  await adminPage.getByRole('button', { name: 'Ownership actions' }).click()
+  adminPage.once('dialog', (dialog) => dialog.accept())
+  await adminPage.getByRole('menuitem', { name: 'Remove ownership' }).click()
   await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
 }
 

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -147,11 +147,11 @@ export async function setProjectStatus(
   status: string,
 ): Promise<void> {
   await page.goto(`${baseUrl}/projects/${projectId}`)
-  await expect(page.getByRole('heading', { name: 'Manage Project Status' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Status', exact: true })).toBeVisible({
     timeout: 10_000,
   })
 
-  await selectFilterDropdown(page, 'Change Status', PROJECT_STATUS_LABELS[status] ?? status)
+  await selectFilterDropdown(page, 'project status', PROJECT_STATUS_LABELS[status] ?? status)
   await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(getAlert(page)).toBeVisible({ timeout: 10_000 })
 }

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../actions/projects'
 
 test.describe('Project Lifecycle', () => {
-  test('Volunteer proposes a project with tasks; admin approves; project moves to Seeking Owner', async ({
+  test('Volunteer proposes a project with tasks; admin approves; project moves to Ready', async ({
     adminPage,
     volunteer,
     baseUrl,
@@ -28,7 +28,7 @@ test.describe('Project Lifecycle', () => {
 
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
     await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
-    await expect(volunteer.page.getByLabel('project status')).toContainText('Seeking Owner', {
+    await expect(volunteer.page.getByLabel('project status')).toContainText('Ready', {
       timeout: 10_000,
     })
   })
@@ -119,8 +119,9 @@ test.describe('Project Lifecycle', () => {
     const title = fake.projectTitle()
     await adminCreateProject(baseUrl, adminPage, title, 'Admin-created project description')
 
-    // Project starts in_progress since it must be created with at least one task
-    await expect(adminPage.getByLabel('project status')).toContainText('In Progress', {
+    // Org projects skip review, so this one is live immediately — but the admin didn't
+    // claim it, so it goes live as Ready rather than In Progress.
+    await expect(adminPage.getByLabel('project status')).toContainText('Ready', {
       timeout: 10_000,
     })
 
@@ -260,7 +261,6 @@ test.describe('Project Creation Requires At Least One Task', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: true,
-        isSeekingOwner: true,
         tasks: [],
       },
     })
@@ -284,7 +284,6 @@ test.describe('Project Creation Requires At Least One Task', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: false,
-        isSeekingOwner: false,
         tasks: [],
       },
     })

--- a/e2e/tests/08-project-tasks.spec.ts
+++ b/e2e/tests/08-project-tasks.spec.ts
@@ -25,11 +25,11 @@ async function setupInProgressProject(
 }
 
 test.describe('Project Tasks', () => {
-  // A project can only reach `needs_tasks` after creation (every project now requires at
-  // least one task up front) — e.g. by accepting a `want_to_own` interest once its only
-  // task has been removed. Reproduce that path via the API, then verify the UI promotes
-  // the project back to In Progress as soon as a new task is added.
-  test('Adding a task to a needs_tasks project auto-promotes it to In Progress', async ({
+  // An owned project with an empty backlog is still owned, so it stays In Progress and
+  // shows a derived "Needs Tasks" badge rather than moving to a status of its own. Get
+  // there via the API (every project requires a task up front, so the only route is
+  // deleting the last one), then check the badge clears as soon as a task is added.
+  test('An owned project with no open tasks shows a Needs Tasks badge until one is added', async ({
     adminPage,
     baseUrl,
   }) => {
@@ -48,7 +48,6 @@ test.describe('Project Tasks', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: false,
-        isSeekingOwner: true,
         tasks: [{ title: 'Initial task' }],
       },
     })
@@ -77,18 +76,19 @@ test.describe('Project Tasks', () => {
     expect(accepted.status).toBe(200)
 
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
-    await expect(adminPage.getByLabel('project status')).toContainText('Needs Tasks', {
+    // Accepting the owner started the work, empty backlog or not.
+    await expect(adminPage.getByLabel('project status')).toContainText('In Progress', {
       timeout: 10_000,
     })
+    await expect(adminPage.getByText('Needs Tasks')).toBeVisible({ timeout: 10_000 })
 
     await adminPage.getByRole('button', { name: 'Add Task' }).click()
     await adminPage.getByLabel('Task title').fill('First task')
     await adminPage.getByRole('button', { name: 'Create Task' }).click()
     await expect(getAlert(adminPage)).toContainText('Task added!', { timeout: 10_000 })
 
-    await expect(adminPage.getByLabel('project status')).toContainText('In Progress', {
-      timeout: 10_000,
-    })
+    await expect(adminPage.getByText('Needs Tasks')).toBeHidden({ timeout: 10_000 })
+    await expect(adminPage.getByLabel('project status')).toContainText('In Progress')
   })
 
   test('A volunteer can claim an open task', async ({ adminPage, volunteer, baseUrl }) => {
@@ -152,7 +152,6 @@ test.describe('Project Tasks', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: false,
-        isSeekingOwner: false,
         tasks: [{ title: 'Setup task' }],
       },
     })

--- a/e2e/tests/20-task-management.spec.ts
+++ b/e2e/tests/20-task-management.spec.ts
@@ -22,7 +22,6 @@ async function createAdminProject(
       country: null,
       localGroup: null,
       isSeekingHelp: opts?.isSeekingHelp ?? false,
-      isSeekingOwner: false,
       tasks: [{ title: 'Seed task' }],
     },
   })

--- a/e2e/tests/21-approval-gate.spec.ts
+++ b/e2e/tests/21-approval-gate.spec.ts
@@ -20,7 +20,6 @@ async function createAdminProject(
       country: null,
       localGroup: null,
       isSeekingHelp: opts?.isSeekingHelp ?? true,
-      isSeekingOwner: false,
       tasks: opts?.tasks ?? [{ title: 'Seed task' }],
     },
   })

--- a/e2e/tests/22-quick-tasks.spec.ts
+++ b/e2e/tests/22-quick-tasks.spec.ts
@@ -71,7 +71,6 @@ test.describe('Quick Tasks: self-serve', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: true,
-        isSeekingOwner: false,
         tasks: [{ title: 'Seed task' }],
       },
     })
@@ -135,7 +134,6 @@ test.describe('Quick Tasks: self-serve', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: true,
-        isSeekingOwner: false,
         tasks: [{ title: 'Seed task' }],
       },
     })
@@ -183,7 +181,6 @@ test.describe('Quick Tasks: self-serve', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: true,
-        isSeekingOwner: false,
         tasks: [{ title: 'Seed task' }],
       },
     })
@@ -268,7 +265,6 @@ test.describe('Leaving a project', () => {
         country: null,
         localGroup: null,
         isSeekingHelp: true,
-        isSeekingOwner: false,
         tasks: [{ title: 'Seed task' }],
       },
     })

--- a/e2e/tests/23-task-detail-page.spec.ts
+++ b/e2e/tests/23-task-detail-page.spec.ts
@@ -27,7 +27,6 @@ async function createAdminProject(
       country: null,
       localGroup: null,
       isSeekingHelp: false,
-      isSeekingOwner: false,
       tasks: [{ title: 'Seed task' }],
     },
   })

--- a/e2e/tests/27-remote-eligibility.spec.ts
+++ b/e2e/tests/27-remote-eligibility.spec.ts
@@ -109,7 +109,6 @@ async function adminCreateRemoteProject(
       localGroup: null,
       remoteEligibility,
       isSeekingHelp: true,
-      isSeekingOwner: true,
       skillIds,
       skillRequiredMap: Object.fromEntries(skillIds.map((id) => [id, true])),
       tasks: [{ title: 'Initial task' }],

--- a/e2e/tests/27-remote-eligibility.spec.ts
+++ b/e2e/tests/27-remote-eligibility.spec.ts
@@ -1,0 +1,230 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  test,
+  expect,
+  getAlert,
+  confirmVolunteerEmail,
+  approveVolunteer,
+  readAdminToken,
+} from '../fixtures'
+import { createApiClient } from '../client'
+import { fake } from '../fake'
+import { selectFilterDropdown } from '../actions/ui'
+import { IS_LOCAL } from '../config'
+
+const STUB_EMAIL_DIR = '/tmp/catalyse-emails'
+
+function countStubEmails(sinceMs: number, contentIncludes: string): number {
+  if (!fs.existsSync(STUB_EMAIL_DIR)) return 0
+  let count = 0
+  for (const file of fs.readdirSync(STUB_EMAIL_DIR)) {
+    const full = path.join(STUB_EMAIL_DIR, file)
+    let mtimeMs: number
+    try {
+      mtimeMs = fs.statSync(full).mtimeMs
+    } catch {
+      continue // file removed by a concurrent worker between readdir and stat
+    }
+    if (mtimeMs < sinceMs) continue
+    if (fs.readFileSync(full, 'utf-8').includes(contentIncludes)) count++
+  }
+  return count
+}
+
+// Polls until at least one matching stub email appears (or the timeout elapses), then
+// returns however many matched. A project's immediate match-alert fan-out fires all
+// recipients' sends together, so once the first lands the rest have had their chance too.
+async function waitForStubEmailCount(
+  sinceMs: number,
+  contentIncludes: string,
+  timeoutMs: number,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  let count = 0
+  while (Date.now() < deadline) {
+    count = countStubEmails(sinceMs, contentIncludes)
+    if (count > 0) break
+    await new Promise((r) => setTimeout(r, 300))
+  }
+  return count
+}
+
+async function createMatchingVolunteer(
+  baseUrl: string,
+  country: string,
+  notifyRemoteProjects: boolean,
+  skillIds: number[],
+): Promise<{ id: number; name: string }> {
+  const person = fake.person()
+  const api = createApiClient(baseUrl)
+  const signup = await api.auth.signup({
+    body: {
+      name: person.name,
+      email: person.email,
+      password: 'testpassword1',
+      bio: 'e2e test bio, at least twenty characters long',
+      country,
+      availabilityHoursPerWeek: 5,
+      applicationMessage: 'e2e test application message',
+      consentMakeProfileVisibleInDirectory: true,
+      consentContactableByProjectOwners: true,
+    },
+  })
+  if (signup.status !== 200) throw new Error(`Signup failed: ${JSON.stringify(signup.body)}`)
+  const { id, token, emailVerificationToken } = signup.body as {
+    id: number
+    token: string
+    emailVerificationToken?: string
+  }
+  if (emailVerificationToken) await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+  await approveVolunteer(baseUrl, id)
+
+  const selfApi = createApiClient(baseUrl, token)
+  const update = await selfApi.volunteers.updateMe({
+    body: { emailDigest: 'match', notifyRemoteProjects, skillIds },
+  })
+  if (update.status !== 200) throw new Error(`updateMe failed: ${JSON.stringify(update.body)}`)
+
+  return { id, name: person.name }
+}
+
+async function adminCreateRemoteProject(
+  baseUrl: string,
+  title: string,
+  remoteEligibility: 'NONE' | 'COUNTRY' | 'GLOBAL',
+  skillIds: number[],
+): Promise<void> {
+  const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+  const created = await adminApi.admin.projects.create({
+    body: {
+      title,
+      description: 'e2e test project description, remote eligibility',
+      projectType: null,
+      estimatedDuration: null,
+      timeCommitmentHoursPerWeek: null,
+      urgency: 'medium',
+      collaborationLink: null,
+      country: 'Australia',
+      localGroup: null,
+      remoteEligibility,
+      isSeekingHelp: true,
+      isSeekingOwner: true,
+      skillIds,
+      skillRequiredMap: Object.fromEntries(skillIds.map((id) => [id, true])),
+      tasks: [{ title: 'Initial task' }],
+    },
+  })
+  if (created.status !== 200)
+    throw new Error(`Project creation failed: ${JSON.stringify(created.body)}`)
+}
+
+async function getSeededSkillIds(baseUrl: string): Promise<number[]> {
+  const api = createApiClient(baseUrl)
+  const result = await api.skills.list()
+  if (result.status !== 200) throw new Error(`skills.list failed: ${JSON.stringify(result.body)}`)
+  const categories = result.body as Array<{ skills: Array<{ id: number; name: string }> }>
+  const allSkills = categories.flatMap((c) => c.skills)
+  const skillA = allSkills.find((s) => s.name === 'Web Development')
+  const skillB = allSkills.find((s) => s.name === 'Software Engineering')
+  if (!skillA || !skillB)
+    throw new Error('Expected seeded skills "Web Development" / "Software Engineering" not found')
+  return [skillA.id, skillB.id]
+}
+
+test.describe('Project form & settings: remote eligibility', () => {
+  test('Admin can mark a project remote-eligible and it persists', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const title = fake.projectTitle()
+
+    await adminPage.goto(`${baseUrl}/admin/projects/new`)
+    await expect(
+      adminPage.getByRole('heading', { name: 'Create Organisation Project' }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    await adminPage.getByLabel('Project Title').fill(title)
+    await adminPage.getByLabel('Description').fill('e2e test project description')
+    await selectFilterDropdown(
+      adminPage,
+      'Select remote eligibility',
+      'Yes - remote OK, from any country',
+    )
+    await adminPage.getByLabel('Task title').first().fill('Initial task')
+    await adminPage.getByRole('button', { name: 'Create Project' }).click()
+
+    await adminPage.waitForURL(/\/projects\/\d+/, { timeout: 15_000 })
+    await expect(adminPage.locator('#projectContent')).toBeVisible({ timeout: 10_000 })
+    const match = adminPage.url().match(/\/projects\/(\d+)/)
+    if (!match) throw new Error(`Could not extract project ID from URL: ${adminPage.url()}`)
+
+    await adminPage.goto(`${baseUrl}/projects/${match[1]}/edit`)
+    await expect(adminPage.getByRole('heading', { name: 'Edit Project' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(adminPage.getByLabel('Select remote eligibility')).toContainText(
+      'Yes - remote OK, from any country',
+    )
+  })
+
+  test('Volunteer can opt in to remote-friendly project alerts outside their country', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    await volunteer.page.goto(`${baseUrl}/settings?tab=notifications`)
+    const checkbox = volunteer.page.getByLabel(/Also alert me about remote-friendly projects/)
+    await expect(checkbox).toBeVisible({ timeout: 10_000 })
+    await expect(checkbox).not.toBeChecked()
+
+    // The checkbox input is visually hidden behind a decorative custom-checkbox span
+    // (see components/Checkbox.tsx), so click the wrapping label instead of the input.
+    await volunteer.page.locator('label:has(#notify_remote_projects)').click()
+    await expect(checkbox).toBeChecked()
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(getAlert(volunteer.page)).toBeVisible({ timeout: 10_000 })
+
+    await volunteer.page.reload()
+    await expect(
+      volunteer.page.getByLabel(/Also alert me about remote-friendly projects/),
+    ).toBeChecked({ timeout: 10_000 })
+  })
+})
+
+test.describe('Match alerts respect remote eligibility & country opt-in', () => {
+  test('GLOBAL remote project alerts an opted-in out-of-country volunteer, not an opted-out one', async ({
+    baseUrl,
+  }) => {
+    test.skip(!IS_LOCAL, 'reads the stub email directory on the app server host')
+
+    const skillIds = await getSeededSkillIds(baseUrl)
+    // Two UK volunteers matching on skills; only one has opted in to cross-country alerts.
+    await createMatchingVolunteer(baseUrl, 'UK', true, skillIds)
+    await createMatchingVolunteer(baseUrl, 'UK', false, skillIds)
+
+    const sinceMs = Date.now()
+    const title = fake.projectTitle()
+    await adminCreateRemoteProject(baseUrl, title, 'GLOBAL', skillIds)
+
+    // Exactly one email for this title: the opted-in volunteer. If the opted-out
+    // volunteer had also been notified, this would be 2.
+    const count = await waitForStubEmailCount(sinceMs, title, 15_000)
+    expect(count).toBe(1)
+  })
+
+  test('NONE-eligibility project does not alert an out-of-country volunteer even if opted in', async ({
+    baseUrl,
+  }) => {
+    test.skip(!IS_LOCAL, 'reads the stub email directory on the app server host')
+
+    const skillIds = await getSeededSkillIds(baseUrl)
+    await createMatchingVolunteer(baseUrl, 'UK', true, skillIds)
+
+    const sinceMs = Date.now()
+    const title = fake.projectTitle()
+    await adminCreateRemoteProject(baseUrl, title, 'NONE', skillIds)
+
+    const count = await waitForStubEmailCount(sinceMs, title, 5_000)
+    expect(count).toBe(0)
+  })
+})

--- a/e2e/tests/28-project-ownership-states.spec.ts
+++ b/e2e/tests/28-project-ownership-states.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect, readAdminToken, createApprovedVolunteer } from '../fixtures'
+import { fake } from '../fake'
+import { createApiClient } from '../client'
+import { removeProjectOwner } from '../actions/projects'
+import { selectFilterDropdown } from '../actions/ui'
+
+// Whether a project wants an owner is derived from (status, assignee), never stored, and
+// `ready` is the status for "approved but nobody owns it yet". These tests pin the two
+// halves of that: assigning or removing an owner moves the project between `ready` and
+// `in_progress`, and what each state advertises to volunteers stays in step.
+
+async function createOrgProject(
+  baseUrl: string,
+  opts: { isSeekingHelp?: boolean; skillIds?: number[]; title?: string } = {},
+): Promise<{ id: number; title: string }> {
+  const title = opts.title ?? fake.projectTitle()
+  const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+  const created = await adminApi.admin.projects.create({
+    body: {
+      title,
+      description: 'e2e ownership-state project description',
+      projectType: null,
+      estimatedDuration: null,
+      timeCommitmentHoursPerWeek: null,
+      urgency: 'medium',
+      collaborationLink: null,
+      country: null,
+      localGroup: null,
+      isSeekingHelp: opts.isSeekingHelp ?? false,
+      ...(opts.skillIds
+        ? {
+            skillIds: opts.skillIds,
+            skillRequiredMap: Object.fromEntries(opts.skillIds.map((id) => [id, true])),
+          }
+        : {}),
+      tasks: [{ title: 'Initial task' }],
+    },
+  })
+  if (created.status !== 200)
+    throw new Error(`Project creation failed: ${JSON.stringify(created.body)}`)
+  return { id: (created.body as { id: number }).id, title }
+}
+
+async function getProject(baseUrl: string, token: string, id: number) {
+  const result = await createApiClient(baseUrl, token).projects.getById({ body: { id } })
+  expect(result.status).toBe(200)
+  return result.body as {
+    status: string
+    ownerId: number | null
+    isSeekingOwner: boolean
+    isSeekingHelp: boolean
+  }
+}
+
+test.describe('Project ownership states', () => {
+  test('An org project with no owner starts Ready and seeking an owner', async ({ baseUrl }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const { id } = await createOrgProject(baseUrl)
+
+    const project = await getProject(baseUrl, adminToken, id)
+    expect(project.status).toBe('ready')
+    expect(project.ownerId).toBeNull()
+    expect(project.isSeekingOwner).toBe(true)
+  })
+
+  // Regression: assigning someone as owner used to create the accepted interest and clear
+  // the stored is_seeking_owner flag without ever setting assignee_id, leaving the project
+  // ownerless *and* no longer advertising for one.
+  test('Assigning a volunteer as owner sets the owner and starts the project', async ({
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const { id } = await createOrgProject(baseUrl)
+    const volunteer = await createApprovedVolunteer(baseUrl)
+
+    const assigned = await createApiClient(baseUrl, adminToken).projects.assign({
+      body: { projectId: id, volunteerId: volunteer.id, interestType: 'want_to_own' },
+    })
+    expect(assigned.status).toBe(200)
+
+    const project = await getProject(baseUrl, adminToken, id)
+    expect(project.ownerId).toBe(volunteer.id)
+    expect(project.status).toBe('in_progress')
+    expect(project.isSeekingOwner).toBe(false)
+  })
+
+  test('Accepting a want_to_own interest sets the owner and starts the project', async ({
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const { id } = await createOrgProject(baseUrl)
+    const volunteer = await createApprovedVolunteer(baseUrl)
+
+    const interest = await createApiClient(baseUrl, volunteer.token).projects.expressInterest({
+      body: { projectId: id, interestType: 'want_to_own' },
+    })
+    expect(interest.status).toBe(200)
+
+    const withInterest = await adminApi.projects.getById({ body: { id } })
+    const interestId = (
+      withInterest.body as { interests: { id: number; volunteerId: number }[] }
+    ).interests.find((i) => i.volunteerId === volunteer.id)!.id
+    const accepted = await adminApi.projects.respondToInterest({
+      body: { projectId: id, interestId, status: 'accepted' },
+    })
+    expect(accepted.status).toBe(200)
+
+    const project = await getProject(baseUrl, adminToken, id)
+    expect(project.ownerId).toBe(volunteer.id)
+    expect(project.status).toBe('in_progress')
+    expect(project.isSeekingOwner).toBe(false)
+  })
+
+  // Regression: removing the owner left the project In Progress with nobody on it and no
+  // "seeking owner" flag, so nothing browsing for a project to lead could ever find it.
+  test('Removing the owner returns the project to Ready and re-advertises it', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const { id, title } = await createOrgProject(baseUrl)
+    const volunteer = await createApprovedVolunteer(baseUrl)
+
+    await createApiClient(baseUrl, adminToken).projects.assign({
+      body: { projectId: id, volunteerId: volunteer.id, interestType: 'want_to_own' },
+    })
+
+    await adminPage.goto(`${baseUrl}/projects/${id}`)
+    await expect(adminPage.getByLabel('project status')).toContainText('In Progress', {
+      timeout: 10_000,
+    })
+
+    await removeProjectOwner(baseUrl, adminPage, id)
+
+    await expect(adminPage.getByLabel('project status')).toContainText('Ready', { timeout: 10_000 })
+    const project = await getProject(baseUrl, adminToken, id)
+    expect(project.ownerId).toBeNull()
+    expect(project.isSeekingOwner).toBe(true)
+
+    // And it is findable again by someone filtering for projects that need a lead.
+    await adminPage.goto(`${baseUrl}/projects`)
+    await selectFilterDropdown(adminPage, 'Needs filter', 'Seeking Owner')
+    await expect(adminPage.getByRole('link', { name: title })).toBeVisible({ timeout: 10_000 })
+  })
+
+  // Regression: an owned project used to be able to sit in the retired `seeking_owner`
+  // status with the flag cleared, and the card suppressed the status badge for exactly
+  // that status — so the card rendered no status at all.
+  test('An owned project shows its status and is excluded from the Seeking Owner filter', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const { id, title } = await createOrgProject(baseUrl)
+    const volunteer = await createApprovedVolunteer(baseUrl)
+    await createApiClient(baseUrl, adminToken).projects.assign({
+      body: { projectId: id, volunteerId: volunteer.id, interestType: 'want_to_own' },
+    })
+
+    await adminPage.goto(`${baseUrl}/projects`)
+    await selectFilterDropdown(adminPage, 'Needs filter', 'Seeking Owner')
+    await expect(adminPage.getByRole('link', { name: title })).toBeHidden({ timeout: 10_000 })
+
+    await adminPage.goto(`${baseUrl}/projects/${id}`)
+    await expect(adminPage.getByLabel('project status')).toContainText('In Progress', {
+      timeout: 10_000,
+    })
+    await expect(adminPage.getByText('Seeking Owner')).toBeHidden()
+  })
+
+  // Regression: setOutcome completes a project directly, and used to do it without
+  // clearing isSeekingHelp — unlike projects.update, the other route to `completed`. A
+  // finished project then kept its "Seeking Help" badge and its place in the "Looking for
+  // People" group. Driven through the API because the UI's outcome panel only appears once
+  // the project is already completed, which is the path that always cleared the flag.
+  test('Recording an outcome stops the project advertising for help', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const adminToken = readAdminToken(baseUrl)
+    const adminApi = createApiClient(baseUrl, adminToken)
+    const { id, title } = await createOrgProject(baseUrl, { isSeekingHelp: true })
+    const volunteer = await createApprovedVolunteer(baseUrl)
+    await adminApi.projects.assign({
+      body: { projectId: id, volunteerId: volunteer.id, interestType: 'want_to_own' },
+    })
+
+    const recorded = await adminApi.admin.projects.setOutcome({
+      body: { id, outcome: 'successful', outcomeNotes: 'Delivered in full' },
+    })
+    expect(recorded.status).toBe(200)
+
+    const project = await getProject(baseUrl, adminToken, id)
+    expect(project.status).toBe('completed')
+    expect(project.isSeekingHelp).toBe(false)
+    expect(project.isSeekingOwner).toBe(false)
+
+    await adminPage.goto(`${baseUrl}/projects`)
+    await selectFilterDropdown(adminPage, 'Needs filter', 'Looking for People')
+    await expect(adminPage.getByRole('link', { name: title })).toBeHidden({ timeout: 10_000 })
+  })
+
+  // Regression: "Suggested for You" matched on the seeking flags alone. Every project is
+  // created with isSeekingHelp true, so proposals were recommended to volunteers before an
+  // admin had reviewed them.
+  test('A proposal awaiting review is not suggested to matching volunteers', async ({
+    baseUrl,
+  }) => {
+    const api = createApiClient(baseUrl)
+    const skillsResult = await api.skills.list()
+    expect(skillsResult.status).toBe(200)
+    const allSkills = (skillsResult.body as Array<{ skills: Array<{ id: number }> }>).flatMap(
+      (c) => c.skills,
+    )
+    const skillIds = [allSkills[0].id]
+
+    // A volunteer who proposes a project, and a second who matches its skills.
+    const proposer = await createApprovedVolunteer(baseUrl)
+    const title = fake.projectTitle()
+    const proposed = await createApiClient(baseUrl, proposer.token).projects.create({
+      body: {
+        title,
+        description: 'Proposal that should stay private until reviewed',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: true,
+        skillIds,
+        skillRequiredMap: Object.fromEntries(skillIds.map((id) => [id, true])),
+        tasks: [{ title: 'Initial task' }],
+      },
+    })
+    expect(proposed.status).toBe(200)
+    const projectId = (proposed.body as { id: number }).id
+
+    const matcher = await createApprovedVolunteer(baseUrl)
+    const matcherApi = createApiClient(baseUrl, matcher.token)
+    const updated = await matcherApi.volunteers.updateMe({ body: { skillIds } })
+    expect(updated.status).toBe(200)
+
+    const beforeReview = await matcherApi.dashboard.get()
+    expect(beforeReview.status).toBe(200)
+    const suggestedBefore = (beforeReview.body as { suggestedProjects: { id: number }[] })
+      .suggestedProjects
+    expect(suggestedBefore.map((p) => p.id)).not.toContain(projectId)
+
+    // Once approved it goes live as `ready`, and the same volunteer should now see it.
+    const approved = await createApiClient(baseUrl, readAdminToken(baseUrl)).admin.projects.review({
+      body: { id: projectId, status: 'approved' },
+    })
+    expect(approved.status).toBe(200)
+
+    const afterReview = await matcherApi.dashboard.get()
+    expect(afterReview.status).toBe(200)
+    const suggestedAfter = (afterReview.body as { suggestedProjects: { id: number }[] })
+      .suggestedProjects
+    expect(suggestedAfter.map((p) => p.id)).toContain(projectId)
+  })
+})

--- a/jobs/digest.ts
+++ b/jobs/digest.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { sendDigestEmail, isEmailConfigured } from '@/lib/email'
+import { isGeoEligible } from '@/lib/matching'
 import { WorkItemType } from '@/generated/prisma/enums'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -45,6 +46,8 @@ export async function runDigestJob(): Promise<Record<string, unknown>> {
     description: p.description ?? '',
     skill_names: p.skills.map((ps) => ps.skill.name),
     requiredSkillIds: new Set(p.skills.filter((ps) => ps.isRequired).map((ps) => ps.skillId)),
+    country: p.country,
+    remoteEligibility: p.remoteEligibility,
   }))
 
   const volunteers = await prisma.volunteer.findMany({
@@ -55,14 +58,21 @@ export async function runDigestJob(): Promise<Record<string, unknown>> {
   let digestSent = 0
   for (const vol of volunteers) {
     const volSkillIds = new Set(vol.skills.map((vs) => vs.skillId))
-    const enriched = projectList.map(({ requiredSkillIds, ...rest }) => {
-      let match_percent: number | undefined
-      if (volSkillIds.size && requiredSkillIds.size) {
-        const matched = [...requiredSkillIds].filter((id) => volSkillIds.has(id)).length
-        match_percent = Math.round((matched / requiredSkillIds.size) * 100)
-      }
-      return { ...rest, match_percent }
-    })
+    const eligible = projectList.filter((p) =>
+      isGeoEligible(vol.country, vol.notifyRemoteProjects, p.country, p.remoteEligibility),
+    )
+    if (!eligible.length) continue
+
+    const enriched = eligible.map(
+      ({ requiredSkillIds, country: _country, remoteEligibility: _remoteEligibility, ...rest }) => {
+        let match_percent: number | undefined
+        if (volSkillIds.size && requiredSkillIds.size) {
+          const matched = [...requiredSkillIds].filter((id) => volSkillIds.has(id)).length
+          match_percent = Math.round((matched / requiredSkillIds.size) * 100)
+        }
+        return { ...rest, match_percent }
+      },
+    )
     enriched.sort((a, b) => (b.match_percent ?? 0) - (a.match_percent ?? 0))
     if (
       await sendDigestEmail({ to: vol.email!, name: vol.name, projects: enriched, isMatch: false })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -81,6 +81,7 @@ export function redactVolunteer(
     approvalStatus: vol.approvalStatus,
     emailConfirmed: vol.emailConfirmed,
     emailDigest: vol.emailDigest,
+    notifyRemoteProjects: vol.notifyRemoteProjects,
     hasPassword: Boolean(vol.passwordHash),
     createdAt: vol.createdAt,
     updatedAt: vol.updatedAt,

--- a/lib/filter-options.ts
+++ b/lib/filter-options.ts
@@ -88,3 +88,19 @@ export function countryLabel(value: string | null | undefined): string {
   if (!value) return ''
   return BASE_LOCATION_OPTIONS.find((o) => o.value === value)?.label ?? value
 }
+
+// Builds the parts of a project's location line, e.g. ['Remote', 'Global', 'United Kingdom', 'London']
+// for a worldwide-remote project, or ['United Kingdom', 'London'] for an in-person one.
+// Join with ' · ' and prefix with 📍 to render.
+export function projectLocationParts(
+  country: string | null | undefined,
+  localGroup: string | null | undefined,
+  remoteEligibility: string | null | undefined,
+): string[] {
+  const parts: string[] = []
+  if (remoteEligibility === 'COUNTRY' || remoteEligibility === 'GLOBAL') parts.push('Remote')
+  if (remoteEligibility === 'GLOBAL') parts.push('Global')
+  if (country) parts.push(countryLabel(country))
+  if (localGroup) parts.push(localGroup)
+  return parts
+}

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -64,3 +64,25 @@ export function calculateMatchScore(
 export function matchGradeLabel(matchedRequired: number): string | null {
   return MATCH_GRADES.find((g) => matchedRequired >= g.minMatched)?.label ?? null
 }
+
+/**
+ * Whether a volunteer should be alerted about a project based on location.
+ *
+ * Same-country volunteers are always eligible. Out-of-country volunteers are only
+ * eligible for GLOBAL-remote projects, and only if they've opted in — otherwise a
+ * volunteer in one country gets flooded with alerts for projects on the other side
+ * of the world they have no way to help with.
+ *
+ * Missing country data (on either side) doesn't restrict eligibility — we only
+ * narrow the audience once we actually know where both parties are.
+ */
+export function isGeoEligible(
+  volunteerCountry: string | null,
+  volunteerNotifyRemoteProjects: boolean,
+  projectCountry: string | null,
+  projectRemoteEligibility: string,
+): boolean {
+  if (!projectCountry || !volunteerCountry) return true
+  if (volunteerCountry === projectCountry) return true
+  return projectRemoteEligibility === 'GLOBAL' && volunteerNotifyRemoteProjects
+}

--- a/lib/project-match-notify.ts
+++ b/lib/project-match-notify.ts
@@ -1,6 +1,6 @@
 import { prisma } from './prisma'
 import { sendDigestEmail, isEmailConfigured } from './email'
-import { calculateMatchScore, matchGradeLabel, MATCH_GRADES } from './matching'
+import { calculateMatchScore, matchGradeLabel, isGeoEligible, MATCH_GRADES } from './matching'
 import { WorkItemType } from '@/generated/prisma/enums'
 
 const NOTIFIABLE_GRADES = new Set(MATCH_GRADES.filter((g) => g.notifiable).map((g) => g.label))
@@ -36,6 +36,16 @@ export async function notifyMatchingVolunteers(projectId: number): Promise<void>
 
   await Promise.all(
     volunteers.map((vol) => {
+      if (
+        !isGeoEligible(
+          vol.country,
+          vol.notifyRemoteProjects,
+          project.country,
+          project.remoteEligibility,
+        )
+      )
+        return
+
       const volSkillIds = new Set(vol.skills.map((vs) => vs.skillId))
       const score = calculateMatchScore(volSkillIds, projectSkills)
       const grade = matchGradeLabel(score.matchedRequiredCount)

--- a/lib/project-status.ts
+++ b/lib/project-status.ts
@@ -1,0 +1,87 @@
+import type { BadgeVariant } from '@/components/Badge'
+import { ProjectStatus } from '@/generated/prisma/enums'
+
+/**
+ * The single source of truth for project lifecycle status — labels, badge colours, and
+ * which statuses each role may pick. Server routers, UI and e2e helpers all read from
+ * here; previously each kept its own copy and they drifted (notification emails were
+ * sending raw enum strings for statuses the server's copy had never heard of).
+ *
+ *   pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
+ *
+ * `ready` means approved and live, but unowned. Assigning an owner is what moves a
+ * project to `in_progress`.
+ */
+export const PROJECT_STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
+  pending_review: { label: 'Pending Review', variant: 'warning' },
+  needs_discussion: { label: 'Needs Discussion', variant: 'neutral' },
+  ready: { label: 'Ready', variant: 'caution' },
+  in_progress: { label: 'In Progress', variant: 'info' },
+  on_hold: { label: 'On Hold', variant: 'neutral' },
+  completed: { label: 'Completed', variant: 'success' },
+  archived: { label: 'Archived', variant: 'neutral' },
+}
+
+export const PROJECT_STATUS_LABELS: Record<string, string> = Object.fromEntries(
+  Object.entries(PROJECT_STATUS_CONFIG).map(([k, v]) => [k, v.label]),
+)
+
+export function projectStatusLabel(status: string): string {
+  return PROJECT_STATUS_LABELS[status] ?? status.replace(/_/g, ' ')
+}
+
+/** Statuses a project owner may set directly. Admins may set any status. */
+export const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
+  ProjectStatus.ready,
+  ProjectStatus.in_progress,
+  ProjectStatus.on_hold,
+  ProjectStatus.completed,
+]
+
+/** Additional statuses only an admin may set. */
+export const ADMIN_ONLY_STATUSES: ProjectStatus[] = [
+  ProjectStatus.archived,
+  ProjectStatus.pending_review,
+  ProjectStatus.needs_discussion,
+]
+
+/** Pre-approval: hidden from browse, never advertised to volunteers. */
+export const UNAPPROVED_STATUSES: string[] = [
+  ProjectStatus.pending_review,
+  ProjectStatus.needs_discussion,
+]
+
+/** Finished: no longer taking volunteers, however its flags happen to be set. */
+export const TERMINAL_STATUSES: string[] = [ProjectStatus.completed, ProjectStatus.archived]
+
+/**
+ * Statuses at which an ownerless project is genuinely looking for an owner: approved
+ * ("ready or beyond") but not yet finished. `in_progress`/`on_hold` are included so a
+ * project whose owner steps down is re-advertised rather than stranded.
+ */
+export const SEEKING_OWNER_STATUSES: string[] = [
+  ProjectStatus.ready,
+  ProjectStatus.in_progress,
+  ProjectStatus.on_hold,
+]
+
+/**
+ * Derived, never stored. There is no `is_seeking_owner` column: a project wants an owner
+ * precisely when it hasn't got one and is live. Storing it as a flag meant every mutation
+ * that touched ownership had to remember to update it, and several didn't.
+ */
+export function isSeekingOwner(p: { status: string; assigneeId: number | null }): boolean {
+  return p.assigneeId === null && SEEKING_OWNER_STATUSES.includes(p.status)
+}
+
+const quoted = (values: string[]) => values.map((v) => `'${v}'`).join(', ')
+
+/** `isSeekingOwner` as a raw SQL predicate, for the hand-written projects.list query. */
+export const SEEKING_OWNER_SQL = `(assignee_id IS NULL AND status IN (${quoted(SEEKING_OWNER_STATUSES)}))`
+
+/** Advertisable = approved and not finished. Guards recommendations and admin counts. */
+export const ADVERTISABLE_STATUSES_SQL = `status NOT IN (${quoted([...UNAPPROVED_STATUSES, ...TERMINAL_STATUSES])})`
+
+export const ADVERTISABLE_STATUSES: string[] = Object.keys(PROJECT_STATUS_CONFIG).filter(
+  (s) => !UNAPPROVED_STATUSES.includes(s) && !TERMINAL_STATUSES.includes(s),
+)

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -122,16 +122,19 @@ const PROJECT_INPUT_FIELDS = {
   collaborationLink: true,
   country: true,
   localGroup: true,
+  remoteEligibility: true,
   isSeekingHelp: true,
   isSeekingOwner: true,
 } as const
 
-export const CreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS).extend({
-  tasks: z.array(TaskInputSchema).optional().default([]),
-  wantToOwn: z.boolean().optional().default(false),
-  skillIds: z.array(z.number().int()).optional().default([]),
-  skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
-})
+export const CreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS)
+  .partial({ remoteEligibility: true })
+  .extend({
+    tasks: z.array(TaskInputSchema).optional().default([]),
+    wantToOwn: z.boolean().optional().default(false),
+    skillIds: z.array(z.number().int()).optional().default([]),
+    skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
+  })
 
 export const UpdateProjectSchema = WorkItemSchema.pick({
   ...PROJECT_INPUT_FIELDS,
@@ -183,12 +186,14 @@ export const CreateProjectUpdateSchema = WorkItemCommentSchema.pick({
 
 // ─── Admin: projects ──────────────────────────────────────────────────────────
 
-export const AdminCreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS).extend({
-  tasks: z.array(TaskInputSchema).optional().default([]),
-  wantToOwn: z.boolean().optional().default(false),
-  skillIds: z.array(z.number().int()).optional().default([]),
-  skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
-})
+export const AdminCreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS)
+  .partial({ remoteEligibility: true })
+  .extend({
+    tasks: z.array(TaskInputSchema).optional().default([]),
+    wantToOwn: z.boolean().optional().default(false),
+    skillIds: z.array(z.number().int()).optional().default([]),
+    skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
+  })
 
 export const ReviewProjectSchema = z.object({
   status: z.enum(['approved', 'needs_discussion'], {

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -124,7 +124,6 @@ const PROJECT_INPUT_FIELDS = {
   localGroup: true,
   remoteEligibility: true,
   isSeekingHelp: true,
-  isSeekingOwner: true,
 } as const
 
 export const CreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS)

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -1,10 +1,12 @@
 import { Prisma } from '@/generated/prisma/client'
 import { calculateMatchScore } from './matching'
+import { isSeekingOwner, UNAPPROVED_STATUSES } from './project-status'
 import {
   InterestStatus,
   ProjectStatus,
   QuickTaskStatus,
   RemoteEligibility,
+  TaskStatus,
   WorkItemType,
 } from '@/generated/prisma/enums'
 
@@ -21,10 +23,7 @@ export type WorkItemForAccess = {
 
 export type CommentViewer = { id: number; isAdmin: boolean; isApproved: boolean } | null
 
-const PROJECT_HIDDEN_STATUSES: string[] = [
-  ProjectStatus.pending_review,
-  ProjectStatus.needs_discussion,
-]
+const PROJECT_HIDDEN_STATUSES: string[] = UNAPPROVED_STATUSES
 
 // A volunteer the owner declined, or who withdrew themselves, is no longer a contributor
 // on that project: they cannot self-claim its tasks and its tasks are hidden from their
@@ -133,13 +132,12 @@ export type EnrichedProject = {
   updatedAt: Date | null
   country: string | null
   isSeekingHelp: boolean | null
-  isSeekingOwner: boolean | null
   localGroup: string | null
   remoteEligibility: RemoteEligibility
   skills: WorkItemSkillWithRelations[]
   assignee: { id: number; name: string } | null
   creator: { id: number; name: string } | null
-  _count: { interests: number }
+  _count: { interests: number; children: number }
 }
 
 // The serialized view keeps the public field names `owner`/`proposedBy`
@@ -175,7 +173,13 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
     updatedAt: p.updatedAt,
     country: p.country,
     isSeekingHelp: p.isSeekingHelp,
-    isSeekingOwner: p.isSeekingOwner,
+    // Derived, not stored — see isSeekingOwner() in lib/project-status.ts.
+    isSeekingOwner: isSeekingOwner(p),
+    // An owned project with an empty backlog. Surfaced as a badge rather than a status:
+    // as a status it flipped back and forth every time a task was completed, so nothing
+    // kept it up to date.
+    needsTasks: p.status === ProjectStatus.in_progress && p._count.children === 0,
+    openTaskCount: p._count.children,
     localGroup: p.localGroup,
     remoteEligibility: p.remoteEligibility,
     skills: p.skills.map((ps) => ({
@@ -206,5 +210,11 @@ export const projectInclude = {
   },
   assignee: { select: { id: true, name: true } },
   creator: { select: { id: true, name: true } },
-  _count: { select: { interests: { where: { status: InterestStatus.pending } } } },
+  _count: {
+    select: {
+      interests: { where: { status: InterestStatus.pending } },
+      // Open (non-completed) child tasks — feeds the derived `needsTasks` badge.
+      children: { where: { type: WorkItemType.TASK, status: { not: TaskStatus.completed } } },
+    },
+  },
 } satisfies Prisma.WorkItemInclude

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -4,6 +4,7 @@ import {
   InterestStatus,
   ProjectStatus,
   QuickTaskStatus,
+  RemoteEligibility,
   WorkItemType,
 } from '@/generated/prisma/enums'
 
@@ -134,6 +135,7 @@ export type EnrichedProject = {
   isSeekingHelp: boolean | null
   isSeekingOwner: boolean | null
   localGroup: string | null
+  remoteEligibility: RemoteEligibility
   skills: WorkItemSkillWithRelations[]
   assignee: { id: number; name: string } | null
   creator: { id: number; name: string } | null
@@ -175,6 +177,7 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
     isSeekingHelp: p.isSeekingHelp,
     isSeekingOwner: p.isSeekingOwner,
     localGroup: p.localGroup,
+    remoteEligibility: p.remoteEligibility,
     skills: p.skills.map((ps) => ({
       id: ps.skill.id,
       categoryId: ps.skill.categoryId,

--- a/prisma/migrations/20260813205953_add_remote_eligibility/migration.sql
+++ b/prisma/migrations/20260813205953_add_remote_eligibility/migration.sql
@@ -1,0 +1,118 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_volunteers" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+    "bio" TEXT,
+    "discord_handle" TEXT,
+    "signal_number" TEXT,
+    "whatsapp_number" TEXT,
+    "contact_preference" TEXT,
+    "contact_notes" TEXT,
+    "availability_hours_per_week" INTEGER,
+    "location" TEXT,
+    "other_skills" TEXT,
+    "consent_make_profile_visible_in_directory" BOOLEAN DEFAULT false,
+    "consent_contactable_by_project_owners" BOOLEAN DEFAULT false,
+    "consent_share_contact_info_with_project_owner" BOOLEAN DEFAULT false,
+    "consent_given_at" DATETIME,
+    "cookie_consent_analytics" BOOLEAN,
+    "auth_token" TEXT,
+    "auth_token_expires_at" DATETIME,
+    "password_hash" TEXT,
+    "is_admin" BOOLEAN DEFAULT false,
+    "is_technical_admin" BOOLEAN DEFAULT false,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" DATETIME,
+    "country" TEXT,
+    "email_digest" TEXT DEFAULT 'none',
+    "notify_remote_projects" BOOLEAN NOT NULL DEFAULT false,
+    "local_group" TEXT,
+    "location_confirmed_at" DATETIME,
+    "approval_status" TEXT NOT NULL DEFAULT 'pending',
+    "application_message" TEXT,
+    "application_admin_notes" TEXT,
+    "application_applicant_notes" TEXT,
+    "rejected_at" DATETIME,
+    "reviewer_id" INTEGER,
+    "email_confirmed" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "volunteers_reviewer_id_fkey" FOREIGN KEY ("reviewer_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+INSERT INTO "new_volunteers" ("application_admin_notes", "application_applicant_notes", "application_message", "approval_status", "auth_token", "auth_token_expires_at", "availability_hours_per_week", "bio", "consent_contactable_by_project_owners", "consent_given_at", "consent_make_profile_visible_in_directory", "consent_share_contact_info_with_project_owner", "contact_notes", "contact_preference", "cookie_consent_analytics", "country", "created_at", "deleted_at", "discord_handle", "email", "email_confirmed", "email_digest", "id", "is_admin", "is_technical_admin", "local_group", "location", "location_confirmed_at", "name", "other_skills", "password_hash", "rejected_at", "reviewer_id", "signal_number", "updated_at", "whatsapp_number") SELECT "application_admin_notes", "application_applicant_notes", "application_message", "approval_status", "auth_token", "auth_token_expires_at", "availability_hours_per_week", "bio", "consent_contactable_by_project_owners", "consent_given_at", "consent_make_profile_visible_in_directory", "consent_share_contact_info_with_project_owner", "contact_notes", "contact_preference", "cookie_consent_analytics", "country", "created_at", "deleted_at", "discord_handle", "email", "email_confirmed", "email_digest", "id", "is_admin", "is_technical_admin", "local_group", "location", "location_confirmed_at", "name", "other_skills", "password_hash", "rejected_at", "reviewer_id", "signal_number", "updated_at", "whatsapp_number" FROM "volunteers";
+DROP TABLE "volunteers";
+ALTER TABLE "new_volunteers" RENAME TO "volunteers";
+Pragma writable_schema=1;
+CREATE UNIQUE INDEX "sqlite_autoindex_volunteers_1" ON "volunteers"("email");
+Pragma writable_schema=0;
+Pragma writable_schema=1;
+CREATE UNIQUE INDEX "sqlite_autoindex_volunteers_2" ON "volunteers"("auth_token");
+Pragma writable_schema=0;
+CREATE INDEX "idx_volunteers_local_group" ON "volunteers"("local_group");
+CREATE INDEX "idx_volunteers_country" ON "volunteers"("country");
+CREATE INDEX "idx_volunteers_deleted" ON "volunteers"("deleted_at");
+CREATE INDEX "idx_volunteers_auth_token" ON "volunteers"("auth_token");
+CREATE INDEX "idx_volunteers_email" ON "volunteers"("email");
+CREATE TABLE "new_work_items" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "deadline" DATETIME,
+    "parent_id" INTEGER,
+    "context_project_id" INTEGER,
+    "creator_id" INTEGER,
+    "assignee_id" INTEGER,
+    "stakeholder_id" INTEGER,
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "review_notes" TEXT,
+    "review_rating" TEXT,
+    "project_type" TEXT,
+    "urgency" TEXT DEFAULT 'medium',
+    "estimated_duration" TEXT,
+    "time_commitment_hours_per_week" INTEGER,
+    "collaboration_link" TEXT,
+    "is_org_proposed" BOOLEAN DEFAULT false,
+    "is_seeking_help" BOOLEAN DEFAULT false,
+    "is_seeking_owner" BOOLEAN DEFAULT false,
+    "outcome" TEXT,
+    "outcome_notes" TEXT,
+    "completed_at" DATETIME,
+    "skill_id" INTEGER,
+    "estimated_hours" REAL,
+    "nudge_sent_at" DATETIME,
+    "final_warning_sent_at" DATETIME,
+    "sort_order" INTEGER DEFAULT 0,
+    "featured_as_quick_task" BOOLEAN DEFAULT false,
+    "country" TEXT,
+    "local_group" TEXT,
+    "remote_eligibility" TEXT NOT NULL DEFAULT 'NONE',
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "work_items_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_context_project_id_fkey" FOREIGN KEY ("context_project_id") REFERENCES "work_items" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_creator_id_fkey" FOREIGN KEY ("creator_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_stakeholder_id_fkey" FOREIGN KEY ("stakeholder_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+INSERT INTO "new_work_items" ("assignee_id", "collaboration_link", "completed_at", "context_project_id", "country", "created_at", "creator_id", "deadline", "description", "estimated_duration", "estimated_hours", "featured_as_quick_task", "final_warning_sent_at", "id", "is_org_proposed", "is_seeking_help", "is_seeking_owner", "local_group", "nudge_sent_at", "outcome", "outcome_notes", "parent_id", "project_type", "review_notes", "review_rating", "reviewed_at", "reviewed_by_id", "skill_id", "sort_order", "stakeholder_id", "status", "time_commitment_hours_per_week", "title", "type", "updated_at", "urgency") SELECT "assignee_id", "collaboration_link", "completed_at", "context_project_id", "country", "created_at", "creator_id", "deadline", "description", "estimated_duration", "estimated_hours", "featured_as_quick_task", "final_warning_sent_at", "id", "is_org_proposed", "is_seeking_help", "is_seeking_owner", "local_group", "nudge_sent_at", "outcome", "outcome_notes", "parent_id", "project_type", "review_notes", "review_rating", "reviewed_at", "reviewed_by_id", "skill_id", "sort_order", "stakeholder_id", "status", "time_commitment_hours_per_week", "title", "type", "updated_at", "urgency" FROM "work_items";
+DROP TABLE "work_items";
+ALTER TABLE "new_work_items" RENAME TO "work_items";
+CREATE INDEX "idx_work_items_type" ON "work_items"("type");
+CREATE INDEX "idx_work_items_status" ON "work_items"("status");
+CREATE INDEX "idx_work_items_parent" ON "work_items"("parent_id");
+CREATE INDEX "idx_work_items_context" ON "work_items"("context_project_id");
+CREATE INDEX "idx_work_items_creator" ON "work_items"("creator_id");
+CREATE INDEX "idx_work_items_assignee" ON "work_items"("assignee_id");
+CREATE INDEX "idx_work_items_skill" ON "work_items"("skill_id");
+CREATE INDEX "idx_work_items_local_group" ON "work_items"("local_group");
+CREATE INDEX "idx_work_items_country" ON "work_items"("country");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+

--- a/prisma/migrations/20260814091500_remove_seeking_help_status/migration.sql
+++ b/prisma/migrations/20260814091500_remove_seeking_help_status/migration.sql
@@ -1,0 +1,4 @@
+-- 'seeking_help' is retired as a project status value. It was only ever set on an
+-- owned project that also wanted more help — that's now represented purely by the
+-- isSeekingHelp flag, with status simply 'in_progress'. Backfill any existing rows.
+UPDATE "work_items" SET "status" = 'in_progress' WHERE "type" = 'PROJECT' AND "status" = 'seeking_help';

--- a/prisma/migrations/20260814094209_retire_seeking_owner_flag/migration.sql
+++ b/prisma/migrations/20260814094209_retire_seeking_owner_flag/migration.sql
@@ -1,0 +1,86 @@
+-- Status-value backfills. These must run BEFORE the table rebuild below, which copies
+-- `status` across verbatim.
+--
+-- 'seeking_owner' is retired as a status: "wants an owner" is now derived from
+-- (status, assignee_id) rather than stored. Its replacement, 'ready', means approved
+-- and live but unowned — so a seeking_owner row that somehow has an owner is not
+-- 'ready', it is simply 'in_progress' (these rows exist: assigning an owner used to
+-- clear the flag without moving the status).
+UPDATE "work_items" SET "status" = 'ready'
+  WHERE "type" = 'PROJECT' AND "status" = 'seeking_owner' AND "assignee_id" IS NULL;
+UPDATE "work_items" SET "status" = 'in_progress'
+  WHERE "type" = 'PROJECT' AND "status" = 'seeking_owner' AND "assignee_id" IS NOT NULL;
+
+-- 'needs_tasks' is retired too. An owned project with an empty backlog is still owned,
+-- so it is 'in_progress'; the empty backlog is surfaced as a derived badge instead of a
+-- status that flips back and forth as tasks are completed.
+UPDATE "work_items" SET "status" = 'in_progress'
+  WHERE "type" = 'PROJECT' AND "status" = 'needs_tasks';
+
+-- Note: `is_seeking_owner` is dropped by the rebuild. Rows that had it set to 1 while
+-- also having an owner lose that (contradictory) intent by design — the derived value
+-- for an owned project is always false.
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_work_items" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "deadline" DATETIME,
+    "parent_id" INTEGER,
+    "context_project_id" INTEGER,
+    "creator_id" INTEGER,
+    "assignee_id" INTEGER,
+    "stakeholder_id" INTEGER,
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "review_notes" TEXT,
+    "review_rating" TEXT,
+    "project_type" TEXT,
+    "urgency" TEXT DEFAULT 'medium',
+    "estimated_duration" TEXT,
+    "time_commitment_hours_per_week" INTEGER,
+    "collaboration_link" TEXT,
+    "is_org_proposed" BOOLEAN DEFAULT false,
+    "is_seeking_help" BOOLEAN DEFAULT false,
+    "outcome" TEXT,
+    "outcome_notes" TEXT,
+    "completed_at" DATETIME,
+    "skill_id" INTEGER,
+    "estimated_hours" REAL,
+    "nudge_sent_at" DATETIME,
+    "final_warning_sent_at" DATETIME,
+    "sort_order" INTEGER DEFAULT 0,
+    "featured_as_quick_task" BOOLEAN DEFAULT false,
+    "country" TEXT,
+    "local_group" TEXT,
+    "remote_eligibility" TEXT NOT NULL DEFAULT 'NONE',
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "work_items_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_context_project_id_fkey" FOREIGN KEY ("context_project_id") REFERENCES "work_items" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_creator_id_fkey" FOREIGN KEY ("creator_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_stakeholder_id_fkey" FOREIGN KEY ("stakeholder_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+INSERT INTO "new_work_items" ("assignee_id", "collaboration_link", "completed_at", "context_project_id", "country", "created_at", "creator_id", "deadline", "description", "estimated_duration", "estimated_hours", "featured_as_quick_task", "final_warning_sent_at", "id", "is_org_proposed", "is_seeking_help", "local_group", "nudge_sent_at", "outcome", "outcome_notes", "parent_id", "project_type", "remote_eligibility", "review_notes", "review_rating", "reviewed_at", "reviewed_by_id", "skill_id", "sort_order", "stakeholder_id", "status", "time_commitment_hours_per_week", "title", "type", "updated_at", "urgency") SELECT "assignee_id", "collaboration_link", "completed_at", "context_project_id", "country", "created_at", "creator_id", "deadline", "description", "estimated_duration", "estimated_hours", "featured_as_quick_task", "final_warning_sent_at", "id", "is_org_proposed", "is_seeking_help", "local_group", "nudge_sent_at", "outcome", "outcome_notes", "parent_id", "project_type", "remote_eligibility", "review_notes", "review_rating", "reviewed_at", "reviewed_by_id", "skill_id", "sort_order", "stakeholder_id", "status", "time_commitment_hours_per_week", "title", "type", "updated_at", "urgency" FROM "work_items";
+DROP TABLE "work_items";
+ALTER TABLE "new_work_items" RENAME TO "work_items";
+CREATE INDEX "idx_work_items_type" ON "work_items"("type");
+CREATE INDEX "idx_work_items_status" ON "work_items"("status");
+CREATE INDEX "idx_work_items_parent" ON "work_items"("parent_id");
+CREATE INDEX "idx_work_items_context" ON "work_items"("context_project_id");
+CREATE INDEX "idx_work_items_creator" ON "work_items"("creator_id");
+CREATE INDEX "idx_work_items_assignee" ON "work_items"("assignee_id");
+CREATE INDEX "idx_work_items_skill" ON "work_items"("skill_id");
+CREATE INDEX "idx_work_items_local_group" ON "work_items"("local_group");
+CREATE INDEX "idx_work_items_country" ON "work_items"("country");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,12 +15,16 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// Lifecycle position only. Whether a project wants an owner or more help is not a
+// status: `isSeekingOwner` is derived (see lib/project-status.ts) and `isSeekingHelp`
+// is an independent flag the owner controls.
+//   pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
+// `ready` = approved and live, but nobody owns it yet.
 enum ProjectStatus {
   pending_review
   needs_discussion
+  ready
   in_progress
-  needs_tasks
-  seeking_owner
   on_hold
   completed
   archived
@@ -274,8 +278,9 @@ model WorkItem {
   timeCommitmentHoursPerWeek Int?      @map("time_commitment_hours_per_week")
   collaborationLink          String?   @map("collaboration_link")
   isOrgProposed              Boolean?  @default(false) @map("is_org_proposed")
+  // No `is_seeking_owner` column: it is derived from (status, assigneeId). See
+  // isSeekingOwner() in lib/project-status.ts.
   isSeekingHelp              Boolean?  @default(false) @map("is_seeking_help")
-  isSeekingOwner             Boolean?  @default(false) @map("is_seeking_owner")
   outcome                    String? // TODO: enum — successful, partial, not_completed, ongoing
   outcomeNotes               String?   @map("outcome_notes")
   completedAt                DateTime? @map("completed_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,6 @@ enum ProjectStatus {
   needs_discussion
   in_progress
   needs_tasks
-  seeking_help
   seeking_owner
   on_hold
   completed

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,12 @@ enum WorkItemType {
   QUICK_TASK
 }
 
+enum RemoteEligibility {
+  NONE
+  COUNTRY
+  GLOBAL
+}
+
 enum TaskStatus {
   open
   in_progress
@@ -283,10 +289,11 @@ model WorkItem {
   sortOrder           Int?      @default(0) @map("sort_order")
   featuredAsQuickTask Boolean?  @default(false) @map("featured_as_quick_task") // TASK only — also list on the Quick Tasks page
 
-  country    String?
-  localGroup String?   @map("local_group")
-  createdAt  DateTime? @default(now()) @map("created_at")
-  updatedAt  DateTime? @default(now()) @map("updated_at")
+  country           String?
+  localGroup        String?           @map("local_group")
+  remoteEligibility RemoteEligibility @default(NONE) @map("remote_eligibility")
+  createdAt         DateTime?         @default(now()) @map("created_at")
+  updatedAt         DateTime?         @default(now()) @map("updated_at")
 
   creator     Volunteer?         @relation("WorkItemCreator", fields: [creatorId], references: [id], onUpdate: NoAction)
   assignee    Volunteer?         @relation("WorkItemAssignee", fields: [assigneeId], references: [id], onUpdate: NoAction)
@@ -526,6 +533,7 @@ model Volunteer {
   deletedAt                               DateTime?                @map("deleted_at")
   country                                 String?
   emailDigest                             String?                  @default("none") @map("email_digest") // TODO: enum — none, daily, weekly
+  notifyRemoteProjects                    Boolean                  @default(false) @map("notify_remote_projects")
   localGroup                              String?                  @map("local_group")
   locationConfirmedAt                     DateTime?                @map("location_confirmed_at")
   approvalStatus                          ApprovalStatus           @default(pending) @map("approval_status")

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -35,6 +35,7 @@ export const adminProjectsRouter = {
           collaborationLink: input.collaborationLink ?? null,
           country: input.country ?? null,
           localGroup: input.localGroup ?? null,
+          remoteEligibility: input.remoteEligibility ?? 'NONE',
           isSeekingHelp: input.isSeekingHelp !== false,
           isSeekingOwner: input.isSeekingOwner === true,
         },

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -83,11 +83,9 @@ export const adminProjectsRouter = {
 
       if (status === 'approved') {
         const hasOwner = project.assigneeId !== null
-        const newStatus = !hasOwner
-          ? ProjectStatus.seeking_owner
-          : project.isSeekingHelp
-            ? ProjectStatus.seeking_help
-            : ProjectStatus.in_progress
+        // Whether it also wants more help is tracked by isSeekingHelp alone, not status —
+        // an owned project is just 'in_progress', with isSeekingHelp as an overlay flag.
+        const newStatus = !hasOwner ? ProjectStatus.seeking_owner : ProjectStatus.in_progress
         const isSeekingOwner = !hasOwner
         const isSeekingHelp = !hasOwner || project.isSeekingHelp
 

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -24,7 +24,9 @@ export const adminProjectsRouter = {
           type: WorkItemType.PROJECT,
           title: input.title,
           description: input.description,
-          status: ProjectStatus.in_progress,
+          // Org projects skip review, so they go live immediately — owned by the admin
+          // who created it, or `ready` for someone to pick up.
+          status: wantToOwn ? ProjectStatus.in_progress : ProjectStatus.ready,
           assigneeId: wantToOwn ? admin.id : null,
           creatorId: admin.id,
           isOrgProposed: true,
@@ -37,7 +39,6 @@ export const adminProjectsRouter = {
           localGroup: input.localGroup ?? null,
           remoteEligibility: input.remoteEligibility ?? 'NONE',
           isSeekingHelp: input.isSeekingHelp !== false,
-          isSeekingOwner: input.isSeekingOwner === true,
         },
       })
 
@@ -82,19 +83,17 @@ export const adminProjectsRouter = {
       const { status, reviewNotes = null, comment = null } = input
 
       if (status === 'approved') {
-        const hasOwner = project.assigneeId !== null
-        // Whether it also wants more help is tracked by isSeekingHelp alone, not status —
-        // an owned project is just 'in_progress', with isSeekingHelp as an overlay flag.
-        const newStatus = !hasOwner ? ProjectStatus.seeking_owner : ProjectStatus.in_progress
-        const isSeekingOwner = !hasOwner
-        const isSeekingHelp = !hasOwner || project.isSeekingHelp
+        // A proposer who offered to lead it owns it from the moment it's approved;
+        // otherwise it goes live as `ready` for someone to pick up. Whether it also wants
+        // contributors is the proposer's call — approval no longer overrides an explicit
+        // "no thanks" by force-setting isSeekingHelp on every unowned project.
+        const newStatus =
+          project.assigneeId === null ? ProjectStatus.ready : ProjectStatus.in_progress
 
         await prisma.workItem.update({
           where: { id: input.id },
           data: {
             status: newStatus,
-            isSeekingHelp,
-            isSeekingOwner,
             reviewNotes,
             stakeholderId: admin.id,
             reviewedById: admin.id,
@@ -185,7 +184,10 @@ export const adminProjectsRouter = {
           outcome,
           outcomeNotes,
           completedAt: isCompleted ? new Date() : null,
-          ...(isCompleted ? { status: ProjectStatus.completed } : {}),
+          // Completing here has to stop advertising the project, exactly as completing it
+          // via projects.update does — otherwise a finished project keeps its "Seeking
+          // Help" badge and stays in the "Looking for People" group.
+          ...(isCompleted ? { status: ProjectStatus.completed, isSeekingHelp: false } : {}),
           updatedAt: new Date(),
         },
       })
@@ -253,6 +255,8 @@ export const adminProjectsRouter = {
     return projects.map((p) => withProjectExtras(p as EnrichedProject))
   }),
 
+  // Owned projects with an empty backlog — the same condition the `needsTasks` badge
+  // derives, from the admin side.
   staleInProgress: adminProcedure.handler(async () => {
     const projects = await prisma.workItem.findMany({
       where: {

--- a/server/routers/admin/stats.ts
+++ b/server/routers/admin/stats.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { adminProcedure } from '../../procedures'
+import { ADVERTISABLE_STATUSES } from '@/lib/project-status'
 import { InterestStatus, ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const adminStatsRouter = {
@@ -27,7 +28,10 @@ export const adminStatsRouter = {
       prisma.workItem.count({
         where: {
           type: WorkItemType.PROJECT,
-          OR: [{ isSeekingHelp: true }, { isSeekingOwner: true }],
+          // Approved and unfinished only — this used to count pending-review proposals
+          // and completed projects carrying stale flags.
+          status: { in: ADVERTISABLE_STATUSES },
+          OR: [{ isSeekingHelp: true }, { assigneeId: null }],
         },
       }),
       prisma.workItem.count({

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
 import { authedProcedure } from '../procedures'
-import { ProjectStatus, WorkItemType } from '@/generated/prisma/enums'
+import { ADVERTISABLE_STATUSES } from '@/lib/project-status'
+import { WorkItemType } from '@/generated/prisma/enums'
 
 export const dashboardRouter = {
   get: authedProcedure.handler(async ({ context }) => {
@@ -50,12 +51,18 @@ export const dashboardRouter = {
               where: {
                 type: WorkItemType.PROJECT,
                 skills: { some: { skillId: { in: [...volunteerSkillIds] } } },
-                OR: [
-                  { isSeekingHelp: true },
-                  { isSeekingOwner: true },
-                  { status: ProjectStatus.seeking_owner },
+                // Approved and unfinished only. Without this, proposals still awaiting
+                // review were recommended to volunteers — every project is created with
+                // isSeekingHelp true, so the flag alone matched them before an admin had
+                // even seen them.
+                status: { in: ADVERTISABLE_STATUSES },
+                AND: [
+                  { OR: [{ isSeekingHelp: true }, { assigneeId: null }] },
+                  // `{ not: id }` alone drops rows where assignee_id IS NULL, which meant
+                  // ownerless projects — the ones most in need of someone — were never
+                  // suggested to anyone. Same workaround as proposedProjects above.
+                  { OR: [{ assigneeId: null }, { assigneeId: { not: volunteer.id } }] },
                 ],
-                assigneeId: { not: volunteer.id },
                 id: { notIn: interestedProjectIds.length > 0 ? interestedProjectIds : [-1] },
               },
               orderBy: { createdAt: 'desc' },

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -53,7 +53,7 @@ export const dashboardRouter = {
                 OR: [
                   { isSeekingHelp: true },
                   { isSeekingOwner: true },
-                  { status: { in: [ProjectStatus.seeking_owner, ProjectStatus.seeking_help] } },
+                  { status: ProjectStatus.seeking_owner },
                 ],
                 assigneeId: { not: volunteer.id },
                 id: { notIn: interestedProjectIds.length > 0 ? interestedProjectIds : [-1] },

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -234,6 +234,7 @@ export const projectsRouter = {
           collaborationLink: input.collaborationLink ?? null,
           country: input.country ?? null,
           localGroup: input.localGroup ?? null,
+          remoteEligibility: input.remoteEligibility ?? 'NONE',
           isSeekingHelp: input.isSeekingHelp !== false,
           isSeekingOwner: !wantToOwn,
         },
@@ -486,6 +487,7 @@ export const projectsRouter = {
         'collaborationLink',
         'country',
         'localGroup',
+        'remoteEligibility',
         'outcome',
         'outcomeNotes',
       ] as const

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -19,21 +19,19 @@ import {
 } from '@/lib/schemas'
 import { authedProcedure, approvedProcedure, adminProcedure } from '../procedures'
 import {
+  OWNER_ALLOWED_STATUSES,
+  SEEKING_OWNER_SQL,
+  TERMINAL_STATUSES,
+  UNAPPROVED_STATUSES,
+  projectStatusLabel,
+} from '@/lib/project-status'
+import {
   ApprovalStatus,
   InterestStatus,
   ProjectStatus,
   TaskStatus,
   WorkItemType,
 } from '@/generated/prisma/enums'
-
-const STATUS_LABELS: Record<string, string> = {
-  seeking_owner: 'Seeking Owner',
-  needs_tasks: 'Needs Tasks',
-  in_progress: 'In Progress',
-  on_hold: 'On Hold',
-  completed: 'Completed',
-  archived: 'Archived',
-}
 
 /** Has this volunteer been declined from, or withdrawn from, this project? */
 async function isBlockedFromClaiming(projectId: number, volunteerId: number): Promise<boolean> {
@@ -70,15 +68,6 @@ async function releaseTasksHeldBy(projectId: number, volunteerId: number): Promi
     },
   })
 }
-
-// 'needs_tasks' is deliberately excluded — it's a system-derived state (an assigned
-// project with zero open tasks), not something an owner should be able to set directly.
-const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
-  ProjectStatus.seeking_owner,
-  ProjectStatus.in_progress,
-  ProjectStatus.on_hold,
-  ProjectStatus.completed,
-]
 
 // open and in_progress share a bucket so claiming/assigning a task doesn't
 // disturb its priority position — only completed tasks sink to the bottom.
@@ -130,7 +119,7 @@ export const projectsRouter = {
       } else {
         conditions.push(
           Prisma.raw(
-            `status NOT IN ('${ProjectStatus.archived}', '${ProjectStatus.pending_review}', '${ProjectStatus.needs_discussion}')`,
+            `status NOT IN ('${ProjectStatus.archived}', ${UNAPPROVED_STATUSES.map((s) => `'${s}'`).join(', ')})`,
           ),
         )
       }
@@ -157,18 +146,20 @@ export const projectsRouter = {
         conditions.push(Prisma.sql`is_seeking_help = ${input.isSeekingHelp ? 1 : 0}`)
       }
       if (input.isSeekingOwner !== undefined) {
-        conditions.push(Prisma.sql`is_seeking_owner = ${input.isSeekingOwner ? 1 : 0}`)
+        conditions.push(
+          Prisma.raw(input.isSeekingOwner ? SEEKING_OWNER_SQL : `NOT ${SEEKING_OWNER_SQL}`),
+        )
       }
       if (input.isSeekingAny) {
-        conditions.push(Prisma.raw(`(is_seeking_help = 1 OR is_seeking_owner = 1)`))
+        conditions.push(Prisma.raw(`(is_seeking_help = 1 OR ${SEEKING_OWNER_SQL})`))
       }
       if (input.notSeeking) {
-        conditions.push(Prisma.raw(`is_seeking_help = 0 AND is_seeking_owner = 0`))
+        conditions.push(Prisma.raw(`is_seeking_help = 0 AND NOT ${SEEKING_OWNER_SQL}`))
       }
 
       const whereClause = Prisma.sql`WHERE ${Prisma.join(conditions, ' AND ')}`
       const orderClause = Prisma.raw(`ORDER BY
-        CASE WHEN is_seeking_help = 1 OR is_seeking_owner = 1 THEN 0 ELSE 1 END,
+        CASE WHEN is_seeking_help = 1 OR ${SEEKING_OWNER_SQL} THEN 0 ELSE 1 END,
         CASE urgency WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
         created_at DESC`)
 
@@ -235,7 +226,6 @@ export const projectsRouter = {
           localGroup: input.localGroup ?? null,
           remoteEligibility: input.remoteEligibility ?? 'NONE',
           isSeekingHelp: input.isSeekingHelp !== false,
-          isSeekingOwner: !wantToOwn,
         },
       })
 
@@ -495,12 +485,7 @@ export const projectsRouter = {
       }
       if (body.timeCommitmentHoursPerWeek !== undefined)
         data.timeCommitmentHoursPerWeek = body.timeCommitmentHoursPerWeek
-      if (body.assigneeId !== undefined) {
-        data.assigneeId = body.assigneeId
-        if (body.assigneeId !== null && body.isSeekingOwner === undefined) {
-          data.isSeekingOwner = false
-        }
-      }
+      if (body.assigneeId !== undefined) data.assigneeId = body.assigneeId
 
       if (newStatus !== undefined) {
         if (volunteer.isAdmin) {
@@ -511,11 +496,26 @@ export const projectsRouter = {
       }
 
       if (body.isSeekingHelp !== undefined) data.isSeekingHelp = body.isSeekingHelp
-      if (body.isSeekingOwner !== undefined) data.isSeekingOwner = body.isSeekingOwner
 
-      if (data.status === ProjectStatus.completed || data.status === ProjectStatus.archived) {
+      // Gaining an owner starts the work; losing one hands the project back to `ready`
+      // rather than leaving it in_progress with nobody on it. isSeekingOwner needs no
+      // maintenance here — it is derived from exactly these two fields.
+      const resultingAssigneeId =
+        body.assigneeId !== undefined ? body.assigneeId : project.assigneeId
+      if (data.status === undefined && !TERMINAL_STATUSES.includes(project.status)) {
+        if (resultingAssigneeId !== null && project.status === ProjectStatus.ready) {
+          data.status = ProjectStatus.in_progress
+        } else if (
+          resultingAssigneeId === null &&
+          project.status !== ProjectStatus.ready &&
+          !UNAPPROVED_STATUSES.includes(project.status)
+        ) {
+          data.status = ProjectStatus.ready
+        }
+      }
+
+      if (TERMINAL_STATUSES.includes(data.status as string)) {
         if (data.isSeekingHelp === undefined) data.isSeekingHelp = false
-        if (data.isSeekingOwner === undefined) data.isSeekingOwner = false
       }
 
       data.updatedAt = new Date()
@@ -535,8 +535,10 @@ export const projectsRouter = {
         }
       }
 
-      if (newStatus && newStatus !== project.status) {
-        const statusLabel = STATUS_LABELS[newStatus] ?? newStatus
+      // Covers the implicit ready ⇄ in_progress moves above, not just an explicit pick.
+      const effectiveStatus = data.status as string | undefined
+      if (effectiveStatus && effectiveStatus !== project.status) {
+        const statusLabel = projectStatusLabel(effectiveStatus)
         const notifyIds = new Set<number>()
         if (project.assigneeId && project.assigneeId !== volunteer.id)
           notifyIds.add(project.assigneeId)
@@ -591,12 +593,9 @@ export const projectsRouter = {
         where: {
           id: input.projectId,
           type: WorkItemType.PROJECT,
-          status: { notIn: [ProjectStatus.completed, ProjectStatus.archived] },
-          OR: [
-            { isSeekingHelp: true },
-            { isSeekingOwner: true },
-            { status: ProjectStatus.seeking_owner },
-          ],
+          status: { notIn: TERMINAL_STATUSES },
+          // Seeking help is a stored flag; seeking an owner is simply having none.
+          OR: [{ isSeekingHelp: true }, { assigneeId: null }],
         },
       })
       if (!project) {
@@ -728,19 +727,9 @@ export const projectsRouter = {
       }
 
       if (input.status === InterestStatus.accepted && interest.interestType === 'want_to_own') {
-        const openTaskCount = await prisma.workItem.count({
-          where: {
-            parentId: input.projectId,
-            type: WorkItemType.TASK,
-            status: { not: TaskStatus.completed },
-          },
-        })
         await prisma.workItem.update({
           where: { id: input.projectId },
-          data: {
-            assigneeId: interest.volunteerId,
-            status: openTaskCount > 0 ? ProjectStatus.in_progress : ProjectStatus.needs_tasks,
-          },
+          data: { assigneeId: interest.volunteerId, status: ProjectStatus.in_progress },
         })
       }
 
@@ -823,10 +812,20 @@ export const projectsRouter = {
         })
       }
 
-      if (input.interestType === 'want_to_own' && project.isSeekingOwner) {
+      // Assigning someone as owner has to actually set the owner. This previously only
+      // cleared the (now derived) isSeekingOwner flag, leaving the project ownerless and
+      // no longer advertising for one — unlike respondToInterest, which took the same
+      // intent and did set the assignee.
+      if (input.interestType === 'want_to_own' && project.assigneeId === null) {
         await prisma.workItem.update({
           where: { id: input.projectId },
-          data: { isSeekingOwner: false },
+          data: {
+            assigneeId: input.volunteerId,
+            status: TERMINAL_STATUSES.includes(project.status)
+              ? project.status
+              : ProjectStatus.in_progress,
+            updatedAt: new Date(),
+          },
         })
       }
 
@@ -978,12 +977,6 @@ export const projectsRouter = {
             sortOrder: (max._max.sortOrder ?? 0) + 1,
           },
         })
-        if (project.status === ProjectStatus.needs_tasks) {
-          await tx.workItem.update({
-            where: { id: input.projectId },
-            data: { status: ProjectStatus.in_progress },
-          })
-        }
         return newTask
       })
 

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -28,7 +28,6 @@ import {
 
 const STATUS_LABELS: Record<string, string> = {
   seeking_owner: 'Seeking Owner',
-  seeking_help: 'Seeking Help',
   needs_tasks: 'Needs Tasks',
   in_progress: 'In Progress',
   on_hold: 'On Hold',
@@ -72,10 +71,10 @@ async function releaseTasksHeldBy(projectId: number, volunteerId: number): Promi
   })
 }
 
+// 'needs_tasks' is deliberately excluded — it's a system-derived state (an assigned
+// project with zero open tasks), not something an owner should be able to set directly.
 const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
   ProjectStatus.seeking_owner,
-  ProjectStatus.seeking_help,
-  ProjectStatus.needs_tasks,
   ProjectStatus.in_progress,
   ProjectStatus.on_hold,
   ProjectStatus.completed,
@@ -596,7 +595,7 @@ export const projectsRouter = {
           OR: [
             { isSeekingHelp: true },
             { isSeekingOwner: true },
-            { status: { in: [ProjectStatus.seeking_owner, ProjectStatus.seeking_help] } },
+            { status: ProjectStatus.seeking_owner },
           ],
         },
       })

--- a/server/routers/quickTasks.ts
+++ b/server/routers/quickTasks.ts
@@ -77,6 +77,7 @@ export const quickTasksRouter = {
         projectId: t.parentId as number,
         projectTitle: t.parent?.title ?? null,
         title: t.title,
+        description: t.description,
         status: t.status,
         assignedToId: t.assigneeId,
         assignedToName: t.assignee?.name ?? null,

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -297,6 +297,7 @@ export const volunteersRouter = {
       'localGroup',
       'otherSkills',
       'emailDigest',
+      'notifyRemoteProjects',
       'applicationMessage',
     ] as const
     for (const field of scalarFields) {


### PR DESCRIPTION
## Summary

Two related threads: scoping project-match alerts by location, and then straightening out project status — which turned out to be tangled enough that fixing it properly needed its own pass.

### Remote eligibility and geo-scoped match alerts

Project-match alerts (immediate skill-match email + fortnightly digest) previously ignored location entirely — a volunteer in one country could be emailed about an unrelated project in another country, purely on skill overlap. This is what caused a UK-based user to get notified about an Australia-based project.

- Added `WorkItem.remoteEligibility` enum (`NONE` / `COUNTRY` / `GLOBAL`), set from a new dropdown on the project create/edit forms, and surfaced on the project card and project page.
- Added `Volunteer.notifyRemoteProjects` opt-in toggle in Settings → Notifications.
- Match-alert eligibility (`lib/matching.ts#isGeoEligible`, wired into `lib/project-match-notify.ts` and `jobs/digest.ts`): same-country volunteers are always eligible; out-of-country volunteers are only eligible for `GLOBAL`-remote projects, and only if they've opted in.
- Along the way, fixed two pre-existing gaps that would have silently broken the new opt-in toggle: `notifyRemoteProjects` was missing from the `volunteers.updateMe` field allowlist and from the `auth.me` response whitelist (`redactVolunteer`), and `remoteEligibility` was missing from the project-serialization whitelist (`withProjectExtras`).

### Project status as a lifecycle

Moved project status and location into a sidebar status card, then rebuilt what status actually means.

`seeking_owner` existed as **both** a status and a stored `is_seeking_owner` flag meaning the same thing. Every mutation touching ownership had to remember to update both, and several didn't — which is where most of the bugs below come from. Status is now purely lifecycle position:

```
pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
```

`ready` means approved and live but unowned. Assigning an owner is what moves a project to `in_progress`; losing one hands it back to `ready`. Seeking-an-owner is derived, never stored:

```
isSeekingOwner = assigneeId IS NULL AND status IN (ready, in_progress, on_hold)
```

`needs_tasks` is retired for the same reason — an owned project with an empty backlog is still owned, and a status that flipped back and forth as tasks completed is precisely why nothing kept it up to date. It's now a derived badge off the open-task count. `isSeekingHelp` survives as the one genuinely owner-controlled flag.

`lib/project-status.ts` becomes the single source of truth for labels, badge variants and pickable-status lists, replacing three copies that had already drifted apart.

### Bugs fixed

All of these were reachable in production:

- `projects.assign` with `want_to_own` created the accepted interest and cleared the flag but **never set `assigneeId`** — the project ended up ownerless *and* no longer advertising for an owner. `respondToInterest` handled the identical intent correctly; the two paths had diverged.
- "Remove ownership" left the project In Progress with nobody on it and nothing advertising it — invisible to anyone browsing for something to lead.
- An owned project could sit in `seeking_owner` with the flag cleared, and the card suppressed the status badge for exactly that status (to avoid printing it twice) — so the card rendered no status at all.
- Dashboard suggestions and the admin "seeking" count matched on the flags with no status guard. Every project is created with `isSeekingHelp` true, so **unreviewed proposals were recommended to volunteers before an admin had seen them**.
- Dashboard suggestions also dropped every ownerless project: Prisma's `{ not: id }` excludes NULL rows, so the projects most in need of someone were never suggested to anyone. (Same workaround the file already used for `proposedProjects`.)
- `setOutcome` completed a project without clearing `isSeekingHelp`, unlike `projects.update` — so finished projects kept their "Seeking Help" badge and their place in the "Looking for People" group.
- Approval force-set `isSeekingHelp` on any unowned project, overriding a proposer who had explicitly unticked it.
- Status-change notifications emailed raw enum strings (`'X' is now needs_discussion`) for statuses the server's label copy had never heard of.

## Migration

`20260814094209_retire_seeking_owner_flag` backfills before dropping the column: ownerless `seeking_owner` → `ready`, owned `seeking_owner` → `in_progress` (repairing rows stranded by the badge bug above), `needs_tasks` → `in_progress`.

**Forward-only.** Rolling back to the previous code would find neither the `is_seeking_owner` column nor the old enum values.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (full Playwright e2e suite, 190 tests)

New `e2e/tests/27-remote-eligibility.spec.ts`:
- Admin can mark a project remote-eligible and it persists through edit
- Volunteer can opt in to remote-friendly alerts and it persists
- A `GLOBAL` remote project alerts an opted-in out-of-country volunteer but not an opted-out one
- A `NONE`-eligibility project alerts no out-of-country volunteer even if opted in

New `e2e/tests/28-project-ownership-states.spec.ts`, covering the assignment and visibility paths:
- An org project with no owner starts `ready` and seeking an owner
- Both assignment routes (`projects.assign`, and accepting a `want_to_own` interest) set the owner and start the project
- Removing the owner returns it to `ready` **and** re-surfaces it under the "Seeking Owner" filter
- An owned project shows its status badge and is excluded from that filter
- Recording an outcome stops the project advertising for help
- A proposal awaiting review isn't suggested to matching volunteers, but is once approved

Two existing assertions updated for the new lifecycle (approval lands on "Ready"; an org project the admin didn't claim is "Ready", not "In Progress"), and the retired `needs_tasks` test rewritten against the derived badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkp5UGb1ym3kw8FLj7275n
