### PR TITLE
Track whether cron job runs were triggered by cron or admin

### DIFF
--- a/app/admin/cron-runs/page.tsx
+++ b/app/admin/cron-runs/page.tsx
@@ -14,6 +14,7 @@ import Modal from '@/components/ui/Modal'
 type CronRun = {
   id: number
   jobName: string
+  triggeredBy: string
   status: string
   startedAt: string | Date
   finishedAt: string | Date | null
@@ -100,6 +101,7 @@ export default function AdminCronRunsPage() {
             <thead>
               <tr className="border-b-2 border-brand-border text-left">
                 <th className="p-3">Job</th>
+                <th className="p-3">Triggered by</th>
                 <th className="p-3">Status</th>
                 <th className="p-3">Started</th>
                 <th className="p-3">Finished</th>
@@ -115,6 +117,11 @@ export default function AdminCronRunsPage() {
                   onClick={() => setSelectedRun(run)}
                 >
                   <td className="p-3 font-semibold whitespace-nowrap">{run.jobName}</td>
+                  <td className="p-3">
+                    <Badge variant={run.triggeredBy === 'admin' ? 'info' : 'neutral'}>
+                      {run.triggeredBy}
+                    </Badge>
+                  </td>
                   <td className="p-3">
                     <Badge variant={STATUS_VARIANT[run.status] ?? 'neutral'}>{run.status}</Badge>
                   </td>
@@ -143,6 +150,7 @@ export default function AdminCronRunsPage() {
       >
         {selectedRun && (
           <div>
+            <p className="text-sm text-text-light mb-1">Triggered by: {selectedRun.triggeredBy}</p>
             <p className="text-sm text-text-light mb-1">
               Started: {formatDateTime(selectedRun.startedAt)}
             </p>

--- a/lib/cron-audit.ts
+++ b/lib/cron-audit.ts
@@ -10,9 +10,15 @@ function summarize(result: unknown): string {
   }
 }
 
-export async function recordCronRun<T>(jobName: string, fn: () => Promise<T>): Promise<T> {
+export type CronTriggerSource = 'cron' | 'admin'
+
+export async function recordCronRun<T>(
+  jobName: string,
+  fn: () => Promise<T>,
+  triggeredBy: CronTriggerSource = 'cron',
+): Promise<T> {
   const run = await prisma.cronJobRun.create({
-    data: { jobName, status: 'running' },
+    data: { jobName, status: 'running', triggeredBy },
   })
 
   try {

--- a/lib/cron-jobs.ts
+++ b/lib/cron-jobs.ts
@@ -1,4 +1,4 @@
-import { recordCronRun } from '@/lib/cron-audit'
+import { recordCronRun, type CronTriggerSource } from '@/lib/cron-audit'
 import { runBackupJob } from '@/jobs/backup'
 import { runDigestJob } from '@/jobs/digest'
 import { runNudgesJob } from '@/jobs/nudges'
@@ -7,11 +7,13 @@ import { type CronJobName } from '@/lib/cron-job-names'
 
 export { CRON_JOB_NAMES, type CronJobName } from '@/lib/cron-job-names'
 
-export const CRON_JOBS: Record<CronJobName, () => Promise<unknown>> = {
-  backup: () => recordCronRun('backup', runBackupJob),
-  digest: () => recordCronRun('digest', runDigestJob),
-  nudges: () => recordCronRun('nudges', runNudgesJob),
-  'applications-summary': () => recordCronRun('applications-summary', runApplicationsSummaryJob),
-  'applications-anonymisation': () =>
-    recordCronRun('applications-anonymisation', runApplicationsAnonymisationJob),
-}
+export const CRON_JOBS: Record<CronJobName, (triggeredBy?: CronTriggerSource) => Promise<unknown>> =
+  {
+    backup: (triggeredBy) => recordCronRun('backup', runBackupJob, triggeredBy),
+    digest: (triggeredBy) => recordCronRun('digest', runDigestJob, triggeredBy),
+    nudges: (triggeredBy) => recordCronRun('nudges', runNudgesJob, triggeredBy),
+    'applications-summary': (triggeredBy) =>
+      recordCronRun('applications-summary', runApplicationsSummaryJob, triggeredBy),
+    'applications-anonymisation': (triggeredBy) =>
+      recordCronRun('applications-anonymisation', runApplicationsAnonymisationJob, triggeredBy),
+  }

--- a/prisma/migrations/20260814192728_add_cron_run_triggered_by/migration.sql
+++ b/prisma/migrations/20260814192728_add_cron_run_triggered_by/migration.sql
@@ -1,0 +1,18 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_cron_job_runs" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "job_name" TEXT NOT NULL,
+    "triggered_by" TEXT NOT NULL DEFAULT 'cron',
+    "started_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finished_at" DATETIME,
+    "status" TEXT NOT NULL,
+    "summary" TEXT
+);
+INSERT INTO "new_cron_job_runs" ("finished_at", "id", "job_name", "started_at", "status", "summary") SELECT "finished_at", "id", "job_name", "started_at", "status", "summary" FROM "cron_job_runs";
+DROP TABLE "cron_job_runs";
+ALTER TABLE "new_cron_job_runs" RENAME TO "cron_job_runs";
+CREATE INDEX "idx_cron_job_runs_job_name" ON "cron_job_runs"("job_name");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -421,12 +421,13 @@ model ApplicationsSummaryRun {
 }
 
 model CronJobRun {
-  id         Int       @id @default(autoincrement())
-  jobName    String    @map("job_name")
-  startedAt  DateTime  @default(now()) @map("started_at")
-  finishedAt DateTime? @map("finished_at")
-  status     String // running | success | error
-  summary    String?
+  id          Int       @id @default(autoincrement())
+  jobName     String    @map("job_name")
+  triggeredBy String    @default("cron") @map("triggered_by") // cron | admin
+  startedAt   DateTime  @default(now()) @map("started_at")
+  finishedAt  DateTime? @map("finished_at")
+  status      String // running | success | error
+  summary     String?
 
   @@index([jobName], map: "idx_cron_job_runs_job_name")
   @@map("cron_job_runs")

--- a/server/routers/admin/cronRuns.ts
+++ b/server/routers/admin/cronRuns.ts
@@ -21,7 +21,7 @@ export const adminCronRunsRouter = {
   run: superAdminProcedure
     .input(z.object({ jobName: z.enum([...CRON_JOB_NAMES] as [CronJobName, ...CronJobName[]]) }))
     .handler(async ({ input }) => {
-      const result = await CRON_JOBS[input.jobName]()
+      const result = await CRON_JOBS[input.jobName]('admin')
       return { result }
     }),
 }


### PR DESCRIPTION
## Summary
- `CronJobRun` gets a `triggeredBy` column (`cron` | `admin`, default `cron`)
- `recordCronRun()` / `CRON_JOBS[name]()` take and forward the source
- Admin panel's "Run now" button tags its runs `admin`; the real `/api/cron/*` endpoints stay untagged (default `cron`)
- `/admin/cron-runs` table + detail modal show a "Triggered by" badge

Came out of debugging why the daily cron job showed no runs — while diagnosing, couldn't tell from the run history whether a listed run was the real cron hitting the endpoint or someone testing via the admin panel.

## Test plan
- [x] `npm run check-all` — typecheck, lint, format, 190 e2e tests all pass
- [ ] Spot-check `/admin/cron-runs`: click "Run now" on a job, confirm it shows `admin`; verify existing/backfilled rows show `cron`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aMYRvQcg9EHRgJXuypUrT