### PR TITLE
Clear resolved notifications for all recipients

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -7,10 +7,27 @@ export async function createNotification(
   title: string,
   body?: string | null,
   link?: string | null,
+  entityId?: number | null,
 ) {
   return prisma.notification.create({
-    data: { volunteerId, type, title, body: body ?? null, link: link ?? null },
+    data: {
+      volunteerId,
+      type,
+      title,
+      body: body ?? null,
+      link: link ?? null,
+      entityId: entityId ?? null,
+    },
   })
+}
+
+// Removes every recipient's copy of a notification once the thing it's about has been
+// resolved by someone — e.g. a project proposal is approved, so the other admins no longer
+// need "new project proposal" in their list.
+export async function clearNotifications(type: string, entityId: number): Promise<void> {
+  await prisma.notification
+    .deleteMany({ where: { type, entityId } })
+    .catch((e) => console.error('[NOTIFY CLEAR ERROR]', e))
 }
 
 type NotifyEmailPayload =
@@ -30,8 +47,9 @@ export async function notifyUser(
   body: string | null | undefined,
   link: string | null | undefined,
   email?: NotifyEmailPayload,
+  entityId?: number | null,
 ): Promise<void> {
-  createNotification(volunteerId, type, title, body, link).catch((e) =>
+  createNotification(volunteerId, type, title, body, link, entityId).catch((e) =>
     console.error('[NOTIFY ERROR]', e),
   )
   if (!email) return
@@ -71,10 +89,13 @@ export async function notifyAdmins(
   body: string | null | undefined,
   link: string | null | undefined,
   email?: NotifyEmailPayload,
+  entityId?: number | null,
 ): Promise<void> {
   const admins = await prisma.volunteer.findMany({
     where: { isAdmin: true, deletedAt: null },
     select: { id: true },
   })
-  await Promise.all(admins.map((admin) => notifyUser(admin.id, type, title, body, link, email)))
+  await Promise.all(
+    admins.map((admin) => notifyUser(admin.id, type, title, body, link, email, entityId)),
+  )
 }

--- a/prisma/migrations/20260822130053_add_notification_entity_id/migration.sql
+++ b/prisma/migrations/20260822130053_add_notification_entity_id/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "notifications" ADD COLUMN "entity_id" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "idx_notifications_type_entity" ON "notifications"("type", "entity_id");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,11 @@ model Notification {
   title       String
   body        String?
   link        String?
+  // Identifies the resource this notification is about (e.g. a project or bug report id), so
+  // that when the underlying item is resolved by one person, matching notifications for the
+  // same (type, entityId) can be cleared for every other recipient. Null for types that aren't
+  // cleared this way.
+  entityId    Int?      @map("entity_id")
   readAt      DateTime? @map("read_at")
   emailedAt   DateTime? @map("emailed_at")
   createdAt   DateTime? @default(now()) @map("created_at")
@@ -208,6 +213,7 @@ model Notification {
 
   @@index([volunteerId, readAt], map: "idx_notifications_unread")
   @@index([volunteerId], map: "idx_notifications_volunteer")
+  @@index([type, entityId], map: "idx_notifications_type_entity")
   @@map("notifications")
 }
 

--- a/server/routers/admin/applications.ts
+++ b/server/routers/admin/applications.ts
@@ -12,6 +12,7 @@ import { APPLICATION_ANONYMISATION_MS } from '@/lib/applications'
 import { ApplicationActionSchema } from '@/lib/schemas'
 import { superAdminProcedure } from '../../procedures'
 import { ApprovalStatus } from '@/generated/prisma/enums'
+import { clearNotifications } from '@/lib/notify'
 
 export const adminApplicationsRouter = {
   list: superAdminProcedure
@@ -361,6 +362,8 @@ export const adminApplicationsRouter = {
           }).catch((e) => console.error('[APPLICATIONS] Rejected email failed:', e))
         }
       }
+
+      await clearNotifications('new_volunteer_signup', input.id)
 
       const label = action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'started'
       return { message: `Application ${label}` }

--- a/server/routers/admin/bugReports.ts
+++ b/server/routers/admin/bugReports.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma'
 import { ApprovalStatus } from '@/generated/prisma/enums'
 import { UpdateBugReportSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
+import { clearNotifications } from '@/lib/notify'
 
 export const adminBugReportsRouter = {
   list: adminProcedure
@@ -84,6 +85,10 @@ export const adminBugReportsRouter = {
 
       if (Object.keys(data).length > 0) {
         await prisma.bugReport.update({ where: { id: input.id }, data })
+      }
+
+      if (input.status === 'resolved' || input.status === 'wont_fix') {
+        await clearNotifications('new_bug_report', input.id)
       }
 
       return { message: 'Bug report updated' }

--- a/server/routers/admin/localGroups.ts
+++ b/server/routers/admin/localGroups.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { sendLocalGroupSuggestionEmail } from '@/lib/email'
 import { BASE_LOCATION_OPTIONS } from '@/lib/filter-options'
-import { createNotification } from '@/lib/notify'
+import { createNotification, clearNotifications } from '@/lib/notify'
 import { LocalGroupBodySchema, ReviewSuggestionSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
 import { LocalGroupSuggestionStatus } from '@/generated/prisma/enums'
@@ -205,6 +205,8 @@ export const adminLocalGroupsRouter = {
         groupName: finalName,
         adminNotes,
       })
+
+      await clearNotifications('local_group_suggestion', input.id)
 
       return { message: 'Suggestion updated' }
     }),

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
-import { notifyUser } from '@/lib/notify'
+import { notifyUser, clearNotifications } from '@/lib/notify'
 import { notifyMatchingVolunteers } from '@/lib/project-match-notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
@@ -162,6 +162,8 @@ export const adminProjectsRouter = {
           )
         }
       }
+
+      await clearNotifications('new_project_proposal', input.id)
 
       return { message: `Project marked as ${status}` }
     }),

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -325,6 +325,7 @@ export const authRouter = {
           ctaLabel: 'Review Application',
           ctaUrl: '/admin/applications',
         },
+        volunteer.id,
       ).catch((e) => console.error('[SIGNUP NOTIFY]', e))
     }
 

--- a/server/routers/bugReports.ts
+++ b/server/routers/bugReports.ts
@@ -83,18 +83,27 @@ export const bugReportsRouter = {
     await Promise.all(
       admins.map((admin) =>
         admin.isTechnicalAdmin
-          ? notifyUser(admin.id, 'new_bug_report', notifyTitle, notifyBody, '/admin/bugs', {
-              subject: notifyTitle,
-              message: notifyBody,
-              ctaLabel: 'View Bug Report',
-              ctaUrl: '/admin/bugs',
-            }).catch((e) => console.error('[NOTIFY ERROR]', e))
+          ? notifyUser(
+              admin.id,
+              'new_bug_report',
+              notifyTitle,
+              notifyBody,
+              '/admin/bugs',
+              {
+                subject: notifyTitle,
+                message: notifyBody,
+                ctaLabel: 'View Bug Report',
+                ctaUrl: '/admin/bugs',
+              },
+              report.id,
+            ).catch((e) => console.error('[NOTIFY ERROR]', e))
           : createNotification(
               admin.id,
               'new_bug_report',
               notifyTitle,
               notifyBody,
               '/admin/bugs',
+              report.id,
             ).catch((e) => console.error('[NOTIFY ERROR]', e)),
       ),
     )

--- a/server/routers/localGroupSuggestions.ts
+++ b/server/routers/localGroupSuggestions.ts
@@ -47,6 +47,8 @@ export const localGroupSuggestionsRouter = {
         `New local group suggestion: ${input.country} — ${input.name}`,
         null,
         '/admin/local-groups',
+        undefined,
+        suggestion.id,
       )
 
       return {

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -9,7 +9,7 @@ import {
   canViewWorkItem,
   CLAIM_BLOCKING_INTEREST_STATUSES,
 } from '@/lib/work-item'
-import { notifyUser, notifyAdmins } from '@/lib/notify'
+import { notifyUser, notifyAdmins, clearNotifications } from '@/lib/notify'
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
@@ -263,6 +263,7 @@ export const projectsRouter = {
         projectTitle: project.title,
         projectId: project.id,
       },
+      project.id,
     )
 
     return { id: project.id, message: 'Project submitted for review' }
@@ -613,30 +614,28 @@ export const projectsRouter = {
 
       const { interestType, message = null } = input
 
-      if (existing) {
-        await prisma.workItemInterest.update({
-          where: {
-            volunteerId_workItemId: { volunteerId: volunteer.id, workItemId: input.projectId },
-          },
-          data: {
-            interestType,
-            message,
-            status: InterestStatus.pending,
-            respondedAt: null,
-            responseMessage: null,
-          },
-        })
-      } else {
-        await prisma.workItemInterest.create({
-          data: {
-            volunteerId: volunteer.id,
-            workItemId: input.projectId,
-            interestType,
-            message,
-            status: InterestStatus.pending,
-          },
-        })
-      }
+      const interest = existing
+        ? await prisma.workItemInterest.update({
+            where: {
+              volunteerId_workItemId: { volunteerId: volunteer.id, workItemId: input.projectId },
+            },
+            data: {
+              interestType,
+              message,
+              status: InterestStatus.pending,
+              respondedAt: null,
+              responseMessage: null,
+            },
+          })
+        : await prisma.workItemInterest.create({
+            data: {
+              volunteerId: volunteer.id,
+              workItemId: input.projectId,
+              interestType,
+              message,
+              status: InterestStatus.pending,
+            },
+          })
 
       const interestLabel = interestType === 'want_to_own' ? 'own / lead' : 'contribute to'
 
@@ -656,6 +655,7 @@ export const projectsRouter = {
               ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Their message:</strong> ${message}</div>`
               : undefined,
           },
+          interest.id,
         )
       }
 
@@ -721,6 +721,8 @@ export const projectsRouter = {
           respondedAt: new Date(),
         },
       })
+
+      await clearNotifications('new_interest', input.interestId)
 
       if (input.status === InterestStatus.declined) {
         await releaseTasksHeldBy(input.projectId, interest.volunteerId)

--- a/server/routers/quickTasks.ts
+++ b/server/routers/quickTasks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
-import { notifyUser } from '@/lib/notify'
+import { notifyUser, clearNotifications } from '@/lib/notify'
 import { CreateQuickTaskSchema, AssignQuickTaskSchema, ReviewQuickTaskSchema } from '@/lib/schemas'
 import { CLAIM_BLOCKING_INTEREST_STATUSES } from '@/lib/work-item'
 import { adminProcedure, approvedProcedure, authedProcedure } from '../procedures'
@@ -350,6 +350,8 @@ export const quickTasksRouter = {
           `${volunteer.name} submitted: ${task.title}`,
           'Ready for review',
           `/quick-tasks#task-${input.id}`,
+          undefined,
+          input.id,
         )
       }
 
@@ -384,6 +386,8 @@ export const quickTasksRouter = {
           data: { workItemId: input.id, authorId: admin.id, content: input.comment.trim() },
         })
       }
+
+      await clearNotifications('quick_task_submitted', input.id)
 
       if (task.assigneeId) {
         const noteContent = `Quick Task '${task.title}': ${input.reviewRating}${input.reviewNotes ? ` - ${input.reviewNotes}` : ''}`


### PR DESCRIPTION
## Summary

Some notifications go to multiple people (all admins, etc.) about a single actionable item. Once one person handles it, the notification had no way to disappear for everyone else — it just sat there until each recipient individually marked it read.

This adds a nullable `entityId` column to `Notification` plus a `clearNotifications(type, entityId)` helper, and wires it into the resolution point for each actionable notification type so every recipient's copy gets removed once someone resolves the underlying item.

## Notifications and their clear triggers

| Notification type | Recipients | Created when | Cleared when |
|---|---|---|---|
| `new_volunteer_signup` | admins | volunteer signs up needing approval (`auth.ts`) | admin approves or rejects the application (`admin/applications.ts`) |
| `new_project_proposal` | admins | volunteer proposes a project (`projects.ts`) | admin approves it or sends it to "needs discussion" (`admin/projects.ts` review) |
| `local_group_suggestion` | admins | volunteer suggests a local group (`localGroupSuggestions.ts`) | admin accepts, merges, declines, or puts on hold (`admin/localGroups.ts` reviewSuggestion) |
| `new_bug_report` | technical admins | bug report submitted (`bugReports.ts`) | admin sets status to `resolved` or `wont_fix` (`admin/bugReports.ts` update) |
| `new_interest` | project owner | volunteer expresses interest in a project (`projects.ts` expressInterest) | owner accepts or declines the interest (`projects.ts` respondToInterest) |
| `quick_task_submitted` | task creator | volunteer submits an assigned Quick Task (`quickTasks.ts` submit) | creator/admin reviews the task (`quickTasks.ts` review) |

`bug_report_comment` was considered but left alone — it's informational (anyone can still read a resolved report's comment history), so it's not auto-cleared; only the `new_bug_report` triage notice clears on resolution.

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, unit + e2e) — 190 passed, 5 skipped
- [ ] Manually verify: two admins both see a "new project proposal" notification; one approves it; the other's notification disappears without them visiting the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkprV1Bfq62tFZb5TBwmsY