### PR TITLE
Attribute org projects to PauseAI and drop the UK qualifier from branding copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Catalyse
 
-**Volunteer & Project Matching Platform for PauseAI UK**
+**Volunteer & Project Matching Platform for PauseAI**
 
-Catalyse connects volunteers with projects, matching skills to needs and enabling effective coordination across PauseAI UK initiatives.
+Catalyse connects volunteers with projects, matching skills to needs and enabling effective coordination across PauseAI initiatives.
 
 ## Features
 
@@ -175,4 +175,4 @@ catalyse/
 
 ## License
 
-MIT - Built for PauseAI UK
+MIT - Built for PauseAI

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -18,7 +18,7 @@ export default function AdminCreateProjectPage() {
       <main className="container py-5 pb-15">
         <h1 role="heading">Create Organisation Project</h1>
         <p className="text-text-light mb-6">
-          Create a project on behalf of PauseAI UK. This skips the approval process.
+          Create a project on behalf of PauseAI. This skips the approval process.
         </p>
         <div className="max-w-4xl">
           <ProjectForm

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -18,6 +18,7 @@ import { badgeClasses } from '@/components/Badge'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
+import { proposerDisplay } from '@/lib/project-status'
 import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
 export default function TriagePage() {
@@ -291,11 +292,10 @@ export default function TriagePage() {
                     key={p.id}
                     project={{
                       ...p,
-                      owner: p.proposedBy
-                        ? {
-                            name: `Proposed by: ${typeof p.proposedBy === 'string' ? p.proposedBy : p.proposedBy.name}`,
-                          }
-                        : null,
+                      owner: (() => {
+                        const proposer = proposerDisplay(p)
+                        return proposer ? { name: `Proposed by: ${proposer.name}` } : null
+                      })(),
                     }}
                     action={
                       <Button size="sm" href={`/projects/${p.id}`}>

--- a/app/admin/triage/page.tsx
+++ b/app/admin/triage/page.tsx
@@ -18,7 +18,6 @@ import { badgeClasses } from '@/components/Badge'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
-import { proposerDisplay } from '@/lib/project-status'
 import { InterestStatus, ProjectStatus } from '@/generated/prisma/enums'
 
 export default function TriagePage() {
@@ -290,13 +289,8 @@ export default function TriagePage() {
                 {visible.map((p) => (
                   <ProjectCard
                     key={p.id}
-                    project={{
-                      ...p,
-                      owner: (() => {
-                        const proposer = proposerDisplay(p)
-                        return proposer ? { name: `Proposed by: ${proposer.name}` } : null
-                      })(),
-                    }}
+                    project={p}
+                    showProposer
                     action={
                       <Button size="sm" href={`/projects/${p.id}`}>
                         Review

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,9 +35,9 @@ const sairaCondensed = Saira_Condensed({
 export const metadata: Metadata = {
   title: {
     template: 'Catalyse | %s',
-    default: 'Catalyse | PauseAI UK Volunteer Platform',
+    default: 'Catalyse | PauseAI Volunteer Platform',
   },
-  description: 'PauseAI UK volunteer platform',
+  description: 'PauseAI volunteer platform',
 }
 
 export default function RootLayout({

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   OWNER_ALLOWED_STATUSES,
   TERMINAL_STATUSES,
   projectStatusLabel,
+  proposerDisplay,
 } from '@/lib/project-status'
 import { InterestStatus, ProjectStatus, TaskStatus } from '@/generated/prisma/enums'
 import type { InferRouterOutputs } from '@orpc/server'
@@ -526,6 +527,8 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
 
   const isOwner = project.ownerId !== null && project.ownerId === user.id
   const isAdmin = user.isAdmin
+  // Org-proposed projects are attributed to the org, not to the admin who filed them.
+  const proposer = proposerDisplay(project)
   const isOwnerOrAdmin = isOwner || isAdmin
 
   const canSeeInterest =
@@ -1253,19 +1256,19 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                       {project.owner.name}
                     </Link>
                   </div>
-                ) : isAdmin && project.proposedBy ? (
+                ) : isAdmin && proposer ? (
                   // Ownerless projects still have a proposer. Admins triaging the queue need
                   // to know who to talk to, so show them that name in place of the empty state.
                   <div className="flex items-center gap-2 min-w-0">
-                    <TaskAvatar name={project.proposedBy.name} />
+                    <TaskAvatar name={proposer.name} />
                     <span className="truncate">
                       Proposer:{' '}
-                      {project.proposedById ? (
-                        <Link href={`/volunteers/${project.proposedById}`} className="underline">
-                          {project.proposedBy.name}
+                      {proposer.volunteerId ? (
+                        <Link href={`/volunteers/${proposer.volunteerId}`} className="underline">
+                          {proposer.name}
                         </Link>
                       ) : (
-                        project.proposedBy.name
+                        proposer.name
                       )}
                     </span>
                   </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -323,7 +323,11 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
 
             {/* Grouped project cards */}
             {statusFilter || needsFilter ? (
-              <ProjectList projects={projects} userSkillIds={userSkillIds} />
+              <ProjectList
+                projects={projects}
+                userSkillIds={userSkillIds}
+                showProposer={user.isAdmin}
+              />
             ) : (
               groups
                 .filter((g) => g.projects.length > 0)
@@ -369,7 +373,11 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
                           key={String(completedOpen)}
                           className={isCompleted ? 'animate-fade-slide-in' : undefined}
                         >
-                          <ProjectList projects={g.projects} userSkillIds={userSkillIds} />
+                          <ProjectList
+                            projects={g.projects}
+                            userSkillIds={userSkillIds}
+                            showProposer={user.isAdmin}
+                          />
                         </div>
                       )}
                     </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -799,7 +799,7 @@ export default function SignupPage() {
         <div className="max-w-2xl mx-auto">
           <h1>Join Catalyse</h1>
           <p className="text-text-light mb-6">
-            Connect with PauseAI UK projects and fellow volunteers.
+            Connect with PauseAI projects and fellow volunteers.
           </p>
 
           {error && (

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -20,7 +20,7 @@ export default function SuggestPage() {
       <main className="container py-5 pb-15">
         <h1 role="heading">Suggest a Project</h1>
         <p>
-          Have an idea for something PauseAI UK should do? Propose it here! Our team will review it
+          Have an idea for something PauseAI should do? Propose it here! Our team will review it
           and, if approved, it&apos;ll be visible to all volunteers.
         </p>
         <div className="max-w-4xl">

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -4,7 +4,10 @@ import Button from '@/components/Button'
 import { Badge, badgeClasses, type BadgeVariant } from '@/components/Badge'
 import { matchGradeLabel } from '@/lib/matching'
 import { projectLocationParts } from '@/lib/filter-options'
-import { PROJECT_STATUS_CONFIG as PROJECT_LIFECYCLE_CONFIG } from '@/lib/project-status'
+import {
+  PROJECT_STATUS_CONFIG as PROJECT_LIFECYCLE_CONFIG,
+  proposerDisplay,
+} from '@/lib/project-status'
 
 export interface Project {
   id: number
@@ -83,11 +86,18 @@ export function ProjectCard({
   project: p,
   userSkillIds = new Set(),
   action,
+  showProposer = false,
 }: {
   project: Project
   userSkillIds?: Set<number>
   action?: React.ReactNode
+  /**
+   * Name the proposer in place of the empty owner state. Admin-only by convention:
+   * volunteers browsing need to know a project has no owner yet, not who filed it.
+   */
+  showProposer?: boolean
 }) {
+  const proposer = p.owner || !showProposer ? null : proposerDisplay(p)
   return (
     <div className="card bg-surface rounded-xl shadow px-5 pt-5 pb-4 overflow-hidden wrap-break-word grid grid-rows-subgrid row-span-6 gap-y-2 relative min-w-0">
       <div className="card-header row-start-1">
@@ -110,7 +120,9 @@ export function ProjectCard({
         {p.needsTasks && <Badge variant="warning">Needs Tasks</Badge>}
       </div>
       <div className="row-start-3 flex items-center gap-3 flex-wrap text-xs text-text-light self-start">
-        <span>👤 {p.owner ? p.owner.name : 'No owner yet'}</span>
+        <span>
+          👤 {p.owner ? p.owner.name : proposer ? `Proposer: ${proposer.name}` : 'No owner yet'}
+        </span>
         {(() => {
           const parts = projectLocationParts(p.country, p.localGroup, p.remoteEligibility)
           return parts.length > 0 && <span>📍 {parts.join(' · ')}</span>
@@ -179,15 +191,22 @@ export function ProjectList({
   projects,
   userSkillIds = new Set(),
   single = false,
+  showProposer = false,
 }: {
   projects: Project[]
   userSkillIds?: Set<number>
   single?: boolean
+  showProposer?: boolean
 }) {
   return (
     <div className={single ? CARD_GRID_SINGLE_CLASSES : CARD_GRID_CLASSES}>
       {projects.map((p) => (
-        <ProjectCard key={p.id} project={p} userSkillIds={userSkillIds} />
+        <ProjectCard
+          key={p.id}
+          project={p}
+          userSkillIds={userSkillIds}
+          showProposer={showProposer}
+        />
       ))}
     </div>
   )

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -423,7 +423,7 @@ export default function ProjectForm({
 
       {showReviewNotice && (
         <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-[#DBEAFE] text-[#1E40AF] border border-[#93C5FD] dark:bg-[#1E3A5F] dark:text-[#93C5FD] dark:border-[#2563EB]">
-          Your project will be reviewed by PauseAI UK team leads before being published. We&apos;ll
+          Your project will be reviewed by PauseAI team leads before being published. We&apos;ll
           reach out if we have questions or suggestions.
         </div>
       )}

--- a/e2e/tests/28-project-ownership-states.spec.ts
+++ b/e2e/tests/28-project-ownership-states.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect, readAdminToken, createApprovedVolunteer } from '../fixtures'
+import {
+  test,
+  expect,
+  readAdminToken,
+  createApprovedVolunteer,
+  dismissCookieConsentScript,
+} from '../fixtures'
 import { fake } from '../fake'
 import { createApiClient } from '../client'
 import { removeProjectOwner } from '../actions/projects'
@@ -183,6 +189,43 @@ test.describe('Project ownership states', () => {
     await expect(
       adminPage.getByRole('link', { name: volunteer.name, exact: true }),
     ).toHaveAttribute('href', `/volunteers/${volunteer.id}`)
+  })
+
+  // Browsing is where the missing name was first noticed. Admins triaging need to know who
+  // filed an ownerless project; a volunteer only needs to know that nobody owns it yet.
+  test('Browse cards name the proposer to admins and stay anonymous for volunteers', async ({
+    adminPage,
+    browser,
+    baseUrl,
+  }) => {
+    const { id, title } = await createOrgProject(baseUrl)
+
+    await adminPage.goto(`${baseUrl}/projects`)
+    const adminCard = adminPage.locator('.card').filter({ hasText: title })
+    await expect(adminCard).toBeVisible({ timeout: 10_000 })
+    await expect(adminCard).toContainText('Proposer: PauseAI')
+
+    const volunteer = await createApprovedVolunteer(baseUrl)
+    const ctx = await browser.newContext()
+    await ctx.addInitScript((token: string) => {
+      localStorage.setItem('authToken', token)
+    }, volunteer.token)
+    await ctx.addInitScript(dismissCookieConsentScript)
+    const volunteerPage = await ctx.newPage()
+    try {
+      await volunteerPage.goto(`${baseUrl}/projects`)
+      const volunteerCard = volunteerPage.locator('.card').filter({ hasText: title })
+      await expect(volunteerCard).toBeVisible({ timeout: 10_000 })
+      await expect(volunteerCard).toContainText('No owner yet')
+      await expect(volunteerCard).not.toContainText('Proposer:')
+
+      // Same on the project's own page: the empty state, not a name.
+      await volunteerPage.goto(`${baseUrl}/projects/${id}`)
+      await expect(volunteerPage.getByText('No owner yet.')).toBeVisible({ timeout: 10_000 })
+      await expect(volunteerPage.getByText('Proposer:')).toBeHidden()
+    } finally {
+      await ctx.close()
+    }
   })
 
   // Regression: an owned project used to be able to sit in the retired `seeking_owner`

--- a/e2e/tests/28-project-ownership-states.spec.ts
+++ b/e2e/tests/28-project-ownership-states.spec.ts
@@ -144,6 +144,47 @@ test.describe('Project ownership states', () => {
     await expect(adminPage.getByRole('link', { name: title })).toBeVisible({ timeout: 10_000 })
   })
 
+  // An ownerless project still has someone behind it. Org-proposed ones are filed by an
+  // admin on the organisation's behalf, so they are attributed to the org rather than to
+  // that admin personally.
+  test('An ownerless project names its proposer to admins: the org, or the volunteer who proposed it', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const { id: orgProjectId } = await createOrgProject(baseUrl)
+
+    await adminPage.goto(`${baseUrl}/projects/${orgProjectId}`)
+    await expect(adminPage.getByText('Proposer: PauseAI')).toBeVisible({ timeout: 10_000 })
+
+    // A volunteer proposal is attributed to the volunteer, linked to their profile.
+    const volunteer = await createApprovedVolunteer(baseUrl)
+    const proposed = await createApiClient(baseUrl, volunteer.token).projects.create({
+      body: {
+        title: fake.projectTitle(),
+        description: 'e2e proposer-attribution project description',
+        projectType: null,
+        estimatedDuration: null,
+        timeCommitmentHoursPerWeek: null,
+        urgency: 'medium',
+        collaborationLink: null,
+        country: null,
+        localGroup: null,
+        isSeekingHelp: true,
+        tasks: [{ title: 'Initial task' }],
+      },
+    })
+    expect(proposed.status).toBe(200)
+    const proposedId = (proposed.body as { id: number }).id
+
+    await adminPage.goto(`${baseUrl}/projects/${proposedId}`)
+    await expect(adminPage.getByText(`Proposer: ${volunteer.name}`)).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(
+      adminPage.getByRole('link', { name: volunteer.name, exact: true }),
+    ).toHaveAttribute('href', `/volunteers/${volunteer.id}`)
+  })
+
   // Regression: an owned project used to be able to sit in the retired `seeking_owner`
   // status with the flag cleared, and the card suppressed the status badge for exactly
   // that status — so the card rendered no status at all.

--- a/lib/project-status.ts
+++ b/lib/project-status.ts
@@ -85,3 +85,28 @@ export const ADVERTISABLE_STATUSES_SQL = `status NOT IN (${quoted([...UNAPPROVED
 export const ADVERTISABLE_STATUSES: string[] = Object.keys(PROJECT_STATUS_CONFIG).filter(
   (s) => !UNAPPROVED_STATUSES.includes(s) && !TERMINAL_STATUSES.includes(s),
 )
+
+/**
+ * How an org-proposed project is attributed. `is_org_proposed` projects are created by an
+ * admin acting for the organisation, not for themselves, so surfacing the admin's personal
+ * name as the proposer misattributes the project to an individual.
+ */
+export const ORG_PROPOSER_NAME = 'PauseAI'
+
+export type ProposerDisplay = { name: string; volunteerId: number | null }
+
+/**
+ * Who to name as the proposer of a project, and whether that name links to a profile.
+ * `volunteerId` is null for the org — there is no profile page to link to.
+ * Returns null when there is nobody to attribute it to at all.
+ */
+export function proposerDisplay(p: {
+  isOrgProposed?: boolean | null
+  proposedById?: number | null
+  proposedBy?: { name: string } | string | null
+}): ProposerDisplay | null {
+  if (p.isOrgProposed) return { name: ORG_PROPOSER_NAME, volunteerId: null }
+  if (!p.proposedBy) return null
+  const name = typeof p.proposedBy === 'string' ? p.proposedBy : p.proposedBy.name
+  return { name, volunteerId: p.proposedById ?? null }
+}


### PR DESCRIPTION
Two related passes at how the platform names itself and its projects.

## 1. Org-proposed projects are attributed to PauseAI, not to the admin who filed them

`is_org_proposed` projects are created by an admin acting for the organisation. Naming that admin as the proposer misattributes an org project to an individual — on the triage card it read as though a staff member had personally proposed it.

Adds `proposerDisplay()` to `lib/project-status.ts` as the single answer to "who proposed this, and does that name link anywhere": the org for org-proposed projects (no profile to link to), otherwise the creating volunteer, linked to their profile. The project detail Owner card and the triage card both read from it, replacing the ad-hoc name unwrapping the triage page was doing.

Note the tension with closed #145: its reporter objected that a "PauseAI" badge adds no information on a PauseAI platform. This is a different use — it replaces a person's name rather than badging every card — but if org projects should simply read "No owner yet", that's a one-line change.

## 2. UK qualifier dropped from branding copy

Catalyse now covers volunteers outside the UK (Switzerland, Ghana and the United States were added in 33e9950), and the landing page copy was already written country-agnostic. The rest of the app still said "PauseAI UK", so a visitor met an agnostic front page and UK-branded pages behind it. Layout metadata, signup, suggest, admin project create, the ProjectForm review banner and the README now all say "PauseAI".

**Two UK references stay on purpose:**

- `app/privacy/page.tsx:250` names the data controller ("Safe AI Alliance Ltd, trading as PauseAI UK / Catalyse") next to the ICO complaint route, and must stay legally accurate.
- The `pauseai.uk` domains (`app/page.tsx:80`, `FROM_EMAIL` in `lib/env.ts:9`, `demo/data.ts:5`) are real addresses that cannot move yet.

## Testing

`npm run check-all` passes — typecheck, lint, format, 192 e2e (5 skipped), including two new cases in `28-project-ownership-states.spec.ts`: an org project shows `Proposer: PauseAI` and a volunteer proposal shows their name linked to their profile; and browse cards name the proposer to an admin while a volunteer sees `No owner yet` on both the card and the project page.

## 3. Browse cards name the proposer to admins

Browsing is where #199 was reported from: an ownerless project's card read `No owner yet` with nothing else. `ProjectCard`/`ProjectList` now take a `showProposer` flag and render `Proposer: <name>` through the same helper. The projects list passes `user.isAdmin`; volunteers keep the plain empty state, since they need to know a project is unowned, not who filed it. Triage passes the flag too, replacing the hand-rolled owner-name rewrite it used to fake the same effect.

## Scope

Closes #198
Closes #199

Three copy questions from #198 are deliberately left rather than blocking it: the landing page has no community chat link since the UK WhatsApp one was dropped, the country-agnostic sentences are our paraphrases rather than the author's own wording, and the metadata description at `app/page.tsx:6-8` is not from the supplied copy. All need the copy author, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3iGrP2JrvxsX1uaHNdfLq
