### PR TITLE
Show proposer in place of empty owner state for admins

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1253,6 +1253,22 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                       {project.owner.name}
                     </Link>
                   </div>
+                ) : isAdmin && project.proposedBy ? (
+                  // Ownerless projects still have a proposer. Admins triaging the queue need
+                  // to know who to talk to, so show them that name in place of the empty state.
+                  <div className="flex items-center gap-2 min-w-0">
+                    <TaskAvatar name={project.proposedBy.name} />
+                    <span className="truncate">
+                      Proposer:{' '}
+                      {project.proposedById ? (
+                        <Link href={`/volunteers/${project.proposedById}`} className="underline">
+                          {project.proposedBy.name}
+                        </Link>
+                      ) : (
+                        project.proposedBy.name
+                      )}
+                    </span>
+                  </div>
                 ) : (
                   <p className="text-text-light text-sm m-0">No owner yet.</p>
                 )}


### PR DESCRIPTION
## What

An ownerless project showed a bare "No owner yet." in the Owner card, even though every project has a creator. Admins triaging the queue had no name to contact without leaving the page.

Admins viewing an ownerless project now see **`Proposer: <name>`**, linked to the volunteer profile — matching the existing `Proposed by:` treatment on the triage page. Owned projects are unchanged (plain linked name). Non-admins keep the plain empty state.

## Why it's a one-file change

No server work was needed: `projectInclude` already pulls `creator` and `withProjectExtras` already returns `proposedById`/`proposedBy` on every project query (`lib/work-item.ts`). The data was reaching the page and simply wasn't rendered.

## Scope

Part of #199 — deliberately not closing it. Still outstanding there:

- `components/ProjectCard.tsx` list views still say "No owner yet" with no name (it declares a `proposedBy` prop nothing renders)
- whether non-admin viewers should see the proposer too, or it stays an admin-only triage aid
- org-proposed naming: an admin-created `isOrgProposed` project shows that admin's personal name, probably should read "PauseAI" (relates to closed #145)

## Testing

`npm run check-all` passes — typecheck, lint, format, 190 e2e tests (5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3iGrP2JrvxsX1uaHNdfLq