### PR TITLE
fix: exec next binary directly, skip npx wrapper on Railway shutdown

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "NIXPACKS"
 buildCommand = "npm run build:railway"
 
 [deploy]
-startCommand = "npm run migrate && exec npx next start"
+startCommand = "npm run migrate && exec node_modules/.bin/next start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 # Old container gets 0s by default between SIGTERM and SIGKILL, so it's


### PR DESCRIPTION
## Summary
- Railway still logged a false-alarm `npm error signal SIGTERM` on every rolling deploy, even after the earlier `exec npx next start` fix
- Root cause: `npx` spawns `next` as a child process instead of exec-ing into it, and npx reuses npm's error-reporting code, so the wrapper still relays/prints the signal as an npm error
- Fix: exec the `next` binary directly (`node_modules/.bin/next`), removing the last wrapper process in the chain

## Test plan
- [ ] Deploy to Railway and confirm no `npm error signal SIGTERM` on the next rolling deploy
- [ ] Confirm app still starts and serves traffic normally after migrate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEMsM5tuaTWcjpoKmqFkUu