### PR TITLE
Add Teams feature (#177)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -83,6 +83,7 @@ export default function AdminLandingPage() {
       links: [
         { href: '/admin/skills', label: 'Manage Skills' },
         { href: '/admin/local-groups', label: 'Manage Local Groups' },
+        { href: '/admin/teams', label: 'Manage Teams' },
         { href: '/admin/bugs', label: 'Bug Reports', count: counts?.openBugReports },
       ],
     },

--- a/app/admin/teams/[id]/page.tsx
+++ b/app/admin/teams/[id]/page.tsx
@@ -1,0 +1,358 @@
+'use client'
+
+import { use, useEffect, useState } from 'react'
+import { useRequireApproved } from '@/lib/hooks/auth'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ORPCError } from '@orpc/client'
+import Button from '@/components/Button'
+import FilterDropdown from '@/components/FilterDropdown'
+import { orpc } from '@/lib/orpc'
+import { useToast } from '@/lib/toast'
+
+interface TeamMember {
+  id: number
+  name: string
+  email: string | null
+  role: 'member' | 'leader'
+}
+
+export default function AdminTeamDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = use(params)
+  const teamId = parseInt(idParam, 10)
+  const { user, loading } = useRequireApproved()
+  const router = useRouter()
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+
+  const {
+    data: team,
+    isLoading,
+    error,
+  } = useQuery({
+    ...orpc.teams.getManageable.queryOptions({ input: { id: teamId } }),
+    enabled: !!user,
+    retry: false,
+  })
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [lumaUrl, setLumaUrl] = useState('')
+  const [docUrl, setDocUrl] = useState('')
+  const [initialized, setInitialized] = useState(false)
+
+  useEffect(() => {
+    if (!team || initialized) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setName(team.name)
+    setDescription(team.description ?? '')
+    setLumaUrl(team.lumaUrl ?? '')
+    setDocUrl(team.docUrl ?? '')
+    setInitialized(true)
+  }, [team, initialized])
+
+  const [assignVolunteerId, setAssignVolunteerId] = useState('')
+
+  // Server-side search rather than a client-side filter over one page — the volunteer
+  // list can be far bigger than any single page we'd otherwise preload.
+  const [volunteerSearchInput, setVolunteerSearchInput] = useState('')
+  const [volunteerSearch, setVolunteerSearch] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setVolunteerSearch(volunteerSearchInput), 300)
+    return () => clearTimeout(t)
+  }, [volunteerSearchInput])
+
+  const { data: volunteersData } = useQuery({
+    ...orpc.volunteers.list.queryOptions({
+      input: { limit: 20, search: volunteerSearch || undefined },
+    }),
+    enabled: !!user,
+  })
+  const volunteerOptions = (volunteersData?.volunteers ?? []).map((v) => ({
+    value: String(v.id),
+    label: v.name,
+  }))
+
+  const { data: joinRequestsData } = useQuery({
+    ...orpc.teams.listJoinRequests.queryOptions({ input: { teamId } }),
+    enabled: !!team,
+  })
+  const joinRequests = joinRequestsData?.requests ?? []
+
+  const invalidate = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: orpc.teams.getManageable.key() }),
+      queryClient.invalidateQueries({ queryKey: orpc.admin.teams.list.key() }),
+      queryClient.invalidateQueries({ queryKey: orpc.teams.list.key() }),
+      queryClient.invalidateQueries({ queryKey: orpc.teams.listJoinRequests.key() }),
+    ])
+
+  const updateTeamMutation = useMutation({ ...orpc.teams.update.mutationOptions() })
+  const deleteTeamMutation = useMutation({ ...orpc.admin.teams.delete.mutationOptions() })
+  const assignMemberMutation = useMutation({ ...orpc.teams.assignMember.mutationOptions() })
+  const setMemberRoleMutation = useMutation({ ...orpc.teams.setMemberRole.mutationOptions() })
+  const removeMemberMutation = useMutation({ ...orpc.teams.removeMember.mutationOptions() })
+  const reviewJoinRequestMutation = useMutation({
+    ...orpc.teams.reviewJoinRequest.mutationOptions(),
+  })
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      await updateTeamMutation.mutateAsync({
+        id: teamId,
+        name: name.trim(),
+        description: description.trim() || null,
+        lumaUrl: lumaUrl.trim() || null,
+        docUrl: docUrl.trim() || null,
+      })
+      await invalidate()
+      showToast('Team updated', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update team', 'error')
+    }
+  }
+
+  function handleDelete() {
+    if (!window.confirm('Delete this team? This cannot be undone.')) return
+    deleteTeamMutation.mutate(
+      { id: teamId },
+      {
+        onSuccess: () => {
+          showToast('Team deleted', 'success')
+          router.push('/admin/teams')
+        },
+        onError: (err: unknown) => {
+          showToast(err instanceof Error ? err.message : 'Failed to delete team', 'error')
+        },
+      },
+    )
+  }
+
+  async function addMember() {
+    if (!assignVolunteerId) return
+    try {
+      await assignMemberMutation.mutateAsync({
+        teamId,
+        volunteerId: Number(assignVolunteerId),
+      })
+      setAssignVolunteerId('')
+      await invalidate()
+      showToast('Volunteer added to team', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to add member', 'error')
+    }
+  }
+
+  async function toggleLeader(member: TeamMember) {
+    try {
+      const newRole = member.role === 'leader' ? 'member' : 'leader'
+      await setMemberRoleMutation.mutateAsync({ teamId, volunteerId: member.id, role: newRole })
+      await invalidate()
+      showToast(newRole === 'leader' ? 'Promoted to leader' : 'Demoted to member', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update role', 'error')
+    }
+  }
+
+  async function removeMember(member: TeamMember) {
+    try {
+      await removeMemberMutation.mutateAsync({ teamId, volunteerId: member.id })
+      await invalidate()
+      showToast('Member removed', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to remove member', 'error')
+    }
+  }
+
+  async function reviewJoinRequest(id: number, action: 'accept' | 'decline') {
+    try {
+      await reviewJoinRequestMutation.mutateAsync({ id, action })
+      await invalidate()
+      showToast(action === 'accept' ? 'Request accepted' : 'Request declined', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to review request', 'error')
+    }
+  }
+
+  const backHref = user?.isAdmin ? '/admin/teams' : '/teams'
+
+  if (loading || !user) return null
+
+  if (isLoading) {
+    return (
+      <main className="container py-5 pb-15">
+        <div className="text-center py-10 text-text-light">Loading…</div>
+      </main>
+    )
+  }
+
+  if (error instanceof ORPCError && error.code === 'FORBIDDEN') {
+    return (
+      <main className="container py-5 pb-15">
+        <p className="text-text-light">Only this team&apos;s leader or an admin can manage it.</p>
+        <Link href={backHref} className="text-secondary-dark no-underline hover:text-primary">
+          ← Back to Teams
+        </Link>
+      </main>
+    )
+  }
+
+  if (!team) {
+    return (
+      <main className="container py-5 pb-15">
+        <p className="text-text-light">Team not found.</p>
+        <Link href={backHref} className="text-secondary-dark no-underline hover:text-primary">
+          ← Back to Teams
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="container py-5 pb-15 max-w-2xl">
+      <Link href={backHref} className="text-sm text-secondary-dark no-underline hover:text-primary">
+        ← All Teams
+      </Link>
+      <h1 className="mt-3 mb-6">{team.name}</h1>
+
+      <div className="bg-surface rounded-xl shadow p-6 mb-4">
+        <h2>Team Details</h2>
+        <form onSubmit={handleSave}>
+          <div className="mb-5">
+            <label htmlFor="team-name">Team Name</label>
+            <input
+              id="team-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="mb-5">
+            <label htmlFor="team-description">Description</label>
+            <textarea
+              id="team-description"
+              rows={2}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full"
+            />
+          </div>
+          <div className="mb-5">
+            <label htmlFor="team-luma">Luma calendar URL</label>
+            <input
+              id="team-luma"
+              type="text"
+              value={lumaUrl}
+              onChange={(e) => setLumaUrl(e.target.value)}
+              placeholder="https://luma.com/…"
+            />
+          </div>
+          <div className="mb-5">
+            <label htmlFor="team-doc">Team doc URL</label>
+            <input
+              id="team-doc"
+              type="text"
+              value={docUrl}
+              onChange={(e) => setDocUrl(e.target.value)}
+              placeholder="https://docs.google.com/…"
+            />
+          </div>
+          <div className="flex gap-3 justify-between">
+            <Button type="submit" disabled={!name.trim() || updateTeamMutation.isPending}>
+              {updateTeamMutation.isPending ? 'Saving…' : 'Save Changes'}
+            </Button>
+            {user.isAdmin && (
+              <Button type="button" variant="danger" onClick={handleDelete}>
+                Delete Team
+              </Button>
+            )}
+          </div>
+        </form>
+      </div>
+
+      {joinRequests.length > 0 && (
+        <div className="bg-surface rounded-xl shadow p-6 mb-4">
+          <h2>Pending Join Requests</h2>
+          <div className="space-y-3">
+            {joinRequests.map((r) => (
+              <div key={r.id} className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="m-0 font-medium">{r.volunteer.name}</p>
+                  {r.message && <p className="m-0 text-xs text-text-light italic">{r.message}</p>}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button size="sm" onClick={() => reviewJoinRequest(r.id, 'accept')}>
+                    Accept
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="danger"
+                    onClick={() => reviewJoinRequest(r.id, 'decline')}
+                  >
+                    Decline
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="bg-surface rounded-xl shadow p-6 mb-4">
+        <h2>Members</h2>
+
+        <div className="mb-5 pb-5 border-b border-brand-border flex items-end gap-2">
+          <div className="flex-1">
+            <FilterDropdown
+              id="assign-volunteer"
+              label="Add a volunteer directly"
+              ariaLabel="Select volunteer to add"
+              value={assignVolunteerId}
+              options={[{ value: '', label: 'Select a volunteer…' }, ...volunteerOptions]}
+              onChange={setAssignVolunteerId}
+              onQueryChange={setVolunteerSearchInput}
+              searchable
+            />
+          </div>
+          <Button
+            size="sm"
+            disabled={!assignVolunteerId || assignMemberMutation.isPending}
+            onClick={addMember}
+          >
+            Add
+          </Button>
+        </div>
+
+        {team.members.length === 0 ? (
+          <p className="text-text-light">No members yet.</p>
+        ) : (
+          <div className="space-y-3">
+            {team.members.map((m) => (
+              <div key={m.id} className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="m-0 font-medium">{m.name}</p>
+                  <p className="m-0 text-xs text-text-light">{m.email}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {m.role === 'leader' && (
+                    <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-primary/10 text-primary">
+                      Leader
+                    </span>
+                  )}
+                  <Button size="sm" variant="secondary" onClick={() => toggleLeader(m)}>
+                    {m.role === 'leader' ? 'Demote' : 'Make Leader'}
+                  </Button>
+                  <Button size="sm" variant="danger" onClick={() => removeMember(m)}>
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/admin/teams/page.tsx
+++ b/app/admin/teams/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
 import { useMutation, useQuery, useQueryClient, useQueries } from '@tanstack/react-query'
@@ -78,7 +78,6 @@ export default function AdminTeamsPage() {
     'all',
   )
   const [deleteTarget, setDeleteTarget] = useState<DisplayItem | null>(null)
-  const [membersTarget, setMembersTarget] = useState<Team | null>(null)
 
   const [showAdd, setShowAdd] = useState(false)
   const [addName, setAddName] = useState('')
@@ -86,13 +85,6 @@ export default function AdminTeamsPage() {
   const [addLumaUrl, setAddLumaUrl] = useState('')
   const [addDocUrl, setAddDocUrl] = useState('')
   const [addSubmitting, setAddSubmitting] = useState(false)
-
-  const [editTeam, setEditTeam] = useState<Team | null>(null)
-  const [editName, setEditName] = useState('')
-  const [editDescription, setEditDescription] = useState('')
-  const [editLumaUrl, setEditLumaUrl] = useState('')
-  const [editDocUrl, setEditDocUrl] = useState('')
-  const [editSubmitting, setEditSubmitting] = useState(false)
 
   const [reviewSuggestion, setReviewSuggestion] = useState<Suggestion | null>(null)
   const [reviewAction, setReviewAction] = useState<ReviewAction>('accept')
@@ -103,10 +95,20 @@ export default function AdminTeamsPage() {
   const [adminNotes, setAdminNotes] = useState('')
   const [reviewSubmitting, setReviewSubmitting] = useState(false)
 
-  const [assignVolunteerId, setAssignVolunteerId] = useState('')
+  // Volunteer picker (assign-member / review-leader) searches server-side rather than
+  // filtering a client-side page — the org can have far more volunteers than fit in one
+  // page, so typing has to actually query rather than filter what's already loaded.
+  const [volunteerSearchInput, setVolunteerSearchInput] = useState('')
+  const [volunteerSearch, setVolunteerSearch] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setVolunteerSearch(volunteerSearchInput), 300)
+    return () => clearTimeout(t)
+  }, [volunteerSearchInput])
 
   const { data: volunteersData } = useQuery({
-    ...orpc.volunteers.list.queryOptions({ input: { limit: 200 } }),
+    ...orpc.volunteers.list.queryOptions({
+      input: { limit: 20, search: volunteerSearch || undefined },
+    }),
     enabled: !!user?.isAdmin,
   })
   const volunteers = volunteersData?.volunteers ?? []
@@ -194,7 +196,6 @@ export default function AdminTeamsPage() {
     ])
 
   const createTeamMutation = useMutation({ ...orpc.admin.teams.create.mutationOptions() })
-  const updateTeamMutation = useMutation({ ...orpc.admin.teams.update.mutationOptions() })
   const reviewSuggestionMutation = useMutation({
     ...orpc.admin.teams.reviewSuggestion.mutationOptions(),
   })
@@ -202,22 +203,11 @@ export default function AdminTeamsPage() {
   const deleteSuggestionMutation = useMutation({
     ...orpc.admin.teams.deleteSuggestion.mutationOptions(),
   })
-  const setMemberRoleMutation = useMutation({ ...orpc.teams.setMemberRole.mutationOptions() })
-  const removeMemberMutation = useMutation({ ...orpc.teams.removeMember.mutationOptions() })
-  const assignMemberMutation = useMutation({ ...orpc.teams.assignMember.mutationOptions() })
 
   const mergeOptions = [
     { value: '', label: 'Select an existing team…' },
     ...allTeams.map((t) => ({ value: String(t.id), label: t.name })),
   ]
-
-  function openEdit(team: Team) {
-    setEditTeam(team)
-    setEditName(team.name)
-    setEditDescription(team.description ?? '')
-    setEditLumaUrl(team.lumaUrl ?? '')
-    setEditDocUrl(team.docUrl ?? '')
-  }
 
   function openReview(suggestion: Suggestion) {
     setReviewSuggestion(suggestion)
@@ -227,6 +217,8 @@ export default function AdminTeamsPage() {
     setReviewLeaderId(String(suggestion.suggestedBy.id))
     setMergeTargetId('')
     setAdminNotes('')
+    setVolunteerSearchInput('')
+    setVolunteerSearch('')
   }
 
   function openAdd() {
@@ -254,28 +246,6 @@ export default function AdminTeamsPage() {
       showToast(err instanceof Error ? err.message : 'Failed to add team', 'error')
     } finally {
       setAddSubmitting(false)
-    }
-  }
-
-  async function submitEdit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!editTeam) return
-    setEditSubmitting(true)
-    try {
-      await updateTeamMutation.mutateAsync({
-        id: editTeam.id,
-        name: editName.trim(),
-        description: editDescription.trim() || null,
-        lumaUrl: editLumaUrl.trim() || null,
-        docUrl: editDocUrl.trim() || null,
-      })
-      await invalidateItems()
-      showToast('Team updated', 'success')
-      setEditTeam(null)
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to update team', 'error')
-    } finally {
-      setEditSubmitting(false)
     }
   }
 
@@ -331,54 +301,6 @@ export default function AdminTeamsPage() {
       showToast(err instanceof Error ? err.message : 'Failed to delete', 'error')
     } finally {
       setDeleteTarget(null)
-    }
-  }
-
-  async function addMember() {
-    if (!membersTarget || !assignVolunteerId) return
-    try {
-      await assignMemberMutation.mutateAsync({
-        teamId: membersTarget.id,
-        volunteerId: Number(assignVolunteerId),
-      })
-      setAssignVolunteerId('')
-      await invalidateItems()
-      const updated = await queryClient.fetchQuery(orpc.admin.teams.list.queryOptions())
-      const refreshed = (updated.teams as Team[]).find((t) => t.id === membersTarget.id)
-      if (refreshed) setMembersTarget(refreshed)
-      showToast('Volunteer added to team', 'success')
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to add member', 'error')
-    }
-  }
-
-  async function toggleLeader(member: TeamMember) {
-    if (!membersTarget) return
-    try {
-      await setMemberRoleMutation.mutateAsync({
-        teamId: membersTarget.id,
-        volunteerId: member.id,
-        role: member.role === 'leader' ? 'member' : 'leader',
-      })
-      await invalidateItems()
-      const updated = await queryClient.fetchQuery(orpc.admin.teams.list.queryOptions())
-      const refreshed = (updated.teams as Team[]).find((t) => t.id === membersTarget.id)
-      if (refreshed) setMembersTarget(refreshed)
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to update role', 'error')
-    }
-  }
-
-  async function removeMember(member: TeamMember) {
-    if (!membersTarget) return
-    try {
-      await removeMemberMutation.mutateAsync({ teamId: membersTarget.id, volunteerId: member.id })
-      await invalidateItems()
-      const updated = await queryClient.fetchQuery(orpc.admin.teams.list.queryOptions())
-      const refreshed = (updated.teams as Team[]).find((t) => t.id === membersTarget.id)
-      if (refreshed) setMembersTarget(refreshed)
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to remove member', 'error')
     }
   }
 
@@ -458,18 +380,11 @@ export default function AdminTeamsPage() {
                   </div>
                   <div className="shrink-0 flex items-center gap-2">
                     {item.kind === 'team' && (
-                      <>
-                        <Button
-                          size="sm"
-                          variant="secondary"
-                          onClick={() => setMembersTarget(item)}
-                        >
-                          Members
+                      <Link href={`/admin/teams/${item.id}`}>
+                        <Button size="sm" variant="secondary">
+                          Manage
                         </Button>
-                        <Button size="sm" variant="secondary" onClick={() => openEdit(item)}>
-                          Edit
-                        </Button>
-                      </>
+                      </Link>
                     )}
                     {item.kind === 'suggestion' && (
                       <Button size="sm" onClick={() => openReview(item)}>
@@ -561,150 +476,6 @@ export default function AdminTeamsPage() {
         </div>
       )}
 
-      {/* Edit Team Modal */}
-      {editTeam && (
-        <div
-          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) setEditTeam(null)
-          }}
-        >
-          <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full">
-            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
-              <h2 role="heading">Edit Team</h2>
-              <Button variant="ghost" icon onClick={() => setEditTeam(null)} aria-label="Close">
-                ×
-              </Button>
-            </div>
-            <div className="p-6">
-              <form onSubmit={submitEdit}>
-                <div className="mb-5">
-                  <label htmlFor="edit-name">Team Name</label>
-                  <input
-                    id="edit-name"
-                    type="text"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                  />
-                </div>
-                <div className="mb-5">
-                  <label htmlFor="edit-description">Description</label>
-                  <textarea
-                    id="edit-description"
-                    rows={2}
-                    value={editDescription}
-                    onChange={(e) => setEditDescription(e.target.value)}
-                    className="w-full"
-                  />
-                </div>
-                <div className="mb-5">
-                  <label htmlFor="edit-luma">Luma calendar URL</label>
-                  <input
-                    id="edit-luma"
-                    type="text"
-                    value={editLumaUrl}
-                    onChange={(e) => setEditLumaUrl(e.target.value)}
-                  />
-                </div>
-                <div className="mb-5">
-                  <label htmlFor="edit-doc">Team doc URL</label>
-                  <input
-                    id="edit-doc"
-                    type="text"
-                    value={editDocUrl}
-                    onChange={(e) => setEditDocUrl(e.target.value)}
-                  />
-                </div>
-                <div className="pt-4 border-t border-brand-border flex gap-3 justify-end">
-                  <Button type="button" variant="secondary" onClick={() => setEditTeam(null)}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={editSubmitting || !editName.trim()}>
-                    {editSubmitting ? 'Saving…' : 'Save Changes'}
-                  </Button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Members Modal */}
-      {membersTarget && (
-        <div
-          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) setMembersTarget(null)
-          }}
-        >
-          <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto">
-            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
-              <h2 role="heading">{membersTarget.name} — Members</h2>
-              <Button
-                variant="ghost"
-                icon
-                onClick={() => setMembersTarget(null)}
-                aria-label="Close"
-              >
-                ×
-              </Button>
-            </div>
-            <div className="p-6">
-              <JoinRequestsSection teamId={membersTarget.id} onReviewed={invalidateItems} />
-
-              <div className="mb-5 pb-5 border-b border-brand-border flex items-end gap-2">
-                <div className="flex-1">
-                  <FilterDropdown
-                    id="assign-volunteer"
-                    label="Add a volunteer directly"
-                    ariaLabel="Select volunteer to add"
-                    value={assignVolunteerId}
-                    options={[{ value: '', label: 'Select a volunteer…' }, ...volunteerOptions]}
-                    onChange={setAssignVolunteerId}
-                    searchable
-                  />
-                </div>
-                <Button
-                  size="sm"
-                  disabled={!assignVolunteerId || assignMemberMutation.isPending}
-                  onClick={addMember}
-                >
-                  Add
-                </Button>
-              </div>
-
-              {membersTarget.members.length === 0 ? (
-                <p className="text-text-light">No members yet.</p>
-              ) : (
-                <div className="space-y-3">
-                  {membersTarget.members.map((m) => (
-                    <div key={m.id} className="flex items-center justify-between gap-3">
-                      <div>
-                        <p className="m-0 font-medium">{m.name}</p>
-                        <p className="m-0 text-xs text-text-light">{m.email}</p>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {m.role === 'leader' && (
-                          <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-primary/10 text-primary">
-                            Leader
-                          </span>
-                        )}
-                        <Button size="sm" variant="secondary" onClick={() => toggleLeader(m)}>
-                          {m.role === 'leader' ? 'Demote' : 'Make Leader'}
-                        </Button>
-                        <Button size="sm" variant="danger" onClick={() => removeMember(m)}>
-                          Remove
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Review Suggestion Modal */}
       {reviewSuggestion && (
         <div
@@ -791,8 +562,19 @@ export default function AdminTeamsPage() {
                         label="Team Leader"
                         ariaLabel="Select team leader"
                         value={reviewLeaderId}
-                        options={volunteerOptions}
+                        options={
+                          volunteerOptions.some((o) => o.value === reviewLeaderId)
+                            ? volunteerOptions
+                            : [
+                                {
+                                  value: String(reviewSuggestion.suggestedBy.id),
+                                  label: reviewSuggestion.suggestedBy.name,
+                                },
+                                ...volunteerOptions,
+                              ]
+                        }
                         onChange={setReviewLeaderId}
+                        onQueryChange={setVolunteerSearchInput}
                         searchable
                       />
                       <p className="text-sm text-text-light mt-1">
@@ -894,50 +676,5 @@ export default function AdminTeamsPage() {
         </div>
       )}
     </>
-  )
-}
-
-function JoinRequestsSection({ teamId, onReviewed }: { teamId: number; onReviewed: () => void }) {
-  const showToast = useToast()
-  const queryClient = useQueryClient()
-  const { data } = useQuery(orpc.teams.listJoinRequests.queryOptions({ input: { teamId } }))
-  const requests = data?.requests ?? []
-  const reviewMutation = useMutation({ ...orpc.teams.reviewJoinRequest.mutationOptions() })
-
-  async function review(id: number, action: 'accept' | 'decline') {
-    try {
-      await reviewMutation.mutateAsync({ id, action })
-      await queryClient.invalidateQueries({ queryKey: orpc.teams.listJoinRequests.key() })
-      await onReviewed()
-      showToast(action === 'accept' ? 'Request accepted' : 'Request declined', 'success')
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to review request', 'error')
-    }
-  }
-
-  if (requests.length === 0) return null
-
-  return (
-    <div className="mb-5 pb-5 border-b border-brand-border">
-      <p className="font-medium mb-3">Pending Join Requests</p>
-      <div className="space-y-3">
-        {requests.map((r) => (
-          <div key={r.id} className="flex items-center justify-between gap-3">
-            <div>
-              <p className="m-0 font-medium">{r.volunteer.name}</p>
-              {r.message && <p className="m-0 text-xs text-text-light italic">{r.message}</p>}
-            </div>
-            <div className="flex items-center gap-2">
-              <Button size="sm" onClick={() => review(r.id, 'accept')}>
-                Accept
-              </Button>
-              <Button size="sm" variant="danger" onClick={() => review(r.id, 'decline')}>
-                Decline
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
   )
 }

--- a/app/admin/teams/page.tsx
+++ b/app/admin/teams/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react'
 import { useRequireAdmin } from '@/lib/hooks/auth'
 import Link from 'next/link'
-import { useMutation, useQueryClient, useQueries } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient, useQueries } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Radio from '@/components/Radio'
 import FilterDropdown, { FilterOption, useFilterOptions } from '@/components/FilterDropdown'
@@ -98,9 +98,19 @@ export default function AdminTeamsPage() {
   const [reviewAction, setReviewAction] = useState<ReviewAction>('accept')
   const [reviewEditName, setReviewEditName] = useState('')
   const [reviewEditDescription, setReviewEditDescription] = useState('')
+  const [reviewLeaderId, setReviewLeaderId] = useState('')
   const [mergeTargetId, setMergeTargetId] = useState<number | ''>('')
   const [adminNotes, setAdminNotes] = useState('')
   const [reviewSubmitting, setReviewSubmitting] = useState(false)
+
+  const [assignVolunteerId, setAssignVolunteerId] = useState('')
+
+  const { data: volunteersData } = useQuery({
+    ...orpc.volunteers.list.queryOptions({ input: { limit: 200 } }),
+    enabled: !!user?.isAdmin,
+  })
+  const volunteers = volunteersData?.volunteers ?? []
+  const volunteerOptions = volunteers.map((v) => ({ value: String(v.id), label: v.name }))
 
   const fetchTeams = statusFilter === 'all' || statusFilter === 'active'
   const fetchPending = statusFilter === 'all' || statusFilter === TeamSuggestionStatus.pending
@@ -192,8 +202,9 @@ export default function AdminTeamsPage() {
   const deleteSuggestionMutation = useMutation({
     ...orpc.admin.teams.deleteSuggestion.mutationOptions(),
   })
-  const setMemberRoleMutation = useMutation({ ...orpc.admin.teams.setMemberRole.mutationOptions() })
-  const removeMemberMutation = useMutation({ ...orpc.admin.teams.removeMember.mutationOptions() })
+  const setMemberRoleMutation = useMutation({ ...orpc.teams.setMemberRole.mutationOptions() })
+  const removeMemberMutation = useMutation({ ...orpc.teams.removeMember.mutationOptions() })
+  const assignMemberMutation = useMutation({ ...orpc.teams.assignMember.mutationOptions() })
 
   const mergeOptions = [
     { value: '', label: 'Select an existing team…' },
@@ -213,6 +224,7 @@ export default function AdminTeamsPage() {
     setReviewAction('accept')
     setReviewEditName(suggestion.name)
     setReviewEditDescription(suggestion.description ?? '')
+    setReviewLeaderId(String(suggestion.suggestedBy.id))
     setMergeTargetId('')
     setAdminNotes('')
   }
@@ -276,6 +288,7 @@ export default function AdminTeamsPage() {
       if (reviewAction === 'accept') {
         body.name = reviewEditName.trim()
         body.description = reviewEditDescription.trim() || null
+        if (reviewLeaderId) body.leaderId = Number(reviewLeaderId)
       } else if (reviewAction === 'merge') {
         body.mergedIntoId = mergeTargetId
       }
@@ -318,6 +331,24 @@ export default function AdminTeamsPage() {
       showToast(err instanceof Error ? err.message : 'Failed to delete', 'error')
     } finally {
       setDeleteTarget(null)
+    }
+  }
+
+  async function addMember() {
+    if (!membersTarget || !assignVolunteerId) return
+    try {
+      await assignMemberMutation.mutateAsync({
+        teamId: membersTarget.id,
+        volunteerId: Number(assignVolunteerId),
+      })
+      setAssignVolunteerId('')
+      await invalidateItems()
+      const updated = await queryClient.fetchQuery(orpc.admin.teams.list.queryOptions())
+      const refreshed = (updated.teams as Team[]).find((t) => t.id === membersTarget.id)
+      if (refreshed) setMembersTarget(refreshed)
+      showToast('Volunteer added to team', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to add member', 'error')
     }
   }
 
@@ -619,6 +650,29 @@ export default function AdminTeamsPage() {
               </Button>
             </div>
             <div className="p-6">
+              <JoinRequestsSection teamId={membersTarget.id} onReviewed={invalidateItems} />
+
+              <div className="mb-5 pb-5 border-b border-brand-border flex items-end gap-2">
+                <div className="flex-1">
+                  <FilterDropdown
+                    id="assign-volunteer"
+                    label="Add a volunteer directly"
+                    ariaLabel="Select volunteer to add"
+                    value={assignVolunteerId}
+                    options={[{ value: '', label: 'Select a volunteer…' }, ...volunteerOptions]}
+                    onChange={setAssignVolunteerId}
+                    searchable
+                  />
+                </div>
+                <Button
+                  size="sm"
+                  disabled={!assignVolunteerId || assignMemberMutation.isPending}
+                  onClick={addMember}
+                >
+                  Add
+                </Button>
+              </div>
+
               {membersTarget.members.length === 0 ? (
                 <p className="text-text-light">No members yet.</p>
               ) : (
@@ -731,6 +785,21 @@ export default function AdminTeamsPage() {
                         className="w-full"
                       />
                     </div>
+                    <div className="mb-5">
+                      <FilterDropdown
+                        id="review-leader"
+                        label="Team Leader"
+                        ariaLabel="Select team leader"
+                        value={reviewLeaderId}
+                        options={volunteerOptions}
+                        onChange={setReviewLeaderId}
+                        searchable
+                      />
+                      <p className="text-sm text-text-light mt-1">
+                        Defaults to the suggester — pick someone else if they shouldn&apos;t lead
+                        it.
+                      </p>
+                    </div>
                   </>
                 )}
 
@@ -825,5 +894,50 @@ export default function AdminTeamsPage() {
         </div>
       )}
     </>
+  )
+}
+
+function JoinRequestsSection({ teamId, onReviewed }: { teamId: number; onReviewed: () => void }) {
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+  const { data } = useQuery(orpc.teams.listJoinRequests.queryOptions({ input: { teamId } }))
+  const requests = data?.requests ?? []
+  const reviewMutation = useMutation({ ...orpc.teams.reviewJoinRequest.mutationOptions() })
+
+  async function review(id: number, action: 'accept' | 'decline') {
+    try {
+      await reviewMutation.mutateAsync({ id, action })
+      await queryClient.invalidateQueries({ queryKey: orpc.teams.listJoinRequests.key() })
+      await onReviewed()
+      showToast(action === 'accept' ? 'Request accepted' : 'Request declined', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to review request', 'error')
+    }
+  }
+
+  if (requests.length === 0) return null
+
+  return (
+    <div className="mb-5 pb-5 border-b border-brand-border">
+      <p className="font-medium mb-3">Pending Join Requests</p>
+      <div className="space-y-3">
+        {requests.map((r) => (
+          <div key={r.id} className="flex items-center justify-between gap-3">
+            <div>
+              <p className="m-0 font-medium">{r.volunteer.name}</p>
+              {r.message && <p className="m-0 text-xs text-text-light italic">{r.message}</p>}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button size="sm" onClick={() => review(r.id, 'accept')}>
+                Accept
+              </Button>
+              <Button size="sm" variant="danger" onClick={() => review(r.id, 'decline')}>
+                Decline
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }

--- a/app/admin/teams/page.tsx
+++ b/app/admin/teams/page.tsx
@@ -1,0 +1,829 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useRequireAdmin } from '@/lib/hooks/auth'
+import Link from 'next/link'
+import { useMutation, useQueryClient, useQueries } from '@tanstack/react-query'
+import Button from '@/components/Button'
+import Radio from '@/components/Radio'
+import FilterDropdown, { FilterOption, useFilterOptions } from '@/components/FilterDropdown'
+import { orpc } from '@/lib/orpc'
+import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
+import { TeamSuggestionStatus } from '@/generated/prisma/enums'
+
+type StatusFilter = 'all' | 'active' | 'pending' | 'on_hold' | 'declined'
+type ReviewAction = 'accept' | 'merge' | 'on_hold' | 'decline'
+
+interface TeamMember {
+  id: number
+  name: string
+  email: string | null
+  role: 'member' | 'leader'
+}
+
+interface Team {
+  id: number
+  name: string
+  description: string | null
+  lumaUrl: string | null
+  docUrl: string | null
+  members: TeamMember[]
+}
+
+interface Suggestion {
+  id: number
+  name: string
+  description: string | null
+  status: 'pending' | 'on_hold' | 'declined'
+  adminNotes: string | null
+  createdAt: string
+  suggestedBy: { id: number; name: string; email: string }
+  mergedInto: { id: number; name: string } | null
+}
+
+type DisplayTeam = { kind: 'team' } & Team
+type DisplaySuggestion = { kind: 'suggestion' } & Suggestion
+type DisplayItem = DisplayTeam | DisplaySuggestion
+
+const STATUS_FILTER_OPTIONS: FilterOption<StatusFilter>[] = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'on_hold', label: 'On Hold' },
+  { value: 'declined', label: 'Declined' },
+]
+
+const STATUS_BADGE: Record<string, string> = {
+  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  on_hold: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  declined: 'bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400',
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  active: 'Active',
+  pending: 'Pending',
+  on_hold: 'On Hold',
+  declined: 'Declined',
+}
+
+export default function AdminTeamsPage() {
+  const { user, loading } = useRequireAdmin()
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+
+  const { value: statusFilter, onChange: setStatusFilter } = useFilterOptions(
+    STATUS_FILTER_OPTIONS,
+    'all',
+  )
+  const [deleteTarget, setDeleteTarget] = useState<DisplayItem | null>(null)
+  const [membersTarget, setMembersTarget] = useState<Team | null>(null)
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [addName, setAddName] = useState('')
+  const [addDescription, setAddDescription] = useState('')
+  const [addLumaUrl, setAddLumaUrl] = useState('')
+  const [addDocUrl, setAddDocUrl] = useState('')
+  const [addSubmitting, setAddSubmitting] = useState(false)
+
+  const [editTeam, setEditTeam] = useState<Team | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editDescription, setEditDescription] = useState('')
+  const [editLumaUrl, setEditLumaUrl] = useState('')
+  const [editDocUrl, setEditDocUrl] = useState('')
+  const [editSubmitting, setEditSubmitting] = useState(false)
+
+  const [reviewSuggestion, setReviewSuggestion] = useState<Suggestion | null>(null)
+  const [reviewAction, setReviewAction] = useState<ReviewAction>('accept')
+  const [reviewEditName, setReviewEditName] = useState('')
+  const [reviewEditDescription, setReviewEditDescription] = useState('')
+  const [mergeTargetId, setMergeTargetId] = useState<number | ''>('')
+  const [adminNotes, setAdminNotes] = useState('')
+  const [reviewSubmitting, setReviewSubmitting] = useState(false)
+
+  const fetchTeams = statusFilter === 'all' || statusFilter === 'active'
+  const fetchPending = statusFilter === 'all' || statusFilter === TeamSuggestionStatus.pending
+  const fetchOnHold = statusFilter === 'all' || statusFilter === TeamSuggestionStatus.on_hold
+  const fetchDeclined = statusFilter === 'all' || statusFilter === 'declined'
+
+  const [teamsResult, pendingResult, onHoldResult, declinedResult] = useQueries({
+    queries: [
+      { ...orpc.admin.teams.list.queryOptions(), enabled: !!user?.isAdmin && fetchTeams },
+      {
+        ...orpc.admin.teams.listSuggestions.queryOptions({
+          input: { status: TeamSuggestionStatus.pending },
+        }),
+        enabled: !!user?.isAdmin && fetchPending,
+      },
+      {
+        ...orpc.admin.teams.listSuggestions.queryOptions({
+          input: { status: TeamSuggestionStatus.on_hold },
+        }),
+        enabled: !!user?.isAdmin && fetchOnHold,
+      },
+      {
+        ...orpc.admin.teams.listSuggestions.queryOptions({ input: { status: 'declined' } }),
+        enabled: !!user?.isAdmin && fetchDeclined,
+      },
+    ],
+  })
+
+  const allTeams: Team[] = useMemo(
+    () => (teamsResult.data?.teams ?? []) as Team[],
+    [teamsResult.data],
+  )
+
+  const loadingItems =
+    (fetchTeams && teamsResult.isFetching) ||
+    (fetchPending && pendingResult.isFetching) ||
+    (fetchOnHold && onHoldResult.isFetching) ||
+    (fetchDeclined && declinedResult.isFetching)
+
+  const items = useMemo<DisplayItem[]>(() => {
+    const teams: DisplayTeam[] = fetchTeams
+      ? allTeams.map((t) => ({ kind: 'team' as const, ...t }))
+      : []
+    const suggestions: DisplaySuggestion[] = [
+      ...(fetchPending && pendingResult.data
+        ? (pendingResult.data.suggestions as unknown as Suggestion[]).map((sg) => ({
+            kind: 'suggestion' as const,
+            ...sg,
+          }))
+        : []),
+      ...(fetchOnHold && onHoldResult.data
+        ? (onHoldResult.data.suggestions as unknown as Suggestion[]).map((sg) => ({
+            kind: 'suggestion' as const,
+            ...sg,
+          }))
+        : []),
+      ...(fetchDeclined && declinedResult.data
+        ? (declinedResult.data.suggestions as unknown as Suggestion[]).map((sg) => ({
+            kind: 'suggestion' as const,
+            ...sg,
+          }))
+        : []),
+    ]
+    return [...teams, ...suggestions].sort((a, b) => a.name.localeCompare(b.name))
+  }, [
+    fetchTeams,
+    fetchPending,
+    fetchOnHold,
+    fetchDeclined,
+    allTeams,
+    pendingResult.data,
+    onHoldResult.data,
+    declinedResult.data,
+  ])
+
+  const invalidateItems = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: orpc.admin.teams.list.key() }),
+      queryClient.invalidateQueries({ queryKey: orpc.admin.teams.listSuggestions.key() }),
+      queryClient.invalidateQueries({ queryKey: orpc.teams.list.key() }),
+    ])
+
+  const createTeamMutation = useMutation({ ...orpc.admin.teams.create.mutationOptions() })
+  const updateTeamMutation = useMutation({ ...orpc.admin.teams.update.mutationOptions() })
+  const reviewSuggestionMutation = useMutation({
+    ...orpc.admin.teams.reviewSuggestion.mutationOptions(),
+  })
+  const deleteTeamMutation = useMutation({ ...orpc.admin.teams.delete.mutationOptions() })
+  const deleteSuggestionMutation = useMutation({
+    ...orpc.admin.teams.deleteSuggestion.mutationOptions(),
+  })
+  const setMemberRoleMutation = useMutation({ ...orpc.admin.teams.setMemberRole.mutationOptions() })
+  const removeMemberMutation = useMutation({ ...orpc.admin.teams.removeMember.mutationOptions() })
+
+  const mergeOptions = [
+    { value: '', label: 'Select an existing team…' },
+    ...allTeams.map((t) => ({ value: String(t.id), label: t.name })),
+  ]
+
+  function openEdit(team: Team) {
+    setEditTeam(team)
+    setEditName(team.name)
+    setEditDescription(team.description ?? '')
+    setEditLumaUrl(team.lumaUrl ?? '')
+    setEditDocUrl(team.docUrl ?? '')
+  }
+
+  function openReview(suggestion: Suggestion) {
+    setReviewSuggestion(suggestion)
+    setReviewAction('accept')
+    setReviewEditName(suggestion.name)
+    setReviewEditDescription(suggestion.description ?? '')
+    setMergeTargetId('')
+    setAdminNotes('')
+  }
+
+  function openAdd() {
+    setAddName('')
+    setAddDescription('')
+    setAddLumaUrl('')
+    setAddDocUrl('')
+    setShowAdd(true)
+  }
+
+  async function submitAdd(e: React.FormEvent) {
+    e.preventDefault()
+    setAddSubmitting(true)
+    try {
+      await createTeamMutation.mutateAsync({
+        name: addName.trim(),
+        description: addDescription.trim() || null,
+        lumaUrl: addLumaUrl.trim() || null,
+        docUrl: addDocUrl.trim() || null,
+      })
+      await invalidateItems()
+      showToast('Team added', 'success')
+      setShowAdd(false)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to add team', 'error')
+    } finally {
+      setAddSubmitting(false)
+    }
+  }
+
+  async function submitEdit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!editTeam) return
+    setEditSubmitting(true)
+    try {
+      await updateTeamMutation.mutateAsync({
+        id: editTeam.id,
+        name: editName.trim(),
+        description: editDescription.trim() || null,
+        lumaUrl: editLumaUrl.trim() || null,
+        docUrl: editDocUrl.trim() || null,
+      })
+      await invalidateItems()
+      showToast('Team updated', 'success')
+      setEditTeam(null)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update team', 'error')
+    } finally {
+      setEditSubmitting(false)
+    }
+  }
+
+  async function submitReview(e: React.FormEvent) {
+    e.preventDefault()
+    if (!reviewSuggestion) return
+    setReviewSubmitting(true)
+    try {
+      const body: Record<string, unknown> = { action: reviewAction }
+      if (reviewAction === 'accept') {
+        body.name = reviewEditName.trim()
+        body.description = reviewEditDescription.trim() || null
+      } else if (reviewAction === 'merge') {
+        body.mergedIntoId = mergeTargetId
+      }
+      if (adminNotes.trim()) body.adminNotes = adminNotes.trim()
+
+      await reviewSuggestionMutation.mutateAsync({
+        id: reviewSuggestion.id,
+        ...body,
+      } as Parameters<typeof reviewSuggestionMutation.mutateAsync>[0])
+
+      await invalidateItems()
+
+      const actionLabels: Record<ReviewAction, string> = {
+        accept: 'accepted',
+        merge: 'merged',
+        on_hold: 'put on hold',
+        decline: 'declined',
+      }
+      showToast(`Suggestion ${actionLabels[reviewAction]}`, 'success')
+      setReviewSuggestion(null)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update suggestion', 'error')
+    } finally {
+      setReviewSubmitting(false)
+    }
+  }
+
+  async function deleteItem() {
+    if (!deleteTarget) return
+    const item = deleteTarget
+    try {
+      if (item.kind === 'team') {
+        await deleteTeamMutation.mutateAsync({ id: item.id })
+      } else {
+        await deleteSuggestionMutation.mutateAsync({ id: item.id })
+      }
+      await invalidateItems()
+      showToast('Deleted', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to delete', 'error')
+    } finally {
+      setDeleteTarget(null)
+    }
+  }
+
+  async function toggleLeader(member: TeamMember) {
+    if (!membersTarget) return
+    try {
+      await setMemberRoleMutation.mutateAsync({
+        teamId: membersTarget.id,
+        volunteerId: member.id,
+        role: member.role === 'leader' ? 'member' : 'leader',
+      })
+      await invalidateItems()
+      const updated = await queryClient.fetchQuery(orpc.admin.teams.list.queryOptions())
+      const refreshed = (updated.teams as Team[]).find((t) => t.id === membersTarget.id)
+      if (refreshed) setMembersTarget(refreshed)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update role', 'error')
+    }
+  }
+
+  async function removeMember(member: TeamMember) {
+    if (!membersTarget) return
+    try {
+      await removeMemberMutation.mutateAsync({ teamId: membersTarget.id, volunteerId: member.id })
+      await invalidateItems()
+      const updated = await queryClient.fetchQuery(orpc.admin.teams.list.queryOptions())
+      const refreshed = (updated.teams as Team[]).find((t) => t.id === membersTarget.id)
+      if (refreshed) setMembersTarget(refreshed)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to remove member', 'error')
+    }
+  }
+
+  function itemStatus(item: DisplayItem): string {
+    return item.kind === 'team' ? 'active' : item.status
+  }
+
+  if (loading || !user) return null
+
+  return (
+    <>
+      <main className="container py-5 pb-15">
+        <div className="flex items-center justify-between mb-2">
+          <h1 className="m-0">Teams</h1>
+          <Button size="sm" onClick={openAdd}>
+            Add Team
+          </Button>
+        </div>
+        <p className="text-text-light mb-6">
+          Manage active teams and review volunteer suggestions.
+        </p>
+
+        <div className="flex flex-wrap gap-4 mb-6">
+          <FilterDropdown
+            id="status-filter"
+            label="Status"
+            ariaLabel="Status filter"
+            value={statusFilter}
+            options={STATUS_FILTER_OPTIONS}
+            onChange={(v) => setStatusFilter(v)}
+          />
+        </div>
+
+        {loadingItems ? (
+          <div className="text-center py-10 text-text-light">Loading…</div>
+        ) : items.length === 0 ? (
+          <p className="text-text-light">No teams found.</p>
+        ) : (
+          <div className="space-y-4">
+            {items.map((item) => {
+              const status = itemStatus(item)
+              return (
+                <article
+                  key={`${item.kind}-${item.id}`}
+                  className="bg-surface rounded-xl shadow px-5 py-4 flex items-center justify-between gap-4"
+                >
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold">{item.name}</span>
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_BADGE[status] ?? ''}`}
+                      >
+                        {STATUS_LABEL[status] ?? status}
+                      </span>
+                      {item.kind === 'team' && (
+                        <span className="text-xs text-text-light">
+                          {item.members.length} member{item.members.length === 1 ? '' : 's'}
+                        </span>
+                      )}
+                    </div>
+                    {item.kind === 'suggestion' && (
+                      <p className="text-sm text-text-light m-0 mt-1">
+                        Suggested by{' '}
+                        <Link
+                          href={`/admin/volunteers/${item.suggestedBy.id}`}
+                          className="text-secondary-dark no-underline hover:text-primary"
+                        >
+                          {item.suggestedBy.name}
+                        </Link>
+                        {' · '}
+                        {formatDate(item.createdAt)}
+                      </p>
+                    )}
+                    {item.kind === 'suggestion' && item.adminNotes && (
+                      <p className="text-sm text-text-light mt-2 mb-0 italic">{item.adminNotes}</p>
+                    )}
+                  </div>
+                  <div className="shrink-0 flex items-center gap-2">
+                    {item.kind === 'team' && (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => setMembersTarget(item)}
+                        >
+                          Members
+                        </Button>
+                        <Button size="sm" variant="secondary" onClick={() => openEdit(item)}>
+                          Edit
+                        </Button>
+                      </>
+                    )}
+                    {item.kind === 'suggestion' && (
+                      <Button size="sm" onClick={() => openReview(item)}>
+                        {item.status === TeamSuggestionStatus.declined ||
+                        item.status === TeamSuggestionStatus.on_hold
+                          ? 'Re-review'
+                          : 'Review'}
+                      </Button>
+                    )}
+                    <Button size="sm" variant="danger" onClick={() => setDeleteTarget(item)}>
+                      Delete
+                    </Button>
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </main>
+
+      {/* Add Team Modal */}
+      {showAdd && (
+        <div
+          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowAdd(false)
+          }}
+        >
+          <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full">
+            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
+              <h2 role="heading">Add Team</h2>
+              <Button variant="ghost" icon onClick={() => setShowAdd(false)} aria-label="Close">
+                ×
+              </Button>
+            </div>
+            <div className="p-6">
+              <form onSubmit={submitAdd}>
+                <div className="mb-5">
+                  <label htmlFor="add-name">Team Name</label>
+                  <input
+                    id="add-name"
+                    type="text"
+                    value={addName}
+                    onChange={(e) => setAddName(e.target.value)}
+                    placeholder="e.g., Comms, Outreach"
+                  />
+                </div>
+                <div className="mb-5">
+                  <label htmlFor="add-description">Description</label>
+                  <textarea
+                    id="add-description"
+                    rows={2}
+                    value={addDescription}
+                    onChange={(e) => setAddDescription(e.target.value)}
+                    className="w-full"
+                  />
+                </div>
+                <div className="mb-5">
+                  <label htmlFor="add-luma">Luma calendar URL</label>
+                  <input
+                    id="add-luma"
+                    type="text"
+                    value={addLumaUrl}
+                    onChange={(e) => setAddLumaUrl(e.target.value)}
+                    placeholder="https://luma.com/…"
+                  />
+                </div>
+                <div className="mb-5">
+                  <label htmlFor="add-doc">Team doc URL</label>
+                  <input
+                    id="add-doc"
+                    type="text"
+                    value={addDocUrl}
+                    onChange={(e) => setAddDocUrl(e.target.value)}
+                    placeholder="https://docs.google.com/…"
+                  />
+                </div>
+                <div className="pt-4 border-t border-brand-border flex gap-3 justify-end">
+                  <Button type="button" variant="secondary" onClick={() => setShowAdd(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={addSubmitting || !addName.trim()}>
+                    {addSubmitting ? 'Saving…' : 'Add Team'}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Edit Team Modal */}
+      {editTeam && (
+        <div
+          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setEditTeam(null)
+          }}
+        >
+          <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full">
+            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
+              <h2 role="heading">Edit Team</h2>
+              <Button variant="ghost" icon onClick={() => setEditTeam(null)} aria-label="Close">
+                ×
+              </Button>
+            </div>
+            <div className="p-6">
+              <form onSubmit={submitEdit}>
+                <div className="mb-5">
+                  <label htmlFor="edit-name">Team Name</label>
+                  <input
+                    id="edit-name"
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                  />
+                </div>
+                <div className="mb-5">
+                  <label htmlFor="edit-description">Description</label>
+                  <textarea
+                    id="edit-description"
+                    rows={2}
+                    value={editDescription}
+                    onChange={(e) => setEditDescription(e.target.value)}
+                    className="w-full"
+                  />
+                </div>
+                <div className="mb-5">
+                  <label htmlFor="edit-luma">Luma calendar URL</label>
+                  <input
+                    id="edit-luma"
+                    type="text"
+                    value={editLumaUrl}
+                    onChange={(e) => setEditLumaUrl(e.target.value)}
+                  />
+                </div>
+                <div className="mb-5">
+                  <label htmlFor="edit-doc">Team doc URL</label>
+                  <input
+                    id="edit-doc"
+                    type="text"
+                    value={editDocUrl}
+                    onChange={(e) => setEditDocUrl(e.target.value)}
+                  />
+                </div>
+                <div className="pt-4 border-t border-brand-border flex gap-3 justify-end">
+                  <Button type="button" variant="secondary" onClick={() => setEditTeam(null)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={editSubmitting || !editName.trim()}>
+                    {editSubmitting ? 'Saving…' : 'Save Changes'}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Members Modal */}
+      {membersTarget && (
+        <div
+          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setMembersTarget(null)
+          }}
+        >
+          <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto">
+            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
+              <h2 role="heading">{membersTarget.name} — Members</h2>
+              <Button
+                variant="ghost"
+                icon
+                onClick={() => setMembersTarget(null)}
+                aria-label="Close"
+              >
+                ×
+              </Button>
+            </div>
+            <div className="p-6">
+              {membersTarget.members.length === 0 ? (
+                <p className="text-text-light">No members yet.</p>
+              ) : (
+                <div className="space-y-3">
+                  {membersTarget.members.map((m) => (
+                    <div key={m.id} className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="m-0 font-medium">{m.name}</p>
+                        <p className="m-0 text-xs text-text-light">{m.email}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {m.role === 'leader' && (
+                          <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-primary/10 text-primary">
+                            Leader
+                          </span>
+                        )}
+                        <Button size="sm" variant="secondary" onClick={() => toggleLeader(m)}>
+                          {m.role === 'leader' ? 'Demote' : 'Make Leader'}
+                        </Button>
+                        <Button size="sm" variant="danger" onClick={() => removeMember(m)}>
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Review Suggestion Modal */}
+      {reviewSuggestion && (
+        <div
+          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setReviewSuggestion(null)
+          }}
+        >
+          <div className="bg-surface rounded-xl shadow-lg max-w-125 w-full max-h-[90vh] overflow-y-auto">
+            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
+              <h2 role="heading">Review Suggestion</h2>
+              <Button
+                variant="ghost"
+                icon
+                onClick={() => setReviewSuggestion(null)}
+                aria-label="Close"
+              >
+                ×
+              </Button>
+            </div>
+
+            <div className="p-6">
+              <p className="text-text-light mb-1 text-sm">
+                Suggested by {reviewSuggestion.suggestedBy.name}
+              </p>
+              <p className="font-semibold mb-5">{reviewSuggestion.name}</p>
+
+              <form onSubmit={submitReview}>
+                <div className="mb-5">
+                  <label>Action</label>
+                  <div className="flex flex-col gap-3 mt-2">
+                    {(
+                      [
+                        {
+                          value: 'accept',
+                          label: 'Accept',
+                          desc: 'Add as a new team (suggester becomes leader)',
+                        },
+                        { value: 'merge', label: 'Merge', desc: 'Link to an existing team' },
+                        { value: 'on_hold', label: 'On Hold', desc: 'Keep for later review' },
+                        { value: 'decline', label: 'Decline', desc: 'Not adding at this time' },
+                      ] as { value: ReviewAction; label: string; desc: string }[]
+                    ).map((opt) => (
+                      <Radio
+                        key={opt.value}
+                        name="action"
+                        value={opt.value}
+                        checked={reviewAction === opt.value}
+                        onChange={() => setReviewAction(opt.value)}
+                      >
+                        <span>
+                          <strong>{opt.label}</strong> — {opt.desc}
+                        </span>
+                      </Radio>
+                    ))}
+                  </div>
+                </div>
+
+                {reviewAction === 'accept' && (
+                  <>
+                    <div className="mb-4">
+                      <label htmlFor="review-name">Team Name</label>
+                      <input
+                        id="review-name"
+                        type="text"
+                        value={reviewEditName}
+                        onChange={(e) => setReviewEditName(e.target.value)}
+                        placeholder="Team name"
+                      />
+                    </div>
+                    <div className="mb-5">
+                      <label htmlFor="review-description">Description</label>
+                      <textarea
+                        id="review-description"
+                        rows={2}
+                        value={reviewEditDescription}
+                        onChange={(e) => setReviewEditDescription(e.target.value)}
+                        className="w-full"
+                      />
+                    </div>
+                  </>
+                )}
+
+                {reviewAction === 'merge' && (
+                  <div className="mb-5">
+                    <FilterDropdown
+                      id="merge-target"
+                      label="Merge into existing team"
+                      ariaLabel="Select existing team to merge into"
+                      value={mergeTargetId === '' ? '' : String(mergeTargetId)}
+                      options={mergeOptions}
+                      onChange={(v) => setMergeTargetId(v ? Number(v) : '')}
+                      searchable
+                    />
+                  </div>
+                )}
+
+                {(reviewAction === 'on_hold' || reviewAction === 'decline') && (
+                  <div className="mb-5">
+                    <label htmlFor="admin-notes">
+                      Note for volunteer{' '}
+                      <span className="text-text-light font-normal">(optional)</span>
+                    </label>
+                    <textarea
+                      id="admin-notes"
+                      rows={3}
+                      value={adminNotes}
+                      onChange={(e) => setAdminNotes(e.target.value)}
+                      className="w-full"
+                    />
+                    <p className="text-sm text-text-light mt-1">
+                      This note will be shared with the volunteer.
+                    </p>
+                  </div>
+                )}
+
+                <div className="pt-4 border-t border-brand-border flex gap-3 justify-end">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setReviewSuggestion(null)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={
+                      reviewSubmitting ||
+                      (reviewAction === 'accept' && !reviewEditName.trim()) ||
+                      (reviewAction === 'merge' && !mergeTargetId)
+                    }
+                    variant={reviewAction === 'decline' ? 'danger' : 'primary'}
+                  >
+                    {reviewSubmitting ? 'Saving…' : 'Confirm'}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 bg-[rgba(29,53,87,0.5)] flex items-center justify-center z-1000 p-5"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setDeleteTarget(null)
+          }}
+        >
+          <div className="bg-surface rounded-xl shadow-lg max-w-md w-full">
+            <div className="px-6 py-5 border-b border-brand-border flex justify-between items-center">
+              <h2 role="heading">Confirm Delete</h2>
+              <Button variant="ghost" icon onClick={() => setDeleteTarget(null)} aria-label="Close">
+                ×
+              </Button>
+            </div>
+            <div className="p-6">
+              <p>
+                Delete <strong>{deleteTarget.name}</strong>? This cannot be undone.
+              </p>
+              <div className="pt-4 border-t border-brand-border flex gap-3 justify-end mt-4">
+                <Button variant="secondary" onClick={() => setDeleteTarget(null)}>
+                  Cancel
+                </Button>
+                <Button variant="danger" onClick={deleteItem}>
+                  Delete
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -55,6 +55,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [hoursPerWeek, setHoursPerWeek] = useState('')
   const [urgency, setUrgency] = useState('medium')
   const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
+  const [teamId, setTeamId] = useState('')
   const [remoteEligibility, setRemoteEligibility] = useState<'NONE' | 'COUNTRY' | 'GLOBAL'>('NONE')
   const [estimatedDuration, setEstimatedDuration] = useState('')
   const [seekingHelp, setSeekingHelp] = useState(true)
@@ -64,6 +65,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     enabled: true,
   })
   const allLocalGroups = localGroupsData?.groups ?? []
+
+  const { data: teamsData } = useQuery(orpc.teams.list.queryOptions())
+  const teams = teamsData?.teams ?? []
 
   const { data: projectData, isPending: loadingProject } = useQuery({
     ...orpc.projects.getById.queryOptions({ input: { id: parseInt(idParam, 10) } }),
@@ -85,6 +89,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     const country = data.country ?? ''
     const localGroup = data.localGroup ?? ''
     setLocationValue(country && localGroup ? `${country}:${localGroup}` : country)
+    setTeamId(data.teamId ? String(data.teamId) : '')
     setRemoteEligibility(data.remoteEligibility ?? 'NONE')
     setEstimatedDuration(data.estimatedDuration ?? '')
     setSeekingHelp(data.isSeekingHelp ?? false)
@@ -124,6 +129,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
       urgency,
       country: country || null,
       localGroup: localGroup || null,
+      teamId: teamId ? Number(teamId) : null,
       remoteEligibility,
       estimatedDuration: estimatedDuration.trim() || null,
       isSeekingHelp: seekingHelp,
@@ -252,6 +258,24 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             />
             <p className="text-sm text-text-light mt-1">
               Local groups appear indented under their country.
+            </p>
+          </div>
+
+          <div className="mb-5">
+            <FilterDropdown
+              id="team"
+              label="Team"
+              ariaLabel="Select team"
+              value={teamId}
+              options={[
+                { value: '', label: 'No team — visible to everyone' },
+                ...teams.map((t) => ({ value: String(t.id), label: t.name })),
+              ]}
+              onChange={setTeamId}
+              searchable
+            />
+            <p className="text-sm text-text-light mt-1">
+              Assigning a team restricts visibility to that team, plus the owner and proposer.
             </p>
           </div>
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1141,6 +1141,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                   )
                 )
               })()}
+              {project.team && (
+                <p className="text-sm text-text-light mt-1 mb-0">🧑‍🤝‍🧑 {project.team.name}</p>
+              )}
               <Modal
                 id="confirm-status-change"
                 title="Change project status?"
@@ -1160,6 +1163,209 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                   </Button>
                 </div>
               </Modal>
+
+              {/* Ownership — same panel as Status/Team above */}
+              <div className="mt-4 pt-4 border-t border-brand-border">
+                <h2>Owner</h2>
+                <div className="flex items-center justify-between gap-2">
+                  {project.owner ? (
+                    <div className="flex items-center gap-2 min-w-0">
+                      <TaskAvatar name={project.owner.name} />
+                      <Link href={`/volunteers/${project.owner.id}`} className="underline truncate">
+                        {project.owner.name}
+                      </Link>
+                    </div>
+                  ) : isAdmin && proposer ? (
+                    // Ownerless projects still have a proposer. Admins triaging the queue need
+                    // to know who to talk to, so show them that name in place of the empty state.
+                    <div className="flex items-center gap-2 min-w-0">
+                      <TaskAvatar name={proposer.name} />
+                      <span className="truncate">
+                        Proposer:{' '}
+                        {proposer.volunteerId ? (
+                          <Link href={`/volunteers/${proposer.volunteerId}`} className="underline">
+                            {proposer.name}
+                          </Link>
+                        ) : (
+                          proposer.name
+                        )}
+                      </span>
+                    </div>
+                  ) : (
+                    <p className="text-text-light text-sm m-0">No owner yet.</p>
+                  )}
+                  {isAdmin && volunteers.length > 0 && (
+                    <ActionMenu ariaLabel="Ownership actions">
+                      {(close) => (
+                        <>
+                          <div className="px-3 py-2 flex flex-col gap-2">
+                            <h3 className="m-0 text-sm">Transfer Ownership</h3>
+                            <FilterDropdown
+                              id="transfer-to"
+                              label="Transfer to"
+                              ariaLabel="Transfer to"
+                              value={transferTo}
+                              options={[
+                                { value: '', label: '— Select volunteer —' },
+                                ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
+                              ]}
+                              onChange={(v) => setTransferTo(v)}
+                              searchable
+                            />
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              disabled={!transferTo || updateProjectMutation.isPending}
+                              onClick={() => {
+                                if (!transferTo) return
+                                if (!window.confirm('Transfer ownership to this volunteer?')) return
+                                updateProjectMutation.mutate({
+                                  id: parseInt(idParam, 10),
+                                  assigneeId: parseInt(transferTo, 10),
+                                })
+                                close()
+                              }}
+                            >
+                              {updateProjectMutation.isPending ? 'Transferring…' : 'Transfer'}
+                            </Button>
+                          </div>
+                          {project.owner && (
+                            <button
+                              role="menuitem"
+                              className="w-full text-left px-3 py-2 text-sm text-red-700 dark:text-red-400 hover:bg-accent transition-colors cursor-pointer border-t border-brand-border mt-1"
+                              onClick={() => {
+                                if (!window.confirm('Remove the current owner from this project?'))
+                                  return
+                                updateProjectMutation.mutate({
+                                  id: parseInt(idParam, 10),
+                                  assigneeId: null,
+                                })
+                                close()
+                              }}
+                            >
+                              Remove ownership
+                            </button>
+                          )}
+                        </>
+                      )}
+                    </ActionMenu>
+                  )}
+                </div>
+                {project.ownerId && !isOwner && !isAdmin && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="mt-3"
+                    onClick={() => setShowContactModal(true)}
+                  >
+                    Contact Owner
+                  </Button>
+                )}
+
+                {isOwnerOrAdmin && Array.isArray(project.interests) && (
+                  <div className="mt-4 pt-4 border-t border-brand-border">
+                    <h3 className="text-sm mb-2">Volunteers</h3>
+
+                    {volunteerInterests.length === 0 ? (
+                      <p className="text-text-light text-sm">No interests yet.</p>
+                    ) : (
+                      <ul className="list-none p-0 m-0">
+                        {volunteerInterests.map((interest) => (
+                          // [test hook] interest-card class used as test selector
+                          <li
+                            key={interest.id}
+                            className="interest-card flex items-center gap-2 py-2 border-b border-brand-border last:border-0 flex-wrap"
+                          >
+                            <TaskAvatar name={interest.volunteerName} />
+                            <div className="flex-1 min-w-0">
+                              <div className="truncate">{interest.volunteerName}</div>
+                              <div className="text-text-light text-xs">
+                                {interest.status === InterestStatus.accepted
+                                  ? interest.interestType === 'want_to_own'
+                                    ? 'Owner'
+                                    : 'Helper'
+                                  : interest.status === InterestStatus.pending
+                                    ? interest.interestType === 'want_to_own'
+                                      ? 'wants to own'
+                                      : 'wants to help'
+                                    : interest.interestType === 'want_to_own'
+                                      ? 'wanted to own'
+                                      : 'wanted to help'}
+                              </div>
+                            </div>
+                            {interest.status === InterestStatus.pending ? (
+                              <div className="flex gap-2 shrink-0">
+                                <Button size="sm" onClick={() => handleAcceptInterest(interest.id)}>
+                                  Accept
+                                </Button>
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={() => handleDeclineInterest(interest.id)}
+                                >
+                                  Decline
+                                </Button>
+                              </div>
+                            ) : interest.status === InterestStatus.accepted ? (
+                              <div className="flex items-center gap-2 shrink-0">
+                                <Badge variant={projectStatusVariant(interest.status)}>
+                                  {INTEREST_STATUS_LABELS[interest.status] ?? interest.status}
+                                </Badge>
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={() => handleDeclineInterest(interest.id)}
+                                >
+                                  Remove
+                                </Button>
+                              </div>
+                            ) : (
+                              <Badge variant={projectStatusVariant(interest.status)}>
+                                {INTEREST_STATUS_LABELS[interest.status] ?? interest.status}
+                              </Badge>
+                            )}
+                            {interest.message && interest.status !== InterestStatus.accepted && (
+                              <p className="text-sm text-text-light w-full m-0">
+                                {interest.message}
+                              </p>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {volunteers.length > 0 && (
+                      <form
+                        onSubmit={handleAssign}
+                        className="flex gap-2 items-center flex-wrap mt-3 pt-3 border-t border-brand-border"
+                      >
+                        <span className="text-text-light text-sm shrink-0">+ Add</span>
+                        <div className="flex-1 min-w-40">
+                          <FilterDropdown
+                            id="assign-volunteer"
+                            label=""
+                            ariaLabel="Volunteer to assign"
+                            value={assignTo}
+                            options={[
+                              { value: '', label: '— Select volunteer —' },
+                              ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
+                            ]}
+                            onChange={(v) => setAssignTo(v)}
+                            searchable
+                          />
+                        </div>
+                        <Button
+                          type="submit"
+                          size="sm"
+                          disabled={!assignTo || assignMutation.isPending}
+                        >
+                          {assignMutation.isPending ? 'Assigning…' : 'Assign'}
+                        </Button>
+                      </form>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Admin triage */}
@@ -1244,207 +1450,6 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                 </form>
               </div>
             )}
-
-            {/* Ownership */}
-            <div className={card}>
-              <h2>Owner</h2>
-              <div className="flex items-center justify-between gap-2">
-                {project.owner ? (
-                  <div className="flex items-center gap-2 min-w-0">
-                    <TaskAvatar name={project.owner.name} />
-                    <Link href={`/volunteers/${project.owner.id}`} className="underline truncate">
-                      {project.owner.name}
-                    </Link>
-                  </div>
-                ) : isAdmin && proposer ? (
-                  // Ownerless projects still have a proposer. Admins triaging the queue need
-                  // to know who to talk to, so show them that name in place of the empty state.
-                  <div className="flex items-center gap-2 min-w-0">
-                    <TaskAvatar name={proposer.name} />
-                    <span className="truncate">
-                      Proposer:{' '}
-                      {proposer.volunteerId ? (
-                        <Link href={`/volunteers/${proposer.volunteerId}`} className="underline">
-                          {proposer.name}
-                        </Link>
-                      ) : (
-                        proposer.name
-                      )}
-                    </span>
-                  </div>
-                ) : (
-                  <p className="text-text-light text-sm m-0">No owner yet.</p>
-                )}
-                {isAdmin && volunteers.length > 0 && (
-                  <ActionMenu ariaLabel="Ownership actions">
-                    {(close) => (
-                      <>
-                        <div className="px-3 py-2 flex flex-col gap-2">
-                          <h3 className="m-0 text-sm">Transfer Ownership</h3>
-                          <FilterDropdown
-                            id="transfer-to"
-                            label="Transfer to"
-                            ariaLabel="Transfer to"
-                            value={transferTo}
-                            options={[
-                              { value: '', label: '— Select volunteer —' },
-                              ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                            ]}
-                            onChange={(v) => setTransferTo(v)}
-                            searchable
-                          />
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            disabled={!transferTo || updateProjectMutation.isPending}
-                            onClick={() => {
-                              if (!transferTo) return
-                              if (!window.confirm('Transfer ownership to this volunteer?')) return
-                              updateProjectMutation.mutate({
-                                id: parseInt(idParam, 10),
-                                assigneeId: parseInt(transferTo, 10),
-                              })
-                              close()
-                            }}
-                          >
-                            {updateProjectMutation.isPending ? 'Transferring…' : 'Transfer'}
-                          </Button>
-                        </div>
-                        {project.owner && (
-                          <button
-                            role="menuitem"
-                            className="w-full text-left px-3 py-2 text-sm text-red-700 dark:text-red-400 hover:bg-accent transition-colors cursor-pointer border-t border-brand-border mt-1"
-                            onClick={() => {
-                              if (!window.confirm('Remove the current owner from this project?'))
-                                return
-                              updateProjectMutation.mutate({
-                                id: parseInt(idParam, 10),
-                                assigneeId: null,
-                              })
-                              close()
-                            }}
-                          >
-                            Remove ownership
-                          </button>
-                        )}
-                      </>
-                    )}
-                  </ActionMenu>
-                )}
-              </div>
-              {project.ownerId && !isOwner && !isAdmin && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="mt-3"
-                  onClick={() => setShowContactModal(true)}
-                >
-                  Contact Owner
-                </Button>
-              )}
-
-              {isOwnerOrAdmin && Array.isArray(project.interests) && (
-                <div className="mt-4 pt-4 border-t border-brand-border">
-                  <h3 className="text-sm mb-2">Volunteers</h3>
-
-                  {volunteerInterests.length === 0 ? (
-                    <p className="text-text-light text-sm">No interests yet.</p>
-                  ) : (
-                    <ul className="list-none p-0 m-0">
-                      {volunteerInterests.map((interest) => (
-                        // [test hook] interest-card class used as test selector
-                        <li
-                          key={interest.id}
-                          className="interest-card flex items-center gap-2 py-2 border-b border-brand-border last:border-0 flex-wrap"
-                        >
-                          <TaskAvatar name={interest.volunteerName} />
-                          <div className="flex-1 min-w-0">
-                            <div className="truncate">{interest.volunteerName}</div>
-                            <div className="text-text-light text-xs">
-                              {interest.status === InterestStatus.accepted
-                                ? interest.interestType === 'want_to_own'
-                                  ? 'Owner'
-                                  : 'Helper'
-                                : interest.status === InterestStatus.pending
-                                  ? interest.interestType === 'want_to_own'
-                                    ? 'wants to own'
-                                    : 'wants to help'
-                                  : interest.interestType === 'want_to_own'
-                                    ? 'wanted to own'
-                                    : 'wanted to help'}
-                            </div>
-                          </div>
-                          {interest.status === InterestStatus.pending ? (
-                            <div className="flex gap-2 shrink-0">
-                              <Button size="sm" onClick={() => handleAcceptInterest(interest.id)}>
-                                Accept
-                              </Button>
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                onClick={() => handleDeclineInterest(interest.id)}
-                              >
-                                Decline
-                              </Button>
-                            </div>
-                          ) : interest.status === InterestStatus.accepted ? (
-                            <div className="flex items-center gap-2 shrink-0">
-                              <Badge variant={projectStatusVariant(interest.status)}>
-                                {INTEREST_STATUS_LABELS[interest.status] ?? interest.status}
-                              </Badge>
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                onClick={() => handleDeclineInterest(interest.id)}
-                              >
-                                Remove
-                              </Button>
-                            </div>
-                          ) : (
-                            <Badge variant={projectStatusVariant(interest.status)}>
-                              {INTEREST_STATUS_LABELS[interest.status] ?? interest.status}
-                            </Badge>
-                          )}
-                          {interest.message && interest.status !== InterestStatus.accepted && (
-                            <p className="text-sm text-text-light w-full m-0">{interest.message}</p>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-
-                  {volunteers.length > 0 && (
-                    <form
-                      onSubmit={handleAssign}
-                      className="flex gap-2 items-center flex-wrap mt-3 pt-3 border-t border-brand-border"
-                    >
-                      <span className="text-text-light text-sm shrink-0">+ Add</span>
-                      <div className="flex-1 min-w-40">
-                        <FilterDropdown
-                          id="assign-volunteer"
-                          label=""
-                          ariaLabel="Volunteer to assign"
-                          value={assignTo}
-                          options={[
-                            { value: '', label: '— Select volunteer —' },
-                            ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                          ]}
-                          onChange={(v) => setAssignTo(v)}
-                          searchable
-                        />
-                      </div>
-                      <Button
-                        type="submit"
-                        size="sm"
-                        disabled={!assignTo || assignMutation.isPending}
-                      >
-                        {assignMutation.isPending ? 'Assigning…' : 'Assign'}
-                      </Button>
-                    </form>
-                  )}
-                </div>
-              )}
-            </div>
 
             {/* Interest section */}
             {canSeeInterest && (

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -58,6 +58,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   const [needsFilter, setNeedsFilter] = useUrlParam('needs')
   const [urgencyFilter, setUrgencyFilter] = useUrlParam('urgency')
   const [locationFilter, setLocationFilter] = useUrlParam('location')
+  const [teamFilter, setTeamFilter] = useUrlParam('team')
   const [sortBy, setSortBy] = useUrlParam('sort')
   const router = useRouter()
   function clearFilters() {
@@ -85,6 +86,19 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   })
   const localGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
 
+  const { data: teamsData } = useQuery({ ...orpc.teams.list.queryOptions(), enabled: !!user })
+  const allTeamsList = teamsData?.teams ?? []
+  const myTeams = allTeamsList.filter((t) => t.viewerRole !== null)
+  const teamOptions = user.isAdmin
+    ? [
+        { value: '', label: 'All teams' },
+        ...allTeamsList.map((t) => ({ value: String(t.id), label: t.name })),
+      ]
+    : [
+        { value: '', label: 'All my teams' },
+        ...myTeams.map((t) => ({ value: String(t.id), label: t.name })),
+      ]
+
   const projectsInput: InferRouterInputs<AppRouter>['projects']['list'] = {}
   if (urlSearch) projectsInput.search = urlSearch
   if (statusFilter) projectsInput.status = statusFilter
@@ -98,6 +112,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
     projectsInput.country = country
     if (localGroup) projectsInput.localGroup = localGroup
   }
+  if (teamFilter) projectsInput.teamId = Number(teamFilter)
   if (sortBy) projectsInput.sortBy = sortBy
 
   const {
@@ -117,7 +132,13 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   const projects = projectsData?.projects ?? []
 
   const hasFilters =
-    searchInput || statusFilter || needsFilter || urgencyFilter || locationFilter || sortBy
+    searchInput ||
+    statusFilter ||
+    needsFilter ||
+    urgencyFilter ||
+    locationFilter ||
+    teamFilter ||
+    sortBy
 
   function byMatchScore(a: Project, b: Project) {
     const scoreA = a.match?.matchedRequiredCount ?? 0
@@ -127,6 +148,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   const sortGroup = (list: Project[]) =>
     userSkillIds.size > 0 ? [...list].sort(byMatchScore) : list
 
+  const yourTeamProjects = sortGroup(projects.filter((p) => p.isMyTeam))
   const seeking = sortGroup(projects.filter((p) => p.isSeekingHelp || p.isSeekingOwner))
   const inProgress = sortGroup(
     projects.filter(
@@ -149,6 +171,19 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   )
 
   const groups = [
+    // Admins see every team's projects, so "your teams" isn't a meaningful cut for them —
+    // this is only a quick-jump section for a volunteer's own team memberships.
+    ...(!user.isAdmin
+      ? [
+          {
+            key: 'your_team',
+            projects: yourTeamProjects,
+            label: 'Your Team Projects',
+            desc: 'Tagged to a team you belong to',
+            color: 'text-primary',
+          },
+        ]
+      : []),
     {
       key: 'seeking',
       projects: seeking,
@@ -255,6 +290,18 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
               onChange={setLocationFilter}
               searchable
             />
+
+            {(user.isAdmin || myTeams.length > 0) && (
+              <FilterDropdown
+                id="team-filter"
+                label="Team"
+                ariaLabel="Team filter"
+                value={teamFilter}
+                options={teamOptions}
+                onChange={setTeamFilter}
+                searchable
+              />
+            )}
 
             <FilterDropdown
               id="sort-filter"

--- a/app/suggest-team/page.tsx
+++ b/app/suggest-team/page.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useState } from 'react'
+import { useRequireAuth } from '@/lib/hooks/auth'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import Button from '@/components/Button'
+import { orpc } from '@/lib/orpc'
+import { useToast } from '@/lib/toast'
+import { formatDate } from '@/lib/format-date'
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: 'Pending Review',
+  accepted: 'Accepted',
+  on_hold: 'Under Review',
+  declined: 'Declined',
+}
+
+const STATUS_CLASSES: Record<string, string> = {
+  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  accepted: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  on_hold: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  declined: 'bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400',
+}
+
+export default function SuggestTeamPage() {
+  const { user, loading } = useRequireAuth()
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+
+  const { data, isLoading: loadingSuggestions } = useQuery({
+    ...orpc.teamSuggestions.list.queryOptions(),
+    enabled: !!user,
+  })
+
+  const suggestions = data?.suggestions ?? []
+
+  const createMutation = useMutation({
+    ...orpc.teamSuggestions.create.mutationOptions(),
+    onSuccess: () => {
+      setName('')
+      setDescription('')
+      showToast('Suggestion submitted!', 'success')
+      void queryClient.invalidateQueries({ queryKey: orpc.teamSuggestions.list.key() })
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to submit suggestion', 'error')
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    createMutation.mutate({ name: name.trim(), description: description.trim() || null })
+  }
+
+  if (loading || !user) return null
+
+  return (
+    <main className="container py-5 pb-15">
+      <h1>Suggest a Team</h1>
+      <p className="text-text-light mb-6">
+        Don&apos;t see a team for what you&apos;re working on? Suggest one and an admin will review
+        it.
+      </p>
+
+      <div className="max-w-xl">
+        <form onSubmit={handleSubmit} className="bg-surface rounded-xl shadow p-6 mb-8">
+          <div className="mb-5">
+            <label htmlFor="name">Team Name</label>
+            <input
+              id="name"
+              type="text"
+              placeholder="e.g., Comms, Outreach, Policy"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+          <div className="mb-5">
+            <label htmlFor="description">
+              Description <span className="text-text-light font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="description"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this team work on?"
+              className="w-full"
+            />
+          </div>
+
+          <Button type="submit" disabled={createMutation.isPending || !name.trim()}>
+            {createMutation.isPending ? 'Submitting…' : 'Submit Suggestion'}
+          </Button>
+        </form>
+
+        {!loadingSuggestions && suggestions.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold mb-4">Your Previous Suggestions</h2>
+            <div className="space-y-3">
+              {suggestions.map((s) => (
+                <article
+                  key={s.id}
+                  className="bg-surface rounded-xl shadow px-5 py-4 flex items-start justify-between gap-4"
+                >
+                  <div>
+                    <p className="font-semibold m-0">
+                      {s.name}
+                      {s.mergedInto && (
+                        <span className="text-text-light font-normal text-sm">
+                          {' '}
+                          (merged into {s.mergedInto.name})
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-xs text-text-light m-0 mt-1">
+                      Submitted {s.createdAt ? formatDate(s.createdAt) : ''}
+                    </p>
+                    {s.adminNotes && (
+                      <p className="text-sm text-text-light mt-2 mb-0 italic">{s.adminNotes}</p>
+                    )}
+                  </div>
+                  <span
+                    className={`text-xs px-2 py-1 rounded-full font-medium whitespace-nowrap ${STATUS_CLASSES[s.status] ?? ''}`}
+                  >
+                    {STATUS_LABELS[s.status] ?? s.status}
+                  </span>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/teams/[id]/page.tsx
+++ b/app/teams/[id]/page.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { use } from 'react'
+import Link from 'next/link'
+import { useRequireAuth } from '@/lib/hooks/auth'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import Button from '@/components/Button'
+import { orpc } from '@/lib/orpc'
+import { useToast } from '@/lib/toast'
+
+export default function TeamDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = use(params)
+  const teamId = parseInt(idParam, 10)
+  const { user, loading } = useRequireAuth()
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+
+  const { data: team, isLoading } = useQuery({
+    ...orpc.teams.getById.queryOptions({ input: { id: teamId } }),
+    enabled: !!user,
+  })
+
+  const invalidate = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: orpc.teams.getById.key() }),
+      queryClient.invalidateQueries({ queryKey: orpc.teams.list.key() }),
+    ])
+
+  const applyMutation = useMutation({
+    ...orpc.teams.apply.mutationOptions(),
+    onSuccess: () => {
+      showToast('Application submitted — a team leader will review it', 'success')
+      void invalidate()
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to apply', 'error')
+    },
+  })
+
+  const leaveMutation = useMutation({
+    ...orpc.teams.leave.mutationOptions(),
+    onSuccess: () => {
+      showToast('Left team', 'success')
+      void invalidate()
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to leave team', 'error')
+    },
+  })
+
+  if (loading || !user) return null
+
+  if (isLoading) {
+    return (
+      <main className="container py-5 pb-15">
+        <div className="text-center py-10 text-text-light">Loading…</div>
+      </main>
+    )
+  }
+
+  if (!team) {
+    return (
+      <main className="container py-5 pb-15">
+        <p className="text-text-light">Team not found.</p>
+      </main>
+    )
+  }
+
+  const isMember = team.viewerRole !== null
+
+  return (
+    <main className="container py-5 pb-15 max-w-2xl">
+      <Link href="/teams" className="text-sm text-secondary-dark no-underline hover:text-primary">
+        ← All Teams
+      </Link>
+
+      <div className="flex items-start justify-between gap-4 mt-3 mb-2">
+        <h1 className="m-0">
+          {team.name}
+          {team.viewerRole === 'leader' && (
+            <span className="text-xs px-2 py-0.5 ml-2 rounded-full font-medium bg-primary/10 text-primary align-middle">
+              Leader
+            </span>
+          )}
+        </h1>
+        {user.isAdmin || team.viewerRole === 'leader' ? (
+          <Link href={`/admin/teams/${team.id}`}>
+            <Button size="sm" variant="secondary">
+              Manage Members
+            </Button>
+          </Link>
+        ) : isMember ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={leaveMutation.isPending}
+            onClick={() => leaveMutation.mutate({ id: team.id })}
+          >
+            Leave
+          </Button>
+        ) : team.viewerRequestStatus === 'pending' ? (
+          <Button size="sm" variant="secondary" disabled>
+            Application Pending
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            disabled={applyMutation.isPending}
+            onClick={() => applyMutation.mutate({ id: team.id })}
+          >
+            Apply to Join
+          </Button>
+        )}
+      </div>
+
+      {team.description && <p className="text-text-light mb-4">{team.description}</p>}
+
+      <p className="text-sm text-text-light mb-4">
+        {team.memberCount} member{team.memberCount === 1 ? '' : 's'}
+        {team.leaders.length > 0 && ` · Led by ${team.leaders.map((l) => l.name).join(', ')}`}
+      </p>
+
+      {(team.lumaUrl || team.docUrl) && (
+        <div className="flex gap-4 text-sm bg-surface rounded-xl shadow px-5 py-4">
+          {team.lumaUrl && (
+            <a
+              href={team.lumaUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-secondary-dark no-underline hover:text-primary"
+            >
+              Meeting calendar
+            </a>
+          )}
+          {team.docUrl && (
+            <a
+              href={team.docUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-secondary-dark no-underline hover:text-primary"
+            >
+              Team doc
+            </a>
+          )}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -17,14 +17,14 @@ export default function TeamsPage() {
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: orpc.teams.list.key() })
 
-  const joinMutation = useMutation({
-    ...orpc.teams.join.mutationOptions(),
+  const applyMutation = useMutation({
+    ...orpc.teams.apply.mutationOptions(),
     onSuccess: () => {
-      showToast('Joined team!', 'success')
+      showToast('Application submitted — a team leader will review it', 'success')
       void invalidate()
     },
     onError: (err: unknown) => {
-      showToast(err instanceof Error ? err.message : 'Failed to join team', 'error')
+      showToast(err instanceof Error ? err.message : 'Failed to apply', 'error')
     },
   })
 
@@ -52,8 +52,8 @@ export default function TeamsPage() {
         </Link>
       </div>
       <p className="text-text-light mb-6">
-        Teams are standing groups of volunteers with a recurring meeting and shared doc — join any
-        number of teams alongside your local group.
+        Teams are standing groups of volunteers with a recurring meeting and shared doc — apply to
+        join any number of teams alongside your local group. A team leader reviews applications.
       </p>
 
       {isLoading ? (
@@ -119,13 +119,17 @@ export default function TeamsPage() {
                     >
                       Leave
                     </Button>
+                  ) : team.viewerRequestStatus === 'pending' ? (
+                    <Button size="sm" variant="secondary" disabled>
+                      Application Pending
+                    </Button>
                   ) : (
                     <Button
                       size="sm"
-                      disabled={joinMutation.isPending}
-                      onClick={() => joinMutation.mutate({ id: team.id })}
+                      disabled={applyMutation.isPending}
+                      onClick={() => applyMutation.mutate({ id: team.id })}
                     >
-                      Join
+                      Apply to Join
                     </Button>
                   )}
                 </div>

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -71,7 +71,12 @@ export default function TeamsPage() {
               >
                 <div>
                   <p className="font-semibold m-0">
-                    {team.name}
+                    <Link
+                      href={`/teams/${team.id}`}
+                      className="text-secondary-dark no-underline hover:text-primary"
+                    >
+                      {team.name}
+                    </Link>
                     {team.viewerRole === 'leader' && (
                       <span className="text-xs px-2 py-0.5 ml-2 rounded-full font-medium bg-primary/10 text-primary">
                         Leader
@@ -110,7 +115,13 @@ export default function TeamsPage() {
                   </div>
                 </div>
                 <div className="shrink-0">
-                  {isMember ? (
+                  {user.isAdmin || team.viewerRole === 'leader' ? (
+                    <Link href={`/admin/teams/${team.id}`}>
+                      <Button size="sm" variant="secondary">
+                        Manage Members
+                      </Button>
+                    </Link>
+                  ) : isMember ? (
                     <Button
                       size="sm"
                       variant="secondary"

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import Link from 'next/link'
+import { useRequireAuth } from '@/lib/hooks/auth'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import Button from '@/components/Button'
+import { orpc } from '@/lib/orpc'
+import { useToast } from '@/lib/toast'
+
+export default function TeamsPage() {
+  const { user, loading } = useRequireAuth()
+  const showToast = useToast()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({ ...orpc.teams.list.queryOptions(), enabled: !!user })
+  const teams = data?.teams ?? []
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: orpc.teams.list.key() })
+
+  const joinMutation = useMutation({
+    ...orpc.teams.join.mutationOptions(),
+    onSuccess: () => {
+      showToast('Joined team!', 'success')
+      void invalidate()
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to join team', 'error')
+    },
+  })
+
+  const leaveMutation = useMutation({
+    ...orpc.teams.leave.mutationOptions(),
+    onSuccess: () => {
+      showToast('Left team', 'success')
+      void invalidate()
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to leave team', 'error')
+    },
+  })
+
+  if (loading || !user) return null
+
+  return (
+    <main className="container py-5 pb-15">
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="m-0">Teams</h1>
+        <Link href="/suggest-team">
+          <Button size="sm" variant="secondary">
+            Suggest a Team
+          </Button>
+        </Link>
+      </div>
+      <p className="text-text-light mb-6">
+        Teams are standing groups of volunteers with a recurring meeting and shared doc — join any
+        number of teams alongside your local group.
+      </p>
+
+      {isLoading ? (
+        <div className="text-center py-10 text-text-light">Loading…</div>
+      ) : teams.length === 0 ? (
+        <p className="text-text-light">No teams yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {teams.map((team) => {
+            const isMember = team.viewerRole !== null
+            return (
+              <article
+                key={team.id}
+                className="bg-surface rounded-xl shadow px-5 py-4 flex items-start justify-between gap-4"
+              >
+                <div>
+                  <p className="font-semibold m-0">
+                    {team.name}
+                    {team.viewerRole === 'leader' && (
+                      <span className="text-xs px-2 py-0.5 ml-2 rounded-full font-medium bg-primary/10 text-primary">
+                        Leader
+                      </span>
+                    )}
+                  </p>
+                  {team.description && (
+                    <p className="text-sm text-text-light mt-1 mb-0">{team.description}</p>
+                  )}
+                  <p className="text-xs text-text-light m-0 mt-1">
+                    {team.memberCount} member{team.memberCount === 1 ? '' : 's'}
+                    {team.leaders.length > 0 &&
+                      ` · Led by ${team.leaders.map((l) => l.name).join(', ')}`}
+                  </p>
+                  <div className="flex gap-3 mt-2 text-sm">
+                    {team.lumaUrl && (
+                      <a
+                        href={team.lumaUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-secondary-dark no-underline hover:text-primary"
+                      >
+                        Meeting calendar
+                      </a>
+                    )}
+                    {team.docUrl && (
+                      <a
+                        href={team.docUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-secondary-dark no-underline hover:text-primary"
+                      >
+                        Team doc
+                      </a>
+                    )}
+                  </div>
+                </div>
+                <div className="shrink-0">
+                  {isMember ? (
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      disabled={leaveMutation.isPending}
+                      onClick={() => leaveMutation.mutate({ id: team.id })}
+                    >
+                      Leave
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      disabled={joinMutation.isPending}
+                      onClick={() => joinMutation.mutate({ id: team.id })}
+                    >
+                      Join
+                    </Button>
+                  )}
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/components/FilterDropdown.tsx
+++ b/components/FilterDropdown.tsx
@@ -34,6 +34,11 @@ interface Props<T extends string = string> {
   options: readonly FilterOption<T>[]
   onChange: (value: T) => void
   searchable?: boolean
+  // Called with the raw search text as the user types (searchable only). Lets a caller
+  // whose full option set isn't loaded client-side (e.g. paged from the server) run its
+  // own debounced fetch and feed back a fresh `options` array — the built-in client-side
+  // filter above still applies to whatever `options` currently holds.
+  onQueryChange?: (query: string) => void
   required?: boolean
   // Full override of the trigger button's classes, for callers that need a
   // custom look (e.g. a colored pill) instead of the default bordered box.
@@ -55,6 +60,7 @@ export default function FilterDropdown<T extends string>({
   options,
   onChange,
   searchable,
+  onQueryChange,
   required,
   triggerClassName,
   renderOption,
@@ -232,6 +238,7 @@ export default function FilterDropdown<T extends string>({
             onChange={(e) => {
               setQuery(e.target.value)
               setFocusedIndex(-1)
+              onQueryChange?.(e.target.value)
             }}
             onKeyDown={handleKeyDown}
             className="absolute inset-0 m-0"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -157,6 +157,7 @@ export default function Header() {
 
   const navLinks = [
     { href: '/projects', label: 'Projects' },
+    { href: '/teams', label: 'Teams' },
     { href: '/volunteers', label: 'Volunteers' },
     { href: '/suggest', label: 'Suggest' },
     { href: '/quick-tasks', label: 'Quick Tasks' },

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -26,6 +26,7 @@ export interface Project {
   country?: string | null
   localGroup?: string | null
   remoteEligibility?: string | null
+  team?: { id: number; name: string } | null
   timeCommitmentHoursPerWeek?: number | null
   urgency?: string | null
   owner?: { name: string } | null
@@ -127,6 +128,7 @@ export function ProjectCard({
           const parts = projectLocationParts(p.country, p.localGroup, p.remoteEligibility)
           return parts.length > 0 && <span>📍 {parts.join(' · ')}</span>
         })()}
+        {p.team && <span>🧑‍🤝‍🧑 {p.team.name}</span>}
         {p.projectType && <span>📋 {PROJECT_TYPE_LABELS[p.projectType] ?? p.projectType}</span>}
         {p.timeCommitmentHoursPerWeek && <span>🕐 {p.timeCommitmentHoursPerWeek}h/week</span>}
         {p.urgency && <span>⚡ {p.urgency} priority</span>}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -27,6 +27,8 @@ export interface Project {
   localGroup?: string | null
   remoteEligibility?: string | null
   team?: { id: number; name: string } | null
+  /** Derived server-side: is the viewer a member of this project's team? */
+  isMyTeam?: boolean
   timeCommitmentHoursPerWeek?: number | null
   urgency?: string | null
   owner?: { name: string } | null
@@ -100,7 +102,9 @@ export function ProjectCard({
 }) {
   const proposer = p.owner || !showProposer ? null : proposerDisplay(p)
   return (
-    <div className="card bg-surface rounded-xl shadow px-5 pt-5 pb-4 overflow-hidden wrap-break-word grid grid-rows-subgrid row-span-6 gap-y-2 relative min-w-0">
+    <div
+      className={`card bg-surface rounded-xl shadow px-5 pt-5 pb-4 overflow-hidden wrap-break-word grid grid-rows-subgrid row-span-6 gap-y-2 relative min-w-0 ${p.isMyTeam ? 'border-l-4 border-primary' : ''}`}
+    >
       <div className="card-header row-start-1">
         <Link
           role="link"

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -69,6 +69,7 @@ export default function ProjectForm({
   const [hoursPerWeek, setHoursPerWeek] = useState('')
   const [urgency, setUrgency] = useState('medium')
   const [locationValue, setLocationValue] = useState('') // 'UK' or 'UK:London'
+  const [teamId, setTeamId] = useState('')
   const [remoteEligibility, setRemoteEligibility] = useState('NONE')
   const [duration, setDuration] = useState('')
   const [collaborationLink, setCollaborationLink] = useState('')
@@ -81,6 +82,9 @@ export default function ProjectForm({
 
   const { data: localGroupsData } = useQuery(orpc.localGroups.list.queryOptions({ input: {} }))
   const allLocalGroups: LocalGroupOption[] = localGroupsData?.groups ?? []
+
+  const { data: teamsData } = useQuery(orpc.teams.list.queryOptions())
+  const teams = teamsData?.teams ?? []
 
   function clearFieldError(field: string) {
     setFieldErrors((prev) => {
@@ -125,6 +129,7 @@ export default function ProjectForm({
         urgency,
         country: country || null,
         localGroup: localGroup || null,
+        teamId: teamId ? Number(teamId) : null,
         remoteEligibility: remoteEligibility as ProjectCreateInput['remoteEligibility'],
         estimatedDuration: duration.trim() || null,
         collaborationLink: collaborationLink.trim() || null,
@@ -307,6 +312,24 @@ export default function ProjectForm({
             </a>
           </p>
         )}
+      </div>
+
+      <div className="mb-5">
+        <FilterDropdown
+          id="team"
+          label="Team"
+          ariaLabel="Select team"
+          value={teamId}
+          options={[
+            { value: '', label: 'No team — visible to everyone' },
+            ...teams.map((t) => ({ value: String(t.id), label: t.name })),
+          ]}
+          onChange={setTeamId}
+          searchable
+        />
+        <p className="text-sm text-text-light mt-1">
+          Assigning a team restricts visibility to that team, plus the owner and proposer.
+        </p>
       </div>
 
       <div className="mb-5">

--- a/e2e/actions/teams.ts
+++ b/e2e/actions/teams.ts
@@ -1,0 +1,141 @@
+import { type Page, expect } from '@playwright/test'
+import { getAlert } from '../fixtures'
+import { selectFilterDropdown } from './ui'
+
+export async function suggestTeam(
+  baseUrl: string,
+  page: Page,
+  name: string,
+  description?: string,
+): Promise<void> {
+  await page.goto(`${baseUrl}/suggest-team`)
+  await page.getByRole('heading', { name: 'Suggest a Team', level: 1 }).waitFor({ timeout: 10_000 })
+  await page.getByLabel('Team Name').fill(name)
+  if (description) await page.getByLabel(/^Description/).fill(description)
+  await page.getByRole('button', { name: 'Submit Suggestion' }).click()
+  await page.getByText('Suggestion submitted!').waitFor({ timeout: 10_000 })
+}
+
+export async function navigateToAdminTeams(baseUrl: string, adminPage: Page): Promise<void> {
+  await adminPage.goto(`${baseUrl}/admin/teams`)
+  await adminPage.getByRole('heading', { name: 'Teams', level: 1 }).waitFor({ timeout: 10_000 })
+  await adminPage.getByText('Loading…').waitFor({ state: 'hidden', timeout: 10_000 })
+}
+
+export async function navigateToAdminTeamDetail(
+  baseUrl: string,
+  adminPage: Page,
+  teamId: number,
+): Promise<void> {
+  await adminPage.goto(`${baseUrl}/admin/teams/${teamId}`)
+  await adminPage.getByRole('heading', { name: 'Team Details', level: 2 }).waitFor({
+    timeout: 10_000,
+  })
+}
+
+export async function adminReviewTeamSuggestion(
+  adminPage: Page,
+  teamName: string,
+  action: 'accept' | 'merge' | 'on_hold' | 'decline',
+  opts: {
+    editName?: string
+    leaderName?: string
+    mergeTarget?: string
+    adminNotes?: string
+  } = {},
+): Promise<void> {
+  const card = adminPage.getByRole('article').filter({ hasText: teamName })
+  await card.getByRole('button', { name: /Review/i }).click()
+
+  await adminPage.getByRole('heading', { name: 'Review Suggestion', level: 2 }).waitFor({
+    timeout: 10_000,
+  })
+
+  const actionLabel = { accept: 'Accept', merge: 'Merge', on_hold: 'On Hold', decline: 'Decline' }[
+    action
+  ]
+  await adminPage.getByRole('radio', { name: new RegExp(actionLabel) }).click({ force: true })
+
+  if (action === 'accept') {
+    if (opts.editName !== undefined) {
+      await adminPage.getByLabel('Team Name').fill(opts.editName)
+    }
+    if (opts.leaderName !== undefined) {
+      await selectFilterDropdown(adminPage, 'Select team leader', opts.leaderName)
+    }
+  }
+
+  if (action === 'merge' && opts.mergeTarget) {
+    await selectFilterDropdown(adminPage, 'Select existing team to merge into', opts.mergeTarget)
+  }
+
+  if ((action === 'on_hold' || action === 'decline') && opts.adminNotes) {
+    await adminPage.getByLabel('Note for volunteer').fill(opts.adminNotes)
+  }
+
+  await adminPage.getByRole('button', { name: 'Confirm' }).click()
+  await adminPage.getByRole('heading', { name: 'Review Suggestion', level: 2 }).waitFor({
+    state: 'hidden',
+    timeout: 10_000,
+  })
+}
+
+export async function applyToJoinTeam(
+  baseUrl: string,
+  page: Page,
+  teamName: string,
+): Promise<void> {
+  await page.goto(`${baseUrl}/teams`)
+  await page.getByRole('heading', { name: 'Teams', level: 1 }).waitFor({ timeout: 10_000 })
+  const card = page.getByRole('article').filter({ hasText: teamName })
+  await card.getByRole('button', { name: 'Apply to Join' }).click()
+  await expect(getAlert(page)).toBeVisible({ timeout: 10_000 })
+}
+
+export async function leaveTeam(baseUrl: string, page: Page, teamName: string): Promise<void> {
+  await page.goto(`${baseUrl}/teams`)
+  await page.getByRole('heading', { name: 'Teams', level: 1 }).waitFor({ timeout: 10_000 })
+  const card = page.getByRole('article').filter({ hasText: teamName })
+  await card.getByRole('button', { name: 'Leave' }).click()
+  await expect(getAlert(page)).toBeVisible({ timeout: 10_000 })
+}
+
+export async function adminAssignMemberDirectly(
+  adminPage: Page,
+  volunteerName: string,
+): Promise<void> {
+  await selectFilterDropdown(adminPage, 'Select volunteer to add', volunteerName)
+  await adminPage.getByRole('button', { name: 'Add', exact: true }).click()
+  await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
+}
+
+function memberRow(adminPage: Page, volunteerName: string) {
+  return adminPage
+    .locator('div.flex.items-center.justify-between.gap-3')
+    .filter({ hasText: volunteerName })
+}
+
+export async function adminToggleMemberLeader(
+  adminPage: Page,
+  volunteerName: string,
+): Promise<void> {
+  const row = memberRow(adminPage, volunteerName)
+  await row.getByRole('button', { name: /Make Leader|Demote/ }).click()
+  await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
+}
+
+export async function adminRemoveMember(adminPage: Page, volunteerName: string): Promise<void> {
+  const row = memberRow(adminPage, volunteerName)
+  await row.getByRole('button', { name: 'Remove' }).click()
+  await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
+}
+
+export async function adminReviewJoinRequest(
+  adminPage: Page,
+  volunteerName: string,
+  action: 'accept' | 'decline',
+): Promise<void> {
+  const row = memberRow(adminPage, volunteerName)
+  await row.getByRole('button', { name: action === 'accept' ? 'Accept' : 'Decline' }).click()
+  await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
+}

--- a/e2e/fake.ts
+++ b/e2e/fake.ts
@@ -26,4 +26,5 @@ export const fake = {
   username: () => faker.internet.username(),
   phoneNumber: () => faker.phone.number({ style: 'international' }),
   localGroupName: () => faker.location.city(),
+  teamName: () => `${faker.word.adjective()} ${faker.word.noun()} Squad`,
 }

--- a/e2e/tests/29-teams.spec.ts
+++ b/e2e/tests/29-teams.spec.ts
@@ -1,0 +1,379 @@
+import { test, expect, readAdminToken, createApprovedVolunteer } from '../fixtures'
+import { fake } from '../fake'
+import { createApiClient } from '../client'
+import {
+  suggestTeam,
+  navigateToAdminTeams,
+  navigateToAdminTeamDetail,
+  adminReviewTeamSuggestion,
+  applyToJoinTeam,
+  leaveTeam,
+  adminAssignMemberDirectly,
+  adminToggleMemberLeader,
+  adminRemoveMember,
+  adminReviewJoinRequest,
+} from '../actions/teams'
+
+interface TeamMemberBody {
+  id: number
+  name: string
+  role: 'member' | 'leader'
+}
+interface TeamBody {
+  id: number
+  name: string
+  members: TeamMemberBody[]
+}
+
+function adminApi(baseUrl: string) {
+  return createApiClient(baseUrl, readAdminToken(baseUrl))
+}
+
+async function getTeamByName(baseUrl: string, name: string): Promise<TeamBody> {
+  const result = await adminApi(baseUrl).admin.teams.list()
+  if (result.status !== 200) throw new Error(`Failed to list teams: ${JSON.stringify(result.body)}`)
+  const team = (result.body as { teams: TeamBody[] }).teams.find((t) => t.name === name)
+  if (!team) throw new Error(`Team not found: ${name}`)
+  return team
+}
+
+async function createTeamViaApi(baseUrl: string, name: string): Promise<TeamBody> {
+  const created = await adminApi(baseUrl).admin.teams.create({
+    body: { name, description: null, lumaUrl: null, docUrl: null },
+  })
+  if (created.status !== 200)
+    throw new Error(`Team creation failed: ${JSON.stringify(created.body)}`)
+  return getTeamByName(baseUrl, name)
+}
+
+async function volunteerToken(
+  baseUrl: string,
+  page: import('@playwright/test').Page,
+): Promise<string> {
+  // Reading localStorage throws on about:blank (no navigation yet) — make sure the page
+  // has actually loaded the app's origin first.
+  if (!page.url().startsWith(baseUrl)) {
+    await page.goto(baseUrl)
+  }
+  const token = await page.evaluate(() => localStorage.getItem('authToken'))
+  if (!token) throw new Error('Volunteer has no auth token in localStorage')
+  return token
+}
+
+async function getMyId(baseUrl: string, token: string): Promise<number> {
+  const result = await createApiClient(baseUrl, token).auth.me()
+  if (result.status !== 200) throw new Error(`auth.me failed: ${JSON.stringify(result.body)}`)
+  return (result.body as { id: number }).id
+}
+
+async function createOrgProjectForTeam(
+  baseUrl: string,
+  teamId: number,
+): Promise<{ id: number; title: string }> {
+  const title = fake.projectTitle()
+  const created = await adminApi(baseUrl).admin.projects.create({
+    body: {
+      title,
+      description: 'e2e team-project link description',
+      projectType: null,
+      estimatedDuration: null,
+      timeCommitmentHoursPerWeek: null,
+      urgency: 'medium',
+      collaborationLink: null,
+      country: null,
+      localGroup: null,
+      isSeekingHelp: false,
+      teamId,
+      tasks: [{ title: 'Initial task' }],
+    },
+  })
+  if (created.status !== 200)
+    throw new Error(`Project creation failed: ${JSON.stringify(created.body)}`)
+  return { id: (created.body as { id: number }).id, title }
+}
+
+test.describe('Teams', () => {
+  test('Volunteer suggests a team and sees it pending', async ({ volunteer, baseUrl }) => {
+    const teamName = fake.teamName()
+    await suggestTeam(baseUrl, volunteer.page, teamName, 'We do the things')
+
+    const item = volunteer.page.getByRole('article').filter({ hasText: teamName })
+    await expect(item).toBeVisible({ timeout: 10_000 })
+    await expect(item).toContainText('Pending Review')
+  })
+
+  test('Admin accepts a suggestion; suggester becomes leader by default', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    await suggestTeam(baseUrl, volunteer.page, teamName)
+
+    const token = await volunteerToken(baseUrl, volunteer.page)
+    const suggesterId = await getMyId(baseUrl, token)
+
+    await navigateToAdminTeams(baseUrl, adminPage)
+    await adminReviewTeamSuggestion(adminPage, teamName, 'accept')
+
+    const team = await getTeamByName(baseUrl, teamName)
+    expect(team.members).toHaveLength(1)
+    expect(team.members[0]).toMatchObject({ id: suggesterId, role: 'leader' })
+  })
+
+  test('Admin accepts a suggestion but assigns a different volunteer as leader', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    await suggestTeam(baseUrl, volunteer.page, teamName)
+    const chosenLeader = await createApprovedVolunteer(baseUrl)
+
+    await navigateToAdminTeams(baseUrl, adminPage)
+    await adminReviewTeamSuggestion(adminPage, teamName, 'accept', {
+      leaderName: chosenLeader.name,
+    })
+
+    const team = await getTeamByName(baseUrl, teamName)
+    expect(team.members).toHaveLength(1)
+    expect(team.members[0]).toMatchObject({ id: chosenLeader.id, role: 'leader' })
+  })
+
+  test('Admin merges a team suggestion into an existing team', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const existingTeamName = fake.teamName()
+    await createTeamViaApi(baseUrl, existingTeamName)
+
+    const suggestedName = fake.teamName()
+    await suggestTeam(baseUrl, volunteer.page, suggestedName)
+    const token = await volunteerToken(baseUrl, volunteer.page)
+    const suggesterId = await getMyId(baseUrl, token)
+
+    await navigateToAdminTeams(baseUrl, adminPage)
+    await adminReviewTeamSuggestion(adminPage, suggestedName, 'merge', {
+      mergeTarget: existingTeamName,
+    })
+
+    // Merging doesn't create a second team under the suggested name, and the suggester
+    // ends up a (regular, non-leader) member of the team they were merged into.
+    await expect(async () => {
+      const result = await adminApi(baseUrl).admin.teams.list()
+      const teams = (result.body as { teams: TeamBody[] }).teams
+      const names = teams.map((t) => t.name)
+      expect(names).not.toContain(suggestedName)
+      const existing = teams.find((t) => t.name === existingTeamName)
+      expect(existing?.members.find((m) => m.id === suggesterId)?.role).toBe('member')
+    }).toPass({ timeout: 10_000 })
+  })
+
+  test('Admin declines a team suggestion', async ({ volunteer, adminPage, baseUrl }) => {
+    const teamName = fake.teamName()
+    await suggestTeam(baseUrl, volunteer.page, teamName)
+
+    await navigateToAdminTeams(baseUrl, adminPage)
+    await adminReviewTeamSuggestion(adminPage, teamName, 'decline', {
+      adminNotes: 'Not right now',
+    })
+
+    const item = volunteer.page.getByRole('article').filter({ hasText: teamName })
+    await volunteer.page.goto(`${baseUrl}/suggest-team`)
+    await expect(item).toContainText('Declined', { timeout: 10_000 })
+  })
+
+  test('Volunteer applies to join a team; admin accepts and they become a member', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+
+    await applyToJoinTeam(baseUrl, volunteer.page, teamName)
+    const pendingCard = volunteer.page.getByRole('article').filter({ hasText: teamName })
+    await expect(pendingCard.getByRole('button', { name: 'Application Pending' })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await navigateToAdminTeamDetail(baseUrl, adminPage, team.id)
+    await adminReviewJoinRequest(adminPage, volunteer.name, 'accept')
+
+    await volunteer.page.goto(`${baseUrl}/teams`)
+    const memberCard = volunteer.page.getByRole('article').filter({ hasText: teamName })
+    await expect(memberCard.getByRole('button', { name: 'Leave' })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('Volunteer applies to join a team; admin declines and they can re-apply', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+
+    await applyToJoinTeam(baseUrl, volunteer.page, teamName)
+
+    await navigateToAdminTeamDetail(baseUrl, adminPage, team.id)
+    await adminReviewJoinRequest(adminPage, volunteer.name, 'decline')
+
+    await volunteer.page.goto(`${baseUrl}/teams`)
+    const card = volunteer.page.getByRole('article').filter({ hasText: teamName })
+    await expect(card.getByRole('button', { name: 'Apply to Join' })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('Volunteer leaves a team', async ({ volunteer, baseUrl }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+
+    const token = await volunteerToken(baseUrl, volunteer.page)
+    const myId = await getMyId(baseUrl, token)
+    const assignResult = await adminApi(baseUrl).teams.assignMember({
+      body: { teamId: team.id, volunteerId: myId },
+    })
+    if (assignResult.status !== 200)
+      throw new Error(`assignMember failed: ${JSON.stringify(assignResult.body)}`)
+
+    await leaveTeam(baseUrl, volunteer.page, teamName)
+
+    const card = volunteer.page.getByRole('article').filter({ hasText: teamName })
+    await expect(card.getByRole('button', { name: 'Apply to Join' })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('Admin assigns a volunteer directly to a team, bypassing the application flow', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+    const recruit = await createApprovedVolunteer(baseUrl)
+
+    await navigateToAdminTeamDetail(baseUrl, adminPage, team.id)
+    await adminAssignMemberDirectly(adminPage, recruit.name)
+
+    await expect(adminPage.getByText(recruit.name)).toBeVisible({ timeout: 10_000 })
+    const updated = await getTeamByName(baseUrl, teamName)
+    expect(updated.members.map((m) => m.id)).toContain(recruit.id)
+  })
+
+  test('Admin promotes a member to leader and can demote them back', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+    const member = await createApprovedVolunteer(baseUrl)
+    await adminApi(baseUrl).teams.assignMember({
+      body: { teamId: team.id, volunteerId: member.id },
+    })
+
+    await navigateToAdminTeamDetail(baseUrl, adminPage, team.id)
+    await adminToggleMemberLeader(adminPage, member.name)
+
+    await expect(async () => {
+      const updated = await getTeamByName(baseUrl, teamName)
+      expect(updated.members.find((m) => m.id === member.id)?.role).toBe('leader')
+    }).toPass({ timeout: 10_000 })
+
+    await adminToggleMemberLeader(adminPage, member.name)
+    await expect(async () => {
+      const updated = await getTeamByName(baseUrl, teamName)
+      expect(updated.members.find((m) => m.id === member.id)?.role).toBe('member')
+    }).toPass({ timeout: 10_000 })
+  })
+
+  test('Admin removes a member from a team', async ({ adminPage, baseUrl }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+    const member = await createApprovedVolunteer(baseUrl)
+    await adminApi(baseUrl).teams.assignMember({
+      body: { teamId: team.id, volunteerId: member.id },
+    })
+
+    await navigateToAdminTeamDetail(baseUrl, adminPage, team.id)
+    await adminRemoveMember(adminPage, member.name)
+
+    await expect(async () => {
+      const updated = await getTeamByName(baseUrl, teamName)
+      expect(updated.members.map((m) => m.id)).not.toContain(member.id)
+    }).toPass({ timeout: 10_000 })
+  })
+
+  test('A volunteer who is neither admin nor team leader cannot review a join request', async ({
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+
+    const applicant = await createApprovedVolunteer(baseUrl)
+    const applicantApi = createApiClient(baseUrl, applicant.token)
+    const applied = await applicantApi.teams.apply({ body: { id: team.id } })
+    if (applied.status !== 200) throw new Error(`apply failed: ${JSON.stringify(applied.body)}`)
+
+    const requests = await adminApi(baseUrl).teams.listJoinRequests({
+      params: { teamId: team.id },
+    })
+    const requestId = (requests.body as { requests: { id: number }[] }).requests[0].id
+
+    const bystander = await createApprovedVolunteer(baseUrl)
+    const bystanderApi = createApiClient(baseUrl, bystander.token)
+    const result = await bystanderApi.teams.reviewJoinRequest({
+      body: { id: requestId, action: 'accept' },
+    })
+    expect(result.status).toBe(403)
+  })
+
+  test('A project tagged to a team is visible to its members, hidden from others, and notifies the team', async ({
+    baseUrl,
+  }) => {
+    const teamName = fake.teamName()
+    const team = await createTeamViaApi(baseUrl, teamName)
+
+    const member = await createApprovedVolunteer(baseUrl)
+    await adminApi(baseUrl).teams.assignMember({
+      body: { teamId: team.id, volunteerId: member.id },
+    })
+    const outsider = await createApprovedVolunteer(baseUrl)
+
+    const project = await createOrgProjectForTeam(baseUrl, team.id)
+
+    const memberApi = createApiClient(baseUrl, member.token)
+    const memberGet = await memberApi.projects.getById({ params: { id: project.id } })
+    expect(memberGet.status).toBe(200)
+    expect((memberGet.body as { isMyTeam: boolean }).isMyTeam).toBe(true)
+
+    // Search by title rather than paging the whole list — the shared worker db accumulates
+    // projects from every other test, so an unscoped list() would be pagination-flaky.
+    const memberList = await memberApi.projects.list({ search: project.title })
+    const memberListIds = (memberList.body as { projects: { id: number }[] }).projects.map(
+      (p) => p.id,
+    )
+    expect(memberListIds).toContain(project.id)
+
+    const outsiderApi = createApiClient(baseUrl, outsider.token)
+    const outsiderGet = await outsiderApi.projects.getById({ params: { id: project.id } })
+    expect(outsiderGet.status).toBe(404)
+
+    const outsiderList = await outsiderApi.projects.list({ search: project.title })
+    const outsiderListIds = (outsiderList.body as { projects: { id: number }[] }).projects.map(
+      (p) => p.id,
+    )
+    expect(outsiderListIds).not.toContain(project.id)
+
+    await expect(async () => {
+      const notifications = await memberApi.notifications.list({})
+      const match = (notifications.body as { type: string; link: string | null }[]).find(
+        (n) => n.type === 'team_project_assigned' && n.link === `/projects/${project.id}`,
+      )
+      expect(match).toBeTruthy()
+    }).toPass({ timeout: 10_000 })
+  })
+})

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -83,6 +83,31 @@ export async function notifyUser(
   send.catch((e) => console.error('[EMAIL ERROR]', e))
 }
 
+/** Alerts every member of a team that a project has been tagged to them and gone live. */
+export async function notifyTeamOfProject(
+  teamId: number,
+  projectId: number,
+  projectTitle: string,
+): Promise<void> {
+  const members = await prisma.teamMembership.findMany({
+    where: { teamId },
+    select: { volunteerId: true },
+  })
+  await Promise.all(
+    members.map((m) =>
+      notifyUser(
+        m.volunteerId,
+        'team_project_assigned',
+        `New project for your team: ${projectTitle}`,
+        null,
+        `/projects/${projectId}`,
+        undefined,
+        projectId,
+      ),
+    ),
+  )
+}
+
 export async function notifyAdmins(
   type: string,
   title: string,

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -8,6 +8,8 @@ import {
   SkillSchema,
   SkillCategorySchema,
   TaskStatusSchema,
+  TeamSchema,
+  TeamSuggestionSchema,
   WorkItemSchema,
   WorkItemCommentSchema,
   VolunteerSchema,
@@ -289,6 +291,25 @@ export const ReviewSuggestionSchema = z.object({
   mergedIntoId: z.number().int().optional().nullable(),
 })
 
+// ─── Admin: teams ─────────────────────────────────────────────────────────────
+
+export const TeamBodySchema = TeamSchema.pick({
+  name: true,
+  description: true,
+  lumaUrl: true,
+  docUrl: true,
+})
+
+export const ReviewTeamSuggestionSchema = z.object({
+  action: z.enum(['accept', 'merge', 'on_hold', 'decline'], {
+    error: 'Invalid action',
+  }),
+  adminNotes: z.string().optional().nullable(),
+  name: z.string().optional(),
+  description: z.string().optional().nullable(),
+  mergedIntoId: z.number().int().optional().nullable(),
+})
+
 // ─── Admin: invite ────────────────────────────────────────────────────────────
 
 export const InviteAdminSchema = AdminInviteSchema.pick({
@@ -340,6 +361,11 @@ export const CreateBugReportSchema = BugReportSchema.pick({
 export const LocalGroupSuggestionBodySchema = LocalGroupSuggestionSchema.pick({
   name: true,
   country: true,
+})
+
+export const TeamSuggestionBodySchema = TeamSuggestionSchema.pick({
+  name: true,
+  description: true,
 })
 
 // ─── Volunteer profile ────────────────────────────────────────────────────────

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -126,10 +126,11 @@ const PROJECT_INPUT_FIELDS = {
   localGroup: true,
   remoteEligibility: true,
   isSeekingHelp: true,
+  teamId: true,
 } as const
 
 export const CreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS)
-  .partial({ remoteEligibility: true })
+  .partial({ remoteEligibility: true, teamId: true })
   .extend({
     tasks: z.array(TaskInputSchema).optional().default([]),
     wantToOwn: z.boolean().optional().default(false),
@@ -188,7 +189,7 @@ export const CreateProjectUpdateSchema = WorkItemCommentSchema.pick({
 // ─── Admin: projects ──────────────────────────────────────────────────────────
 
 export const AdminCreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS)
-  .partial({ remoteEligibility: true })
+  .partial({ remoteEligibility: true, teamId: true })
   .extend({
     tasks: z.array(TaskInputSchema).optional().default([]),
     wantToOwn: z.boolean().optional().default(false),
@@ -308,6 +309,8 @@ export const ReviewTeamSuggestionSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional().nullable(),
   mergedIntoId: z.number().int().optional().nullable(),
+  // 'accept' only — who becomes the new team's first leader. Defaults to the suggester.
+  leaderId: z.number().int().optional(),
 })
 
 // ─── Admin: invite ────────────────────────────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,6 +21,9 @@ import type {
   CreateSkillCategorySchema,
   UpdateSkillCategorySchema,
   LocalGroupBodySchema,
+  TeamBodySchema,
+  ReviewTeamSuggestionSchema,
+  TeamSuggestionBodySchema,
   UpdateBugReportSchema,
   ReviewSuggestionSchema,
   InviteAdminSchema,
@@ -61,6 +64,9 @@ export type UpdateSkillBody = z.infer<typeof UpdateSkillSchema>
 export type CreateSkillCategoryBody = z.infer<typeof CreateSkillCategorySchema>
 export type UpdateSkillCategoryBody = z.infer<typeof UpdateSkillCategorySchema>
 export type LocalGroupBody = z.infer<typeof LocalGroupBodySchema>
+export type TeamBody = z.infer<typeof TeamBodySchema>
+export type ReviewTeamSuggestionBody = z.infer<typeof ReviewTeamSuggestionSchema>
+export type TeamSuggestionBody = z.infer<typeof TeamSuggestionBodySchema>
 export type UpdateBugReportBody = z.infer<typeof UpdateBugReportSchema>
 export type ReviewSuggestionBody = z.infer<typeof ReviewSuggestionSchema>
 export type InviteAdminBody = z.infer<typeof InviteAdminSchema>

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -188,7 +188,11 @@ export type EnrichedProject = {
 // (mapped from the WorkItem `assignee`/`creator` columns) so the ProjectCard
 // contract and all consuming pages stay stable.
 
-export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<number>) {
+export function withProjectExtras(
+  p: EnrichedProject,
+  volunteerSkillIds?: Set<number>,
+  viewerTeamIds?: Set<number>,
+) {
   const matchInput = p.skills.map((ps) => ({ id: ps.skillId, isRequired: ps.isRequired }))
   const match =
     volunteerSkillIds !== undefined ? calculateMatchScore(volunteerSkillIds, matchInput) : undefined
@@ -228,6 +232,7 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
     remoteEligibility: p.remoteEligibility,
     teamId: p.teamId,
     team: p.team,
+    isMyTeam: p.teamId !== null && Boolean(viewerTeamIds?.has(p.teamId)),
     skills: p.skills.map((ps) => ({
       id: ps.skill.id,
       categoryId: ps.skill.categoryId,

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@/generated/prisma/client'
+import { prisma } from './prisma'
 import { calculateMatchScore } from './matching'
 import { isSeekingOwner, UNAPPROVED_STATUSES } from './project-status'
 import {
@@ -19,6 +20,7 @@ export type WorkItemForAccess = {
   status: string
   creatorId: number | null
   assigneeId: number | null
+  teamId?: number | null
 }
 
 export type CommentViewer = { id: number; isAdmin: boolean; isApproved: boolean } | null
@@ -36,18 +38,34 @@ export const CLAIM_BLOCKING_INTEREST_STATUSES: InterestStatus[] = [
 /**
  * Can `viewer` see this work item (and therefore its comment thread)?
  * For TASK, pass the parent PROJECT — task visibility follows the project.
+ *
+ * `isTeamPrivy` — viewer is a member of the project's team, or an accepted helper on it.
+ * The caller resolves it (requires a DB lookup); only relevant when the project has a
+ * team assigned, in which case it's otherwise restricted to the team, its owner/proposer,
+ * and admins.
  */
 export function canViewWorkItem(
   item: WorkItemForAccess,
   viewer: CommentViewer,
   parent?: WorkItemForAccess | null,
+  isTeamPrivy?: boolean,
 ): boolean {
   switch (item.type) {
-    case WorkItemType.PROJECT:
+    case WorkItemType.PROJECT: {
+      if (item.teamId !== null && item.teamId !== undefined) {
+        const isDirectParticipant = Boolean(
+          viewer &&
+          (viewer.isAdmin || viewer.id === item.creatorId || viewer.id === item.assigneeId),
+        )
+        if (!isDirectParticipant && !isTeamPrivy) return false
+      }
       if (!PROJECT_HIDDEN_STATUSES.includes(item.status)) return true
       return Boolean(viewer && (viewer.isAdmin || viewer.id === item.creatorId))
+    }
     case WorkItemType.TASK:
-      return parent ? canViewWorkItem(parent, viewer) : Boolean(viewer?.isAdmin)
+      return parent
+        ? canViewWorkItem(parent, viewer, undefined, isTeamPrivy)
+        : Boolean(viewer?.isAdmin)
     case WorkItemType.QUICK_TASK:
       // Open, unclaimed tasks are browsable by any approved volunteer before they claim one —
       // but not by a pending applicant, same as the approvedProcedure gate on the pages that
@@ -61,6 +79,30 @@ export function canViewWorkItem(
     default:
       return Boolean(viewer?.isAdmin)
   }
+}
+
+/**
+ * Resolves `isTeamPrivy` for `canViewWorkItem` — does `volunteerId` belong to the
+ * project's team, or hold an accepted interest on it? No-ops (returns false) when the
+ * project has no team, so callers can call this unconditionally.
+ */
+export async function resolveTeamPrivy(
+  teamId: number | null | undefined,
+  projectId: number,
+  volunteerId: number,
+): Promise<boolean> {
+  if (teamId === null || teamId === undefined) return false
+  const [membership, interest] = await Promise.all([
+    prisma.teamMembership.findUnique({
+      where: { teamId_volunteerId: { teamId, volunteerId } },
+      select: { id: true },
+    }),
+    prisma.workItemInterest.findFirst({
+      where: { workItemId: projectId, volunteerId, status: InterestStatus.accepted },
+      select: { id: true },
+    }),
+  ])
+  return Boolean(membership || interest)
 }
 
 /**
@@ -134,9 +176,11 @@ export type EnrichedProject = {
   isSeekingHelp: boolean | null
   localGroup: string | null
   remoteEligibility: RemoteEligibility
+  teamId: number | null
   skills: WorkItemSkillWithRelations[]
   assignee: { id: number; name: string } | null
   creator: { id: number; name: string } | null
+  team: { id: number; name: string } | null
   _count: { interests: number; children: number }
 }
 
@@ -182,6 +226,8 @@ export function withProjectExtras(p: EnrichedProject, volunteerSkillIds?: Set<nu
     openTaskCount: p._count.children,
     localGroup: p.localGroup,
     remoteEligibility: p.remoteEligibility,
+    teamId: p.teamId,
+    team: p.team,
     skills: p.skills.map((ps) => ({
       id: ps.skill.id,
       categoryId: ps.skill.categoryId,
@@ -210,6 +256,7 @@ export const projectInclude = {
   },
   assignee: { select: { id: true, name: true } },
   creator: { select: { id: true, name: true } },
+  team: { select: { id: true, name: true } },
   _count: {
     select: {
       interests: { where: { status: InterestStatus.pending } },

--- a/prisma/migrations/20260823005337_add_teams/migration.sql
+++ b/prisma/migrations/20260823005337_add_teams/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+CREATE TABLE "teams" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "luma_url" TEXT,
+    "doc_url" TEXT,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "team_memberships" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "team_id" INTEGER NOT NULL,
+    "volunteer_id" INTEGER NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'member',
+    "joined_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "team_memberships_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "team_memberships_volunteer_id_fkey" FOREIGN KEY ("volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- CreateTable
+CREATE TABLE "team_suggestions" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "suggested_by_id" INTEGER NOT NULL,
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "admin_notes" TEXT,
+    "merged_into_id" INTEGER,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "team_suggestions_suggested_by_id_fkey" FOREIGN KEY ("suggested_by_id") REFERENCES "volunteers" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "team_suggestions_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "team_suggestions_merged_into_id_fkey" FOREIGN KEY ("merged_into_id") REFERENCES "teams" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "idx_team_memberships_volunteer" ON "team_memberships"("volunteer_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_team_memberships_team_volunteer" ON "team_memberships"("team_id", "volunteer_id");
+
+-- CreateIndex
+CREATE INDEX "idx_team_suggestions_status" ON "team_suggestions"("status");
+
+-- CreateIndex
+CREATE INDEX "idx_team_suggestions_suggested_by" ON "team_suggestions"("suggested_by_id");
+

--- a/prisma/migrations/20260823161848_add_work_item_team/migration.sql
+++ b/prisma/migrations/20260823161848_add_work_item_team/migration.sql
@@ -1,0 +1,66 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_work_items" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "deadline" DATETIME,
+    "parent_id" INTEGER,
+    "context_project_id" INTEGER,
+    "creator_id" INTEGER,
+    "assignee_id" INTEGER,
+    "stakeholder_id" INTEGER,
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "review_notes" TEXT,
+    "review_rating" TEXT,
+    "project_type" TEXT,
+    "urgency" TEXT DEFAULT 'medium',
+    "estimated_duration" TEXT,
+    "time_commitment_hours_per_week" INTEGER,
+    "collaboration_link" TEXT,
+    "is_org_proposed" BOOLEAN DEFAULT false,
+    "is_seeking_help" BOOLEAN DEFAULT false,
+    "outcome" TEXT,
+    "outcome_notes" TEXT,
+    "completed_at" DATETIME,
+    "skill_id" INTEGER,
+    "estimated_hours" REAL,
+    "nudge_sent_at" DATETIME,
+    "final_warning_sent_at" DATETIME,
+    "sort_order" INTEGER DEFAULT 0,
+    "featured_as_quick_task" BOOLEAN DEFAULT false,
+    "country" TEXT,
+    "local_group" TEXT,
+    "remote_eligibility" TEXT NOT NULL DEFAULT 'NONE',
+    "team_id" INTEGER,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "work_items_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "work_items" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_context_project_id_fkey" FOREIGN KEY ("context_project_id") REFERENCES "work_items" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_creator_id_fkey" FOREIGN KEY ("creator_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_stakeholder_id_fkey" FOREIGN KEY ("stakeholder_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+    CONSTRAINT "work_items_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+INSERT INTO "new_work_items" ("assignee_id", "collaboration_link", "completed_at", "context_project_id", "country", "created_at", "creator_id", "deadline", "description", "estimated_duration", "estimated_hours", "featured_as_quick_task", "final_warning_sent_at", "id", "is_org_proposed", "is_seeking_help", "local_group", "nudge_sent_at", "outcome", "outcome_notes", "parent_id", "project_type", "remote_eligibility", "review_notes", "review_rating", "reviewed_at", "reviewed_by_id", "skill_id", "sort_order", "stakeholder_id", "status", "time_commitment_hours_per_week", "title", "type", "updated_at", "urgency") SELECT "assignee_id", "collaboration_link", "completed_at", "context_project_id", "country", "created_at", "creator_id", "deadline", "description", "estimated_duration", "estimated_hours", "featured_as_quick_task", "final_warning_sent_at", "id", "is_org_proposed", "is_seeking_help", "local_group", "nudge_sent_at", "outcome", "outcome_notes", "parent_id", "project_type", "remote_eligibility", "review_notes", "review_rating", "reviewed_at", "reviewed_by_id", "skill_id", "sort_order", "stakeholder_id", "status", "time_commitment_hours_per_week", "title", "type", "updated_at", "urgency" FROM "work_items";
+DROP TABLE "work_items";
+ALTER TABLE "new_work_items" RENAME TO "work_items";
+CREATE INDEX "idx_work_items_type" ON "work_items"("type");
+CREATE INDEX "idx_work_items_status" ON "work_items"("status");
+CREATE INDEX "idx_work_items_parent" ON "work_items"("parent_id");
+CREATE INDEX "idx_work_items_context" ON "work_items"("context_project_id");
+CREATE INDEX "idx_work_items_creator" ON "work_items"("creator_id");
+CREATE INDEX "idx_work_items_assignee" ON "work_items"("assignee_id");
+CREATE INDEX "idx_work_items_skill" ON "work_items"("skill_id");
+CREATE INDEX "idx_work_items_local_group" ON "work_items"("local_group");
+CREATE INDEX "idx_work_items_country" ON "work_items"("country");
+CREATE INDEX "idx_work_items_team" ON "work_items"("team_id");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+

--- a/prisma/migrations/20260823162306_add_team_join_requests/migration.sql
+++ b/prisma/migrations/20260823162306_add_team_join_requests/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "team_join_requests" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "team_id" INTEGER NOT NULL,
+    "volunteer_id" INTEGER NOT NULL,
+    "message" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "reviewed_by_id" INTEGER,
+    "reviewed_at" DATETIME,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "team_join_requests_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "team_join_requests_volunteer_id_fkey" FOREIGN KEY ("volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "team_join_requests_reviewed_by_id_fkey" FOREIGN KEY ("reviewed_by_id") REFERENCES "volunteers" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+-- CreateIndex
+CREATE INDEX "idx_team_join_requests_team_status" ON "team_join_requests"("team_id", "status");
+
+-- CreateIndex
+CREATE INDEX "idx_team_join_requests_volunteer" ON "team_join_requests"("volunteer_id");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -410,6 +410,70 @@ model LocalGroupSuggestion {
   @@map("local_group_suggestions")
 }
 
+enum TeamSuggestionStatus {
+  pending
+  accepted
+  merged
+  on_hold
+  declined
+}
+
+enum TeamMembershipRole {
+  member
+  leader
+}
+
+model Team {
+  id          Int              @id @default(autoincrement())
+  /// @zod.string.min(1, { message: "Team name is required" })
+  name        String
+  description String?
+  lumaUrl     String?          @map("luma_url")
+  docUrl      String?          @map("doc_url")
+  createdAt   DateTime?        @default(now()) @map("created_at")
+  members     TeamMembership[]
+  suggestions TeamSuggestion[] @relation("TeamSuggestionMergedInto")
+
+  @@map("teams")
+}
+
+model TeamMembership {
+  id          Int                 @id @default(autoincrement())
+  teamId      Int                 @map("team_id")
+  volunteerId Int                 @map("volunteer_id")
+  role        TeamMembershipRole  @default(member)
+  joinedAt    DateTime?           @default(now()) @map("joined_at")
+  team        Team                @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  volunteer   Volunteer           @relation(fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([teamId, volunteerId], map: "uq_team_memberships_team_volunteer")
+  @@index([volunteerId], map: "idx_team_memberships_volunteer")
+  @@map("team_memberships")
+}
+
+model TeamSuggestion {
+  id            Int                  @id @default(autoincrement())
+  /// @zod.string.min(1, { message: "Team name is required" })
+  name          String
+  description   String?
+  status        TeamSuggestionStatus @default(pending)
+  suggestedById Int                  @map("suggested_by_id")
+  reviewedById  Int?                 @map("reviewed_by_id")
+  reviewedAt    DateTime?            @map("reviewed_at")
+  adminNotes    String?              @map("admin_notes")
+  mergedIntoId  Int?                 @map("merged_into_id")
+  createdAt     DateTime?            @default(now()) @map("created_at")
+  updatedAt     DateTime?            @default(now()) @map("updated_at")
+
+  suggestedBy Volunteer @relation("TeamSuggestionSuggestedBy", fields: [suggestedById], references: [id])
+  reviewedBy  Volunteer? @relation("TeamSuggestionReviewedBy", fields: [reviewedById], references: [id])
+  mergedInto  Team?     @relation("TeamSuggestionMergedInto", fields: [mergedIntoId], references: [id])
+
+  @@index([status], map: "idx_team_suggestions_status")
+  @@index([suggestedById], map: "idx_team_suggestions_suggested_by")
+  @@map("team_suggestions")
+}
+
 model DigestRun {
   id     Int      @id @default(autoincrement())
   type   String // TODO: enum — fortnightly
@@ -580,6 +644,9 @@ model Volunteer {
   skills                                  VolunteerSkill[]
   localGroupSuggestions                   LocalGroupSuggestion[]   @relation("LocalGroupSuggestionSuggestedBy")
   localGroupSuggestionsReviewed           LocalGroupSuggestion[]   @relation("LocalGroupSuggestionReviewedBy")
+  teamMemberships                         TeamMembership[]
+  teamSuggestions                         TeamSuggestion[]         @relation("TeamSuggestionSuggestedBy")
+  teamSuggestionsReviewed                 TeamSuggestion[]         @relation("TeamSuggestionReviewedBy")
 
   @@index([localGroup], map: "idx_volunteers_local_group")
   @@index([country], map: "idx_volunteers_country")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -302,6 +302,9 @@ model WorkItem {
   country           String?
   localGroup        String?           @map("local_group")
   remoteEligibility RemoteEligibility @default(NONE) @map("remote_eligibility")
+  // Optional standing team this PROJECT belongs to (Team is orthogonal to LocalGroup —
+  // see Team model). Nullable, TASK/QUICK_TASK don't use it.
+  teamId            Int?              @map("team_id")
   createdAt         DateTime?         @default(now()) @map("created_at")
   updatedAt         DateTime?         @default(now()) @map("updated_at")
 
@@ -310,6 +313,7 @@ model WorkItem {
   stakeholder Volunteer?         @relation("WorkItemStakeholder", fields: [stakeholderId], references: [id], onUpdate: NoAction)
   reviewedBy  Volunteer?         @relation("WorkItemReviewedBy", fields: [reviewedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
   skill       Skill?             @relation(fields: [skillId], references: [id], onUpdate: NoAction)
+  team        Team?              @relation(fields: [teamId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   comments    WorkItemComment[]
   skills      WorkItemSkill[]
   interests   WorkItemInterest[]
@@ -325,6 +329,7 @@ model WorkItem {
   @@index([skillId], map: "idx_work_items_skill")
   @@index([localGroup], map: "idx_work_items_local_group")
   @@index([country], map: "idx_work_items_country")
+  @@index([teamId], map: "idx_work_items_team")
   @@map("work_items")
 }
 
@@ -423,16 +428,24 @@ enum TeamMembershipRole {
   leader
 }
 
+enum TeamJoinRequestStatus {
+  pending
+  accepted
+  declined
+}
+
 model Team {
-  id          Int              @id @default(autoincrement())
+  id           Int               @id @default(autoincrement())
   /// @zod.string.min(1, { message: "Team name is required" })
-  name        String
-  description String?
-  lumaUrl     String?          @map("luma_url")
-  docUrl      String?          @map("doc_url")
-  createdAt   DateTime?        @default(now()) @map("created_at")
-  members     TeamMembership[]
-  suggestions TeamSuggestion[] @relation("TeamSuggestionMergedInto")
+  name         String
+  description  String?
+  lumaUrl      String?           @map("luma_url")
+  docUrl       String?           @map("doc_url")
+  createdAt    DateTime?         @default(now()) @map("created_at")
+  members      TeamMembership[]
+  joinRequests TeamJoinRequest[]
+  suggestions  TeamSuggestion[]  @relation("TeamSuggestionMergedInto")
+  workItems    WorkItem[]
 
   @@map("teams")
 }
@@ -449,6 +462,28 @@ model TeamMembership {
   @@unique([teamId, volunteerId], map: "uq_team_memberships_team_volunteer")
   @@index([volunteerId], map: "idx_team_memberships_volunteer")
   @@map("team_memberships")
+}
+
+// A volunteer applies to join; a team leader or admin accepts (creating the
+// TeamMembership) or declines. Unlike LocalGroup/Team suggestions this isn't a
+// moderation queue for new entities — it's per-team membership approval.
+model TeamJoinRequest {
+  id           Int                    @id @default(autoincrement())
+  teamId       Int                    @map("team_id")
+  volunteerId  Int                    @map("volunteer_id")
+  message      String?
+  status       TeamJoinRequestStatus  @default(pending)
+  reviewedById Int?                   @map("reviewed_by_id")
+  reviewedAt   DateTime?              @map("reviewed_at")
+  createdAt    DateTime?              @default(now()) @map("created_at")
+
+  team       Team       @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  volunteer  Volunteer  @relation("TeamJoinRequestVolunteer", fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  reviewedBy Volunteer? @relation("TeamJoinRequestReviewedBy", fields: [reviewedById], references: [id], onUpdate: NoAction)
+
+  @@index([teamId, status], map: "idx_team_join_requests_team_status")
+  @@index([volunteerId], map: "idx_team_join_requests_volunteer")
+  @@map("team_join_requests")
 }
 
 model TeamSuggestion {
@@ -647,6 +682,8 @@ model Volunteer {
   teamMemberships                         TeamMembership[]
   teamSuggestions                         TeamSuggestion[]         @relation("TeamSuggestionSuggestedBy")
   teamSuggestionsReviewed                 TeamSuggestion[]         @relation("TeamSuggestionReviewedBy")
+  teamJoinRequests                        TeamJoinRequest[]        @relation("TeamJoinRequestVolunteer")
+  teamJoinRequestsReviewed                TeamJoinRequest[]        @relation("TeamJoinRequestReviewedBy")
 
   @@index([localGroup], map: "idx_volunteers_local_group")
   @@index([country], map: "idx_volunteers_country")

--- a/server/router.ts
+++ b/server/router.ts
@@ -8,6 +8,8 @@ import { messagesRouter } from './routers/messages'
 import { bugReportsRouter } from './routers/bugReports'
 import { localGroupsRouter } from './routers/localGroups'
 import { localGroupSuggestionsRouter } from './routers/localGroupSuggestions'
+import { teamsRouter } from './routers/teams'
+import { teamSuggestionsRouter } from './routers/teamSuggestions'
 import { quickTasksRouter } from './routers/quickTasks'
 import { workItemCommentsRouter } from './routers/workItemComments'
 import { bugReportCommentsRouter } from './routers/bugReportComments'
@@ -21,6 +23,7 @@ import { adminProjectsRouter } from './routers/admin/projects'
 import { adminSkillsRouter } from './routers/admin/skills'
 import { adminSkillCategoriesRouter } from './routers/admin/skillCategories'
 import { adminLocalGroupsRouter } from './routers/admin/localGroups'
+import { adminTeamsRouter } from './routers/admin/teams'
 import { adminBugReportsRouter } from './routers/admin/bugReports'
 import { adminAdminsRouter } from './routers/admin/admins'
 import { adminPlatformSettingsRouter } from './routers/admin/platformSettings'
@@ -46,6 +49,8 @@ export const appRouter = {
   bugReportComments: bugReportCommentsRouter,
   localGroups: localGroupsRouter,
   localGroupSuggestions: localGroupSuggestionsRouter,
+  teams: teamsRouter,
+  teamSuggestions: teamSuggestionsRouter,
   quickTasks: quickTasksRouter,
   workItemComments: workItemCommentsRouter,
   my: myRouter,
@@ -60,6 +65,7 @@ export const appRouter = {
     skills: adminSkillsRouter,
     skillCategories: adminSkillCategoriesRouter,
     localGroups: adminLocalGroupsRouter,
+    teams: adminTeamsRouter,
     bugReports: adminBugReportsRouter,
     admins: adminAdminsRouter,
     platformSettings: adminPlatformSettingsRouter,

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
-import { notifyUser, clearNotifications } from '@/lib/notify'
+import { notifyUser, notifyTeamOfProject, clearNotifications } from '@/lib/notify'
 import { notifyMatchingVolunteers } from '@/lib/project-match-notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
@@ -39,6 +39,7 @@ export const adminProjectsRouter = {
           localGroup: input.localGroup ?? null,
           remoteEligibility: input.remoteEligibility ?? 'NONE',
           isSeekingHelp: input.isSeekingHelp !== false,
+          teamId: input.teamId ?? null,
         },
       })
 
@@ -67,6 +68,12 @@ export const adminProjectsRouter = {
     })
 
     notifyMatchingVolunteers(project.id).catch((e) => console.error('[MATCH NOTIFY]', e))
+
+    if (input.teamId) {
+      notifyTeamOfProject(input.teamId, project.id, project.title).catch((e) =>
+        console.error('[TEAM NOTIFY]', e),
+      )
+    }
 
     return { id: project.id, message: 'Org project created' }
   }),
@@ -125,6 +132,12 @@ export const adminProjectsRouter = {
         }
 
         notifyMatchingVolunteers(input.id).catch((e) => console.error('[MATCH NOTIFY]', e))
+
+        if (project.teamId) {
+          notifyTeamOfProject(project.teamId, project.id, project.title).catch((e) =>
+            console.error('[TEAM NOTIFY]', e),
+          )
+        }
       } else {
         await prisma.workItem.update({
           where: { id: input.id },

--- a/server/routers/admin/teams.ts
+++ b/server/routers/admin/teams.ts
@@ -83,36 +83,6 @@ export const adminTeamsRouter = {
     return { message: 'Team deleted' }
   }),
 
-  setMemberRole: adminProcedure
-    .input(
-      z.object({
-        teamId: z.number().int(),
-        volunteerId: z.number().int(),
-        role: z.enum([TeamMembershipRole.member, TeamMembershipRole.leader]),
-      }),
-    )
-    .handler(async ({ input }) => {
-      const membership = await prisma.teamMembership.findUnique({
-        where: { teamId_volunteerId: { teamId: input.teamId, volunteerId: input.volunteerId } },
-      })
-      if (!membership) throw new ORPCError('NOT_FOUND', { message: 'Not a team member' })
-
-      await prisma.teamMembership.update({
-        where: { id: membership.id },
-        data: { role: input.role },
-      })
-      return { message: 'Role updated' }
-    }),
-
-  removeMember: adminProcedure
-    .input(z.object({ teamId: z.number().int(), volunteerId: z.number().int() }))
-    .handler(async ({ input }) => {
-      await prisma.teamMembership.deleteMany({
-        where: { teamId: input.teamId, volunteerId: input.volunteerId },
-      })
-      return { message: 'Member removed' }
-    }),
-
   listSuggestions: adminProcedure
     .input(
       z.object({
@@ -171,6 +141,11 @@ export const adminTeamsRouter = {
         const name = input.name?.trim() || suggestion.name
         const description = input.description?.trim() || suggestion.description
         if (!name) throw new ORPCError('BAD_REQUEST', { message: 'Name required' })
+
+        const leaderId = input.leaderId ?? suggestion.suggestedBy.id
+        const leader = await prisma.volunteer.findUnique({ where: { id: leaderId } })
+        if (!leader) throw new ORPCError('BAD_REQUEST', { message: 'Leader not found' })
+
         finalName = name
         const [createdTeam] = await prisma.$transaction([
           prisma.team.create({ data: { name, description: description ?? null } }),
@@ -188,7 +163,7 @@ export const adminTeamsRouter = {
         await prisma.teamMembership.create({
           data: {
             teamId: createdTeam.id,
-            volunteerId: suggestion.suggestedBy.id,
+            volunteerId: leaderId,
             role: TeamMembershipRole.leader,
           },
         })

--- a/server/routers/admin/teams.ts
+++ b/server/routers/admin/teams.ts
@@ -1,0 +1,264 @@
+import { z } from 'zod'
+import { ORPCError } from '@orpc/server'
+import { prisma } from '@/lib/prisma'
+import { createNotification, clearNotifications } from '@/lib/notify'
+import { TeamBodySchema, ReviewTeamSuggestionSchema } from '@/lib/schemas'
+import { adminProcedure } from '../../procedures'
+import { TeamSuggestionStatus, TeamMembershipRole } from '@/generated/prisma/enums'
+
+const NOTIFICATION_TITLES: Record<string, (name: string) => string> = {
+  accepted: (n) => `Your team suggestion "${n}" was accepted`,
+  merge: (n) => `Your team suggestion "${n}" has been merged`,
+  on_hold: (n) => `Your team suggestion "${n}" is under review`,
+  declined: (n) => `Update on your team suggestion "${n}"`,
+}
+
+export const adminTeamsRouter = {
+  list: adminProcedure.handler(async () => {
+    const teams = await prisma.team.findMany({
+      orderBy: { name: 'asc' },
+      include: {
+        members: { include: { volunteer: { select: { id: true, name: true, email: true } } } },
+      },
+    })
+    return {
+      teams: teams.map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        lumaUrl: t.lumaUrl,
+        docUrl: t.docUrl,
+        members: t.members.map((m) => ({
+          id: m.volunteer.id,
+          name: m.volunteer.name,
+          email: m.volunteer.email,
+          role: m.role,
+        })),
+      })),
+    }
+  }),
+
+  create: adminProcedure.input(TeamBodySchema).handler(async ({ input }) => {
+    const team = await prisma.team.create({
+      data: {
+        name: input.name,
+        description: input.description ?? null,
+        lumaUrl: input.lumaUrl ?? null,
+        docUrl: input.docUrl ?? null,
+      },
+    })
+    return { id: team.id, name: team.name }
+  }),
+
+  update: adminProcedure
+    .input(z.object({ id: z.number().int() }).merge(TeamBodySchema))
+    .handler(async ({ input }) => {
+      const existing = await prisma.team.findUnique({ where: { id: input.id } })
+      if (!existing) throw new ORPCError('NOT_FOUND', { message: 'Not found' })
+
+      const team = await prisma.team.update({
+        where: { id: input.id },
+        data: {
+          name: input.name,
+          description: input.description ?? null,
+          lumaUrl: input.lumaUrl ?? null,
+          docUrl: input.docUrl ?? null,
+        },
+      })
+      return { id: team.id, name: team.name }
+    }),
+
+  delete: adminProcedure.input(z.object({ id: z.number().int() })).handler(async ({ input }) => {
+    const existing = await prisma.team.findUnique({ where: { id: input.id } })
+    if (!existing) throw new ORPCError('NOT_FOUND', { message: 'Not found' })
+
+    await prisma.$transaction([
+      prisma.teamSuggestion.updateMany({
+        where: { mergedIntoId: input.id },
+        data: { mergedIntoId: null },
+      }),
+      prisma.team.delete({ where: { id: input.id } }),
+    ])
+
+    return { message: 'Team deleted' }
+  }),
+
+  setMemberRole: adminProcedure
+    .input(
+      z.object({
+        teamId: z.number().int(),
+        volunteerId: z.number().int(),
+        role: z.enum([TeamMembershipRole.member, TeamMembershipRole.leader]),
+      }),
+    )
+    .handler(async ({ input }) => {
+      const membership = await prisma.teamMembership.findUnique({
+        where: { teamId_volunteerId: { teamId: input.teamId, volunteerId: input.volunteerId } },
+      })
+      if (!membership) throw new ORPCError('NOT_FOUND', { message: 'Not a team member' })
+
+      await prisma.teamMembership.update({
+        where: { id: membership.id },
+        data: { role: input.role },
+      })
+      return { message: 'Role updated' }
+    }),
+
+  removeMember: adminProcedure
+    .input(z.object({ teamId: z.number().int(), volunteerId: z.number().int() }))
+    .handler(async ({ input }) => {
+      await prisma.teamMembership.deleteMany({
+        where: { teamId: input.teamId, volunteerId: input.volunteerId },
+      })
+      return { message: 'Member removed' }
+    }),
+
+  listSuggestions: adminProcedure
+    .input(
+      z.object({
+        status: z.enum(['pending', 'on_hold', 'accepted', 'declined'] as const).default('pending'),
+      }),
+    )
+    .handler(async ({ input }) => {
+      const suggestions = await prisma.teamSuggestion.findMany({
+        where: { status: input.status },
+        orderBy: { createdAt: 'asc' },
+        include: {
+          suggestedBy: { select: { id: true, name: true, email: true } },
+          mergedInto: { select: { id: true, name: true } },
+        },
+      })
+
+      return {
+        suggestions: suggestions.map((s) => ({
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          status: s.status,
+          adminNotes: s.adminNotes,
+          createdAt: s.createdAt,
+          suggestedBy: {
+            id: s.suggestedBy.id,
+            name: s.suggestedBy.name,
+            email: s.suggestedBy.email,
+          },
+          mergedInto: s.mergedInto ? { id: s.mergedInto.id, name: s.mergedInto.name } : null,
+        })),
+      }
+    }),
+
+  reviewSuggestion: adminProcedure
+    .input(z.object({ id: z.number().int() }).merge(ReviewTeamSuggestionSchema))
+    .handler(async ({ input, context }) => {
+      const admin = context.volunteer
+      const suggestion = await prisma.teamSuggestion.findUnique({
+        where: { id: input.id },
+        include: { suggestedBy: { select: { id: true, name: true, email: true } } },
+      })
+      if (!suggestion) throw new ORPCError('NOT_FOUND', { message: 'Not found' })
+
+      const action = input.action
+      const adminNotes =
+        typeof input.adminNotes === 'string' ? input.adminNotes.trim() || null : null
+      const now = new Date()
+      const reviewBase = { reviewedById: admin.id, reviewedAt: now, updatedAt: now }
+
+      let finalName = suggestion.name
+      let notificationAction: string = action
+      let targetTeamId: number | null = null
+
+      if (action === 'accept') {
+        const name = input.name?.trim() || suggestion.name
+        const description = input.description?.trim() || suggestion.description
+        if (!name) throw new ORPCError('BAD_REQUEST', { message: 'Name required' })
+        finalName = name
+        const [createdTeam] = await prisma.$transaction([
+          prisma.team.create({ data: { name, description: description ?? null } }),
+          prisma.teamSuggestion.update({
+            where: { id: input.id },
+            data: {
+              ...reviewBase,
+              status: TeamSuggestionStatus.accepted,
+              name,
+              description,
+              adminNotes,
+            },
+          }),
+        ])
+        await prisma.teamMembership.create({
+          data: {
+            teamId: createdTeam.id,
+            volunteerId: suggestion.suggestedBy.id,
+            role: TeamMembershipRole.leader,
+          },
+        })
+        targetTeamId = createdTeam.id
+        notificationAction = TeamSuggestionStatus.accepted
+      } else if (action === 'merge') {
+        const mergedIntoId = input.mergedIntoId ?? null
+        if (!mergedIntoId) {
+          throw new ORPCError('BAD_REQUEST', { message: 'mergedIntoId required for merge' })
+        }
+        const target = await prisma.team.findUnique({ where: { id: mergedIntoId } })
+        if (!target) throw new ORPCError('NOT_FOUND', { message: 'Target team not found' })
+
+        await prisma.$transaction([
+          prisma.teamSuggestion.update({
+            where: { id: input.id },
+            data: {
+              ...reviewBase,
+              status: TeamSuggestionStatus.accepted,
+              mergedIntoId,
+              adminNotes,
+            },
+          }),
+          prisma.teamMembership.upsert({
+            where: {
+              teamId_volunteerId: { teamId: mergedIntoId, volunteerId: suggestion.suggestedBy.id },
+            },
+            create: { teamId: mergedIntoId, volunteerId: suggestion.suggestedBy.id },
+            update: {},
+          }),
+        ])
+        targetTeamId = mergedIntoId
+        notificationAction = 'merge'
+      } else if (action === 'on_hold') {
+        await prisma.teamSuggestion.update({
+          where: { id: input.id },
+          data: { ...reviewBase, status: TeamSuggestionStatus.on_hold, adminNotes },
+        })
+      } else if (action === 'decline') {
+        await prisma.teamSuggestion.update({
+          where: { id: input.id },
+          data: { ...reviewBase, status: TeamSuggestionStatus.declined, adminNotes },
+        })
+        notificationAction = TeamSuggestionStatus.declined
+      }
+
+      const titleFn = NOTIFICATION_TITLES[notificationAction]
+      const title = titleFn ? titleFn(finalName) : `Update on your team suggestion`
+      const notificationLink = targetTeamId ? `/teams/${targetTeamId}` : null
+
+      await createNotification(
+        suggestion.suggestedBy.id,
+        'team_suggestion_reviewed',
+        title,
+        adminNotes,
+        notificationLink,
+      )
+
+      await clearNotifications('team_suggestion', input.id)
+
+      return { message: 'Suggestion updated' }
+    }),
+
+  deleteSuggestion: adminProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input }) => {
+      const suggestion = await prisma.teamSuggestion.findUnique({ where: { id: input.id } })
+      if (!suggestion) throw new ORPCError('NOT_FOUND', { message: 'Not found' })
+
+      await prisma.teamSuggestion.delete({ where: { id: input.id } })
+      return { message: 'Suggestion deleted' }
+    }),
+}

--- a/server/routers/admin/teams.ts
+++ b/server/routers/admin/teams.ts
@@ -50,24 +50,6 @@ export const adminTeamsRouter = {
     return { id: team.id, name: team.name }
   }),
 
-  update: adminProcedure
-    .input(z.object({ id: z.number().int() }).merge(TeamBodySchema))
-    .handler(async ({ input }) => {
-      const existing = await prisma.team.findUnique({ where: { id: input.id } })
-      if (!existing) throw new ORPCError('NOT_FOUND', { message: 'Not found' })
-
-      const team = await prisma.team.update({
-        where: { id: input.id },
-        data: {
-          name: input.name,
-          description: input.description ?? null,
-          lumaUrl: input.lumaUrl ?? null,
-          docUrl: input.docUrl ?? null,
-        },
-      })
-      return { id: team.id, name: team.name }
-    }),
-
   delete: adminProcedure.input(z.object({ id: z.number().int() })).handler(async ({ input }) => {
     const existing = await prisma.team.findUnique({ where: { id: input.id } })
     if (!existing) throw new ORPCError('NOT_FOUND', { message: 'Not found' })

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -114,6 +114,12 @@ export const projectsRouter = {
       })
       const volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
 
+      const teamMemberships = await prisma.teamMembership.findMany({
+        where: { volunteerId: volunteer.id },
+        select: { teamId: true },
+      })
+      const viewerTeamIds = new Set(teamMemberships.map((m) => m.teamId))
+
       const conditions: Prisma.Sql[] = [Prisma.sql`type = ${WorkItemType.PROJECT}`]
 
       if (input.status) {
@@ -206,7 +212,7 @@ export const projectsRouter = {
       const projects = ids
         .map((id) => projectMap.get(id))
         .filter((p): p is NonNullable<typeof p> => p !== undefined)
-        .map((p) => withProjectExtras(p as EnrichedProject, volunteerSkillIds))
+        .map((p) => withProjectExtras(p as EnrichedProject, volunteerSkillIds, viewerTeamIds))
 
       if (input.sortBy === 'match' && volunteerSkillIds && volunteerSkillIds.size > 0) {
         projects.sort((a, b) => (b.match?.overallScore ?? 0) - (a.match?.overallScore ?? 0))
@@ -327,7 +333,13 @@ export const projectsRouter = {
       })
       const volunteerSkillIds = new Set((v?.skills ?? []).map((s) => s.skillId))
 
-      const base = withProjectExtras(project as EnrichedProject, volunteerSkillIds)
+      const teamMemberships = await prisma.teamMembership.findMany({
+        where: { volunteerId: volunteer.id },
+        select: { teamId: true },
+      })
+      const viewerTeamIds = new Set(teamMemberships.map((m) => m.teamId))
+
+      const base = withProjectExtras(project as EnrichedProject, volunteerSkillIds, viewerTeamIds)
 
       const tasks = await prisma.workItem.findMany({
         where: { parentId: input.id, type: WorkItemType.TASK },

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -7,9 +7,10 @@ import {
   projectInclude,
   EnrichedProject,
   canViewWorkItem,
+  resolveTeamPrivy,
   CLAIM_BLOCKING_INTEREST_STATUSES,
 } from '@/lib/work-item'
-import { notifyUser, notifyAdmins, clearNotifications } from '@/lib/notify'
+import { notifyUser, notifyAdmins, notifyTeamOfProject, clearNotifications } from '@/lib/notify'
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
@@ -87,6 +88,7 @@ export const projectsRouter = {
         urgency: z.string().optional(),
         country: z.string().optional(),
         localGroup: z.string().optional(),
+        teamId: z.number().int().optional(),
         isOrgProposed: z.boolean().optional(),
         isSeekingHelp: z.boolean().optional(),
         isSeekingOwner: z.boolean().optional(),
@@ -138,6 +140,7 @@ export const projectsRouter = {
       if (input.urgency) conditions.push(Prisma.sql`urgency = ${input.urgency}`)
       if (input.country) conditions.push(Prisma.sql`country = ${input.country}`)
       if (input.localGroup) conditions.push(Prisma.sql`local_group = ${input.localGroup}`)
+      if (input.teamId) conditions.push(Prisma.sql`team_id = ${input.teamId}`)
 
       if (input.isOrgProposed !== undefined) {
         conditions.push(Prisma.sql`is_org_proposed = ${input.isOrgProposed ? 1 : 0}`)
@@ -155,6 +158,21 @@ export const projectsRouter = {
       }
       if (input.notSeeking) {
         conditions.push(Prisma.raw(`is_seeking_help = 0 AND NOT ${SEEKING_OWNER_SQL}`))
+      }
+
+      // A project tagged to a team is only browsable by that team's members, its
+      // owner/proposer, or an admin — everyone else never sees it in the list.
+      if (!volunteer.isAdmin) {
+        conditions.push(Prisma.sql`(
+          team_id IS NULL
+          OR creator_id = ${volunteer.id}
+          OR assignee_id = ${volunteer.id}
+          OR team_id IN (SELECT team_id FROM team_memberships WHERE volunteer_id = ${volunteer.id})
+          OR id IN (
+            SELECT work_item_id FROM work_item_interests
+            WHERE volunteer_id = ${volunteer.id} AND status = ${InterestStatus.accepted}
+          )
+        )`)
       }
 
       const whereClause = Prisma.sql`WHERE ${Prisma.join(conditions, ' AND ')}`
@@ -226,6 +244,7 @@ export const projectsRouter = {
           localGroup: input.localGroup ?? null,
           remoteEligibility: input.remoteEligibility ?? 'NONE',
           isSeekingHelp: input.isSeekingHelp !== false,
+          teamId: input.teamId ?? null,
         },
       })
 
@@ -280,6 +299,17 @@ export const projectsRouter = {
       })
 
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
+
+      if (project.teamId !== null && !volunteer.isAdmin) {
+        const isDirectParticipant =
+          project.creatorId === volunteer.id || project.assigneeId === volunteer.id
+        if (
+          !isDirectParticipant &&
+          !(await resolveTeamPrivy(project.teamId, project.id, volunteer.id))
+        ) {
+          throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
+        }
+      }
 
       const hiddenStatuses: string[] = [
         ProjectStatus.pending_review,
@@ -481,6 +511,7 @@ export const projectsRouter = {
         'outcome',
         'outcomeNotes',
       ] as const
+      if (body.teamId !== undefined) data.teamId = body.teamId
       for (const field of stringFields) {
         if (body[field] !== undefined) data[field] = body[field]
       }
@@ -521,6 +552,18 @@ export const projectsRouter = {
 
       data.updatedAt = new Date()
       await prisma.workItem.update({ where: { id: input.id }, data })
+
+      // Tagging a team onto a project that's already visible alerts that team right away;
+      // tagging one still in review waits until it goes live (see admin/projects.ts).
+      if (
+        typeof data.teamId === 'number' &&
+        data.teamId !== project.teamId &&
+        !UNAPPROVED_STATUSES.includes(project.status)
+      ) {
+        notifyTeamOfProject(data.teamId, project.id, project.title).catch((e) =>
+          console.error('[TEAM NOTIFY]', e),
+        )
+      }
 
       if (body.skillIds !== undefined) {
         const skillRequiredMap = body.skillRequiredMap ?? {}
@@ -904,6 +947,7 @@ export const projectsRouter = {
       })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
 
+      const isTeamPrivy = await resolveTeamPrivy(project.teamId, project.id, volunteer.id)
       if (
         !canViewWorkItem(
           task,
@@ -913,6 +957,7 @@ export const projectsRouter = {
             isApproved: volunteer.approvalStatus === ApprovalStatus.approved,
           },
           project,
+          isTeamPrivy,
         )
       ) {
         throw new ORPCError('NOT_FOUND', { message: 'Task not found' })

--- a/server/routers/teamSuggestions.ts
+++ b/server/routers/teamSuggestions.ts
@@ -1,0 +1,54 @@
+import { prisma } from '@/lib/prisma'
+import { TeamSuggestionBodySchema } from '@/lib/schemas'
+import { notifyAdmins } from '@/lib/notify'
+import { authedProcedure, approvedProcedure } from '../procedures'
+
+export const teamSuggestionsRouter = {
+  list: authedProcedure.handler(async ({ context }) => {
+    const suggestions = await prisma.teamSuggestion.findMany({
+      where: { suggestedById: context.volunteer.id },
+      orderBy: { createdAt: 'desc' },
+      include: { mergedInto: { select: { id: true, name: true } } },
+    })
+    return {
+      suggestions: suggestions.map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+        status: s.status,
+        adminNotes: s.adminNotes,
+        createdAt: s.createdAt,
+        mergedInto: s.mergedInto ? { id: s.mergedInto.id, name: s.mergedInto.name } : null,
+      })),
+    }
+  }),
+
+  create: approvedProcedure.input(TeamSuggestionBodySchema).handler(async ({ input, context }) => {
+    const suggestion = await prisma.teamSuggestion.create({
+      data: {
+        name: input.name,
+        description: input.description ?? null,
+        suggestedById: context.volunteer.id,
+      },
+    })
+
+    await notifyAdmins(
+      'team_suggestion',
+      `New team suggestion: ${input.name}`,
+      null,
+      '/admin/teams',
+      undefined,
+      suggestion.id,
+    )
+
+    return {
+      id: suggestion.id,
+      name: suggestion.name,
+      description: suggestion.description,
+      status: suggestion.status,
+      adminNotes: null,
+      createdAt: suggestion.createdAt,
+      mergedInto: null,
+    }
+  }),
+}

--- a/server/routers/teamSuggestions.ts
+++ b/server/routers/teamSuggestions.ts
@@ -32,12 +32,18 @@ export const teamSuggestionsRouter = {
       },
     })
 
+    const title = `New team suggestion: ${input.name}`
     await notifyAdmins(
       'team_suggestion',
-      `New team suggestion: ${input.name}`,
+      title,
       null,
       '/admin/teams',
-      undefined,
+      {
+        subject: title,
+        message: `${context.volunteer.name} suggested a new team: <strong>${input.name}</strong>.`,
+        ctaLabel: 'Review Suggestion',
+        ctaUrl: '/admin/teams',
+      },
       suggestion.id,
     )
 

--- a/server/routers/teams.ts
+++ b/server/routers/teams.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { notifyUser } from '@/lib/notify'
+import { TeamBodySchema } from '@/lib/schemas'
 import { publicProcedure, approvedProcedure } from '../procedures'
 import { TeamMembershipRole, TeamJoinRequestStatus } from '@/generated/prisma/enums'
 
@@ -20,16 +21,20 @@ function serializeTeam(
   },
   viewerId?: number,
   viewerRequestStatus?: TeamJoinRequestStatus | null,
+  viewerIsAdmin?: boolean,
 ) {
   const viewerMembership = viewerId
     ? team.members.find((m) => m.volunteerId === viewerId)
     : undefined
+  // Meeting calendar and doc are for accepted members and admins only — not a public
+  // recruitment page, and not visible while an application is merely pending.
+  const isPrivy = Boolean(viewerMembership) || Boolean(viewerIsAdmin)
   return {
     id: team.id,
     name: team.name,
     description: team.description,
-    lumaUrl: team.lumaUrl,
-    docUrl: team.docUrl,
+    lumaUrl: isPrivy ? team.lumaUrl : null,
+    docUrl: isPrivy ? team.docUrl : null,
     memberCount: team.members.length,
     leaders: team.members
       .filter((m) => m.role === TeamMembershipRole.leader)
@@ -67,8 +72,11 @@ export const teamsRouter = {
         })
       : []
     const pendingByTeam = new Map(pendingRequests.map((r) => [r.teamId, r.status]))
+    const viewerIsAdmin = Boolean(context.volunteer?.isAdmin)
     return {
-      teams: teams.map((t) => serializeTeam(t, viewerId, pendingByTeam.get(t.id) ?? null)),
+      teams: teams.map((t) =>
+        serializeTeam(t, viewerId, pendingByTeam.get(t.id) ?? null, viewerIsAdmin),
+      ),
     }
   }),
 
@@ -90,7 +98,59 @@ export const teamsRouter = {
             },
           })
         : null
-      return serializeTeam(team, viewerId, pending?.status ?? null)
+      return serializeTeam(
+        team,
+        viewerId,
+        pending?.status ?? null,
+        Boolean(context.volunteer?.isAdmin),
+      )
+    }),
+
+  /** Full team detail for management — admin or that team's leader only. */
+  getManageable: approvedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      await assertCanManageTeam(input.id, context.volunteer)
+      const team = await prisma.team.findUnique({
+        where: { id: input.id },
+        include: {
+          members: { include: { volunteer: { select: { id: true, name: true, email: true } } } },
+        },
+      })
+      if (!team) throw new ORPCError('NOT_FOUND', { message: 'Team not found' })
+      return {
+        id: team.id,
+        name: team.name,
+        description: team.description,
+        lumaUrl: team.lumaUrl,
+        docUrl: team.docUrl,
+        members: team.members.map((m) => ({
+          id: m.volunteer.id,
+          name: m.volunteer.name,
+          email: m.volunteer.email,
+          role: m.role,
+        })),
+      }
+    }),
+
+  /** Edit team details — admin or that team's leader only. Deleting a team stays admin-only. */
+  update: approvedProcedure
+    .input(z.object({ id: z.number().int() }).merge(TeamBodySchema))
+    .handler(async ({ input, context }) => {
+      await assertCanManageTeam(input.id, context.volunteer)
+      const existing = await prisma.team.findUnique({ where: { id: input.id } })
+      if (!existing) throw new ORPCError('NOT_FOUND', { message: 'Team not found' })
+
+      const team = await prisma.team.update({
+        where: { id: input.id },
+        data: {
+          name: input.name,
+          description: input.description ?? null,
+          lumaUrl: input.lumaUrl ?? null,
+          docUrl: input.docUrl ?? null,
+        },
+      })
+      return { id: team.id, name: team.name }
     }),
 
   apply: approvedProcedure
@@ -131,15 +191,17 @@ export const teamsRouter = {
       })
       const recipientIds = leaders.length > 0 ? leaders.map((l) => l.volunteerId) : null
       if (recipientIds) {
+        const title = `${context.volunteer.name} applied to join ${team.name}`
         await Promise.all(
           recipientIds.map((id) =>
-            notifyUser(
-              id,
-              'team_join_request',
-              `${context.volunteer.name} applied to join ${team.name}`,
-              null,
-              '/teams',
-            ),
+            notifyUser(id, 'team_join_request', title, null, '/teams', {
+              subject: title,
+              message: input.message
+                ? `${context.volunteer.name} applied to join <strong>${team.name}</strong>: "${input.message.trim()}"`
+                : `${context.volunteer.name} applied to join <strong>${team.name}</strong>.`,
+              ctaLabel: 'Review Application',
+              ctaUrl: '/teams',
+            }),
           ),
         )
       }

--- a/server/routers/teams.ts
+++ b/server/routers/teams.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod'
+import { ORPCError } from '@orpc/server'
+import { prisma } from '@/lib/prisma'
+import { publicProcedure, approvedProcedure } from '../procedures'
+import { TeamMembershipRole } from '@/generated/prisma/enums'
+
+function serializeTeam(
+  team: {
+    id: number
+    name: string
+    description: string | null
+    lumaUrl: string | null
+    docUrl: string | null
+    members: {
+      volunteerId: number
+      role: TeamMembershipRole
+      volunteer: { id: number; name: string }
+    }[]
+  },
+  viewerId?: number,
+) {
+  const viewerMembership = viewerId
+    ? team.members.find((m) => m.volunteerId === viewerId)
+    : undefined
+  return {
+    id: team.id,
+    name: team.name,
+    description: team.description,
+    lumaUrl: team.lumaUrl,
+    docUrl: team.docUrl,
+    memberCount: team.members.length,
+    leaders: team.members
+      .filter((m) => m.role === TeamMembershipRole.leader)
+      .map((m) => ({ id: m.volunteer.id, name: m.volunteer.name })),
+    viewerRole: viewerMembership?.role ?? null,
+  }
+}
+
+export const teamsRouter = {
+  list: publicProcedure.handler(async ({ context }) => {
+    const teams = await prisma.team.findMany({
+      orderBy: { name: 'asc' },
+      include: { members: { include: { volunteer: { select: { id: true, name: true } } } } },
+    })
+    return { teams: teams.map((t) => serializeTeam(t, context.volunteer?.id)) }
+  }),
+
+  getById: publicProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      const team = await prisma.team.findUnique({
+        where: { id: input.id },
+        include: { members: { include: { volunteer: { select: { id: true, name: true } } } } },
+      })
+      if (!team) throw new ORPCError('NOT_FOUND', { message: 'Team not found' })
+      return serializeTeam(team, context.volunteer?.id)
+    }),
+
+  join: approvedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      const team = await prisma.team.findUnique({ where: { id: input.id } })
+      if (!team) throw new ORPCError('NOT_FOUND', { message: 'Team not found' })
+
+      await prisma.teamMembership.upsert({
+        where: { teamId_volunteerId: { teamId: input.id, volunteerId: context.volunteer.id } },
+        create: { teamId: input.id, volunteerId: context.volunteer.id },
+        update: {},
+      })
+      return { message: 'Joined team' }
+    }),
+
+  leave: approvedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      await prisma.teamMembership.deleteMany({
+        where: { teamId: input.id, volunteerId: context.volunteer.id },
+      })
+      return { message: 'Left team' }
+    }),
+}

--- a/server/routers/teams.ts
+++ b/server/routers/teams.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
+import { notifyUser } from '@/lib/notify'
 import { publicProcedure, approvedProcedure } from '../procedures'
-import { TeamMembershipRole } from '@/generated/prisma/enums'
+import { TeamMembershipRole, TeamJoinRequestStatus } from '@/generated/prisma/enums'
 
 function serializeTeam(
   team: {
@@ -18,6 +19,7 @@ function serializeTeam(
     }[]
   },
   viewerId?: number,
+  viewerRequestStatus?: TeamJoinRequestStatus | null,
 ) {
   const viewerMembership = viewerId
     ? team.members.find((m) => m.volunteerId === viewerId)
@@ -33,6 +35,21 @@ function serializeTeam(
       .filter((m) => m.role === TeamMembershipRole.leader)
       .map((m) => ({ id: m.volunteer.id, name: m.volunteer.name })),
     viewerRole: viewerMembership?.role ?? null,
+    viewerRequestStatus: viewerRequestStatus ?? null,
+  }
+}
+
+/** Team leader (of this team) or admin — who may review join requests / manage membership. */
+async function assertCanManageTeam(
+  teamId: number,
+  volunteer: { id: number; isAdmin: boolean | null },
+) {
+  if (volunteer.isAdmin) return
+  const membership = await prisma.teamMembership.findUnique({
+    where: { teamId_volunteerId: { teamId, volunteerId: volunteer.id } },
+  })
+  if (membership?.role !== TeamMembershipRole.leader) {
+    throw new ORPCError('FORBIDDEN', { message: 'Only a team leader or admin can do this' })
   }
 }
 
@@ -42,7 +59,17 @@ export const teamsRouter = {
       orderBy: { name: 'asc' },
       include: { members: { include: { volunteer: { select: { id: true, name: true } } } } },
     })
-    return { teams: teams.map((t) => serializeTeam(t, context.volunteer?.id)) }
+    const viewerId = context.volunteer?.id
+    const pendingRequests = viewerId
+      ? await prisma.teamJoinRequest.findMany({
+          where: { volunteerId: viewerId, status: TeamJoinRequestStatus.pending },
+          select: { teamId: true, status: true },
+        })
+      : []
+    const pendingByTeam = new Map(pendingRequests.map((r) => [r.teamId, r.status]))
+    return {
+      teams: teams.map((t) => serializeTeam(t, viewerId, pendingByTeam.get(t.id) ?? null)),
+    }
   }),
 
   getById: publicProcedure
@@ -53,21 +80,71 @@ export const teamsRouter = {
         include: { members: { include: { volunteer: { select: { id: true, name: true } } } } },
       })
       if (!team) throw new ORPCError('NOT_FOUND', { message: 'Team not found' })
-      return serializeTeam(team, context.volunteer?.id)
+      const viewerId = context.volunteer?.id
+      const pending = viewerId
+        ? await prisma.teamJoinRequest.findFirst({
+            where: {
+              teamId: input.id,
+              volunteerId: viewerId,
+              status: TeamJoinRequestStatus.pending,
+            },
+          })
+        : null
+      return serializeTeam(team, viewerId, pending?.status ?? null)
     }),
 
-  join: approvedProcedure
-    .input(z.object({ id: z.number().int() }))
+  apply: approvedProcedure
+    .input(z.object({ id: z.number().int(), message: z.string().optional() }))
     .handler(async ({ input, context }) => {
       const team = await prisma.team.findUnique({ where: { id: input.id } })
       if (!team) throw new ORPCError('NOT_FOUND', { message: 'Team not found' })
 
-      await prisma.teamMembership.upsert({
+      const existingMembership = await prisma.teamMembership.findUnique({
         where: { teamId_volunteerId: { teamId: input.id, volunteerId: context.volunteer.id } },
-        create: { teamId: input.id, volunteerId: context.volunteer.id },
-        update: {},
       })
-      return { message: 'Joined team' }
+      if (existingMembership) {
+        throw new ORPCError('BAD_REQUEST', { message: 'Already a member of this team' })
+      }
+
+      const existingRequest = await prisma.teamJoinRequest.findFirst({
+        where: {
+          teamId: input.id,
+          volunteerId: context.volunteer.id,
+          status: TeamJoinRequestStatus.pending,
+        },
+      })
+      if (existingRequest) {
+        throw new ORPCError('BAD_REQUEST', { message: 'Already applied — awaiting review' })
+      }
+
+      await prisma.teamJoinRequest.create({
+        data: {
+          teamId: input.id,
+          volunteerId: context.volunteer.id,
+          message: input.message?.trim() || null,
+        },
+      })
+
+      const leaders = await prisma.teamMembership.findMany({
+        where: { teamId: input.id, role: TeamMembershipRole.leader },
+        select: { volunteerId: true },
+      })
+      const recipientIds = leaders.length > 0 ? leaders.map((l) => l.volunteerId) : null
+      if (recipientIds) {
+        await Promise.all(
+          recipientIds.map((id) =>
+            notifyUser(
+              id,
+              'team_join_request',
+              `${context.volunteer.name} applied to join ${team.name}`,
+              null,
+              '/teams',
+            ),
+          ),
+        )
+      }
+
+      return { message: 'Application submitted' }
     }),
 
   leave: approvedProcedure
@@ -77,5 +154,128 @@ export const teamsRouter = {
         where: { teamId: input.id, volunteerId: context.volunteer.id },
       })
       return { message: 'Left team' }
+    }),
+
+  listJoinRequests: approvedProcedure
+    .input(z.object({ teamId: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      await assertCanManageTeam(input.teamId, context.volunteer)
+      const requests = await prisma.teamJoinRequest.findMany({
+        where: { teamId: input.teamId, status: TeamJoinRequestStatus.pending },
+        orderBy: { createdAt: 'asc' },
+        include: { volunteer: { select: { id: true, name: true, email: true } } },
+      })
+      return {
+        requests: requests.map((r) => ({
+          id: r.id,
+          message: r.message,
+          createdAt: r.createdAt,
+          volunteer: { id: r.volunteer.id, name: r.volunteer.name, email: r.volunteer.email },
+        })),
+      }
+    }),
+
+  reviewJoinRequest: approvedProcedure
+    .input(z.object({ id: z.number().int(), action: z.enum(['accept', 'decline']) }))
+    .handler(async ({ input, context }) => {
+      const request = await prisma.teamJoinRequest.findUnique({ where: { id: input.id } })
+      if (!request) throw new ORPCError('NOT_FOUND', { message: 'Request not found' })
+      await assertCanManageTeam(request.teamId, context.volunteer)
+
+      if (request.status !== TeamJoinRequestStatus.pending) {
+        throw new ORPCError('BAD_REQUEST', { message: 'Request already reviewed' })
+      }
+
+      await prisma.$transaction([
+        prisma.teamJoinRequest.update({
+          where: { id: input.id },
+          data: {
+            status:
+              input.action === 'accept'
+                ? TeamJoinRequestStatus.accepted
+                : TeamJoinRequestStatus.declined,
+            reviewedById: context.volunteer.id,
+            reviewedAt: new Date(),
+          },
+        }),
+        ...(input.action === 'accept'
+          ? [
+              prisma.teamMembership.upsert({
+                where: {
+                  teamId_volunteerId: { teamId: request.teamId, volunteerId: request.volunteerId },
+                },
+                create: { teamId: request.teamId, volunteerId: request.volunteerId },
+                update: {},
+              }),
+            ]
+          : []),
+      ])
+
+      const team = await prisma.team.findUnique({ where: { id: request.teamId } })
+      await notifyUser(
+        request.volunteerId,
+        'team_join_request_reviewed',
+        input.action === 'accept'
+          ? `You're in! Approved to join ${team?.name ?? 'the team'}`
+          : `Your request to join ${team?.name ?? 'the team'} was declined`,
+        null,
+        '/teams',
+      )
+
+      return { message: `Request ${input.action === 'accept' ? 'accepted' : 'declined'}` }
+    }),
+
+  /** Admin or team leader adds a volunteer directly — skips the apply/review flow. */
+  assignMember: approvedProcedure
+    .input(
+      z.object({
+        teamId: z.number().int(),
+        volunteerId: z.number().int(),
+        role: z.enum([TeamMembershipRole.member, TeamMembershipRole.leader]).optional(),
+      }),
+    )
+    .handler(async ({ input, context }) => {
+      await assertCanManageTeam(input.teamId, context.volunteer)
+      const volunteer = await prisma.volunteer.findUnique({ where: { id: input.volunteerId } })
+      if (!volunteer) throw new ORPCError('NOT_FOUND', { message: 'Volunteer not found' })
+
+      await prisma.teamMembership.upsert({
+        where: { teamId_volunteerId: { teamId: input.teamId, volunteerId: input.volunteerId } },
+        create: { teamId: input.teamId, volunteerId: input.volunteerId, role: input.role },
+        update: { role: input.role },
+      })
+      return { message: 'Volunteer added to team' }
+    }),
+
+  setMemberRole: approvedProcedure
+    .input(
+      z.object({
+        teamId: z.number().int(),
+        volunteerId: z.number().int(),
+        role: z.enum([TeamMembershipRole.member, TeamMembershipRole.leader]),
+      }),
+    )
+    .handler(async ({ input, context }) => {
+      await assertCanManageTeam(input.teamId, context.volunteer)
+      const membership = await prisma.teamMembership.findUnique({
+        where: { teamId_volunteerId: { teamId: input.teamId, volunteerId: input.volunteerId } },
+      })
+      if (!membership) throw new ORPCError('NOT_FOUND', { message: 'Not a team member' })
+
+      await prisma.teamMembership.update({
+        where: { id: membership.id },
+        data: { role: input.role },
+      })
+      return { message: 'Role updated' }
+    }),
+
+  removeMember: approvedProcedure
+    .input(z.object({ teamId: z.number().int(), volunteerId: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      await assertCanManageTeam(input.teamId, context.volunteer)
+      await prisma.teamMembership.deleteMany({
+        where: { teamId: input.teamId, volunteerId: input.volunteerId },
+      })
+      return { message: 'Member removed' }
     }),
 }

--- a/server/routers/workItemComments.ts
+++ b/server/routers/workItemComments.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { notifyUser } from '@/lib/notify'
-import { canViewWorkItem, canPostComment } from '@/lib/work-item'
+import { canViewWorkItem, canPostComment, resolveTeamPrivy } from '@/lib/work-item'
 import { publicProcedure, authedProcedure } from '../procedures'
 import { ApprovalStatus, InterestStatus, WorkItemType } from '@/generated/prisma/enums'
 
@@ -14,6 +14,7 @@ const WORK_ITEM_SELECT = {
   parentId: true,
   creatorId: true,
   assigneeId: true,
+  teamId: true,
 } as const
 
 type LoadedWorkItem = {
@@ -24,6 +25,7 @@ type LoadedWorkItem = {
   parentId: number | null
   creatorId: number | null
   assigneeId: number | null
+  teamId: number | null
 }
 
 async function loadWithParent(id: number) {
@@ -84,7 +86,15 @@ export const workItemCommentsRouter = {
             isApproved: context.volunteer.approvalStatus === ApprovalStatus.approved,
           }
         : null
-      if (!canViewWorkItem(loaded.item, viewer, loaded.parent)) {
+      const teamProject = loaded.item.type === WorkItemType.TASK ? loaded.parent : loaded.item
+      const isTeamPrivy = viewer
+        ? await resolveTeamPrivy(
+            teamProject?.teamId,
+            teamProject?.id ?? input.workItemId,
+            viewer.id,
+          )
+        : false
+      if (!canViewWorkItem(loaded.item, viewer, loaded.parent, isTeamPrivy)) {
         throw new ORPCError('NOT_FOUND', { message: 'Work item not found' })
       }
 


### PR DESCRIPTION
## Summary
- New `Team` / `TeamMembership` / `TeamJoinRequest` / `TeamSuggestion` models, orthogonal to `WorkItem` and to a volunteer's single `localGroup` string — a volunteer can belong to any number of teams
- Volunteer-facing: `/teams` and `/teams/[id]` (browse, apply to join, leave) and `/suggest-team` (mirrors the existing local-group suggestion flow)
- Joining a team requires an application reviewed by a team leader or admin — no self-serve instant join
- **Team leaders can self-manage their own team** at `/admin/teams/[id]` — edit details, review join requests, add/promote/demote/remove members — without needing admin access. Only deleting a team stays admin-only. `/admin/teams` remains the admin-only bulk list + suggestion review queue.
- Accepting a team suggestion lets the admin pick who becomes the first leader (defaults to the suggester)
- **Projects can be tagged to a team** (`WorkItem.teamId`). A team-tagged project is visible only to that team's members, its owner/proposer, accepted helpers, and admins — enforced in the browse list, project detail, task detail, and comment access. Team members are notified in-app when a tagged project goes live.
- **Project browse page**: team-tagged projects the viewer belongs to get a highlighted border and their own "Your Team Projects" section; a team filter dropdown lets a volunteer scope to their own teams (admins can filter by any team)
- **Email notifications**: admins get an email when a team is suggested; team leaders get an email when someone applies to join their team (in addition to existing in-app notifications)

## Scope notes
- No enforcement that admins keep projects single, well-defined deliverables (per the original issue discussion, this isn't something code can gate — it's a workflow norm)

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite) — 205 passed, 5 skipped
- [x] New `e2e/tests/29-teams.spec.ts` (13 tests): suggest → accept/merge/decline, leader selection on accept, apply → accept/decline → re-apply, leave, direct member assignment, promote/demote/remove, authorization (non-leader/non-admin blocked from reviewing), and project-visibility + notification
- [ ] Manually exercise: suggest a team → admin accepts, choosing a leader → that leader manages the team themselves (no admin role) → volunteer applies to join another team → admin tags a project to a team → non-member can't see it, team member sees the highlight and the "Your Team Projects" section

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3iGrP2JrvxsX1uaHNdfLq