### PR TITLE
Add standalone node script + Railway config for daily cron trigger

### DIFF
--- a/railway.cron.toml
+++ b/railway.cron.toml
@@ -2,5 +2,5 @@
 builder = "NIXPACKS"
 
 [deploy]
-startCommand = "npm start"
+startCommand = "node scripts/cron-trigger/trigger.mjs"
 restartPolicyType = "NEVER"

--- a/railway.cron.toml
+++ b/railway.cron.toml
@@ -1,0 +1,6 @@
+[build]
+builder = "NIXPACKS"
+
+[deploy]
+startCommand = "npm start"
+restartPolicyType = "NEVER"

--- a/scripts/cron-trigger/package.json
+++ b/scripts/cron-trigger/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cron-trigger",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node trigger.mjs"
+  }
+}

--- a/scripts/cron-trigger/package.json
+++ b/scripts/cron-trigger/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "cron-trigger",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "start": "node trigger.mjs"
-  }
-}

--- a/scripts/cron-trigger/trigger.mjs
+++ b/scripts/cron-trigger/trigger.mjs
@@ -1,0 +1,24 @@
+const url = process.env.CRON_URL ?? 'https://catalyse.up.railway.app/api/cron/daily'
+const secret = process.env.CRON_SECRET
+
+console.log(`[cron-trigger] POST ${url}`)
+
+if (!secret) {
+  console.error('[cron-trigger] CRON_SECRET is not set')
+  process.exit(1)
+}
+
+try {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${secret}` },
+    signal: AbortSignal.timeout(20_000),
+  })
+  const body = await res.text()
+  console.log(`[cron-trigger] HTTP ${res.status}`)
+  console.log(body)
+  process.exit(res.ok ? 0 : 1)
+} catch (err) {
+  console.error('[cron-trigger] request failed:', err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- The alpine-image inline shell script on the "Cron for digest" Railway service silently failed for days: `apk add curl` ran fine, then nothing — no echo output, no curl output, no way to tell if the container died early or Railway just wasn't capturing stdout for that container type.
- Replaced it with `scripts/cron-trigger/trigger.mjs`, a small Node script (POSTs to `/api/cron/daily` with `CRON_SECRET`, logs status/body clearly, non-zero exit on failure), deployed from this repo via `railway.cron.toml` instead of a bare `alpine:latest` image.
- Verified live against production: confirmed the new script correctly logs `HTTP 200` and the app's own logs show the request landing.

## Test plan
- [x] Ran locally with a bad secret, confirmed clean `401` + exit 1
- [x] Live-tested against the Railway "Cron for digest" service on a temp schedule — deploy logs showed `[cron-trigger] POST ...` / `HTTP 200`, and web's HTTP logs confirmed the hit landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aMYRvQcg9EHRgJXuypUrT