### PR TITLE
Extract reusable VolunteerSelect with server-side typeahead

### DIFF
--- a/app/admin/bugs/page.tsx
+++ b/app/admin/bugs/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
+import VolunteerSelect from '@/components/VolunteerSelect'
 import Button from '@/components/Button'
 import { orpc } from '@/lib/orpc'
 import { formatDate } from '@/lib/format-date'
@@ -45,12 +46,6 @@ export default function AdminBugsPage() {
     ...listQuery,
     enabled: !!user?.isAdmin,
   })
-
-  const { data: volunteersData } = useQuery({
-    ...orpc.volunteers.list.queryOptions({ input: { limit: 100 } }),
-    enabled: !!user?.isAdmin,
-  })
-  const volunteers = volunteersData?.volunteers ?? []
 
   const [assignSelections, setAssignSelections] = useState<Record<number, string>>({})
 
@@ -163,17 +158,14 @@ export default function AdminBugsPage() {
               )}
 
               <div className="flex-1 min-w-50 max-w-75">
-                <FilterDropdown
+                <VolunteerSelect
                   id={`assign-bug-${r.id}`}
                   label="Assign to"
                   ariaLabel={`Assign volunteer to ${r.title}`}
                   value={assignSelections[r.id] ?? ''}
-                  options={[
-                    { value: '', label: 'Select volunteer…' },
-                    ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                  ]}
                   onChange={(v) => setAssignSelections((s) => ({ ...s, [r.id]: v }))}
-                  searchable
+                  placeholder="Select volunteer…"
+                  enabled={!!user?.isAdmin}
                 />
               </div>
               <Button

--- a/app/admin/teams/[id]/page.tsx
+++ b/app/admin/teams/[id]/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ORPCError } from '@orpc/client'
 import Button from '@/components/Button'
-import FilterDropdown from '@/components/FilterDropdown'
+import VolunteerSelect from '@/components/VolunteerSelect'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 
@@ -53,26 +53,6 @@ export default function AdminTeamDetailPage({ params }: { params: Promise<{ id: 
   }, [team, initialized])
 
   const [assignVolunteerId, setAssignVolunteerId] = useState('')
-
-  // Server-side search rather than a client-side filter over one page — the volunteer
-  // list can be far bigger than any single page we'd otherwise preload.
-  const [volunteerSearchInput, setVolunteerSearchInput] = useState('')
-  const [volunteerSearch, setVolunteerSearch] = useState('')
-  useEffect(() => {
-    const t = setTimeout(() => setVolunteerSearch(volunteerSearchInput), 300)
-    return () => clearTimeout(t)
-  }, [volunteerSearchInput])
-
-  const { data: volunteersData } = useQuery({
-    ...orpc.volunteers.list.queryOptions({
-      input: { limit: 20, search: volunteerSearch || undefined },
-    }),
-    enabled: !!user,
-  })
-  const volunteerOptions = (volunteersData?.volunteers ?? []).map((v) => ({
-    value: String(v.id),
-    label: v.name,
-  }))
 
   const { data: joinRequestsData } = useQuery({
     ...orpc.teams.listJoinRequests.queryOptions({ input: { teamId } }),
@@ -305,15 +285,14 @@ export default function AdminTeamDetailPage({ params }: { params: Promise<{ id: 
 
         <div className="mb-5 pb-5 border-b border-brand-border flex items-end gap-2">
           <div className="flex-1">
-            <FilterDropdown
+            <VolunteerSelect
               id="assign-volunteer"
               label="Add a volunteer directly"
               ariaLabel="Select volunteer to add"
               value={assignVolunteerId}
-              options={[{ value: '', label: 'Select a volunteer…' }, ...volunteerOptions]}
               onChange={setAssignVolunteerId}
-              onQueryChange={setVolunteerSearchInput}
-              searchable
+              placeholder="Select a volunteer…"
+              enabled={!!user}
             />
           </div>
           <Button

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -14,6 +14,7 @@ import { INTEREST_STATUS_LABELS, projectStatusVariant } from '@/components/Proje
 import CommentThread from '@/components/CommentThread'
 import Modal from '@/components/ui/Modal'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
+import VolunteerSelect from '@/components/VolunteerSelect'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
@@ -1200,17 +1201,12 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                         <>
                           <div className="px-3 py-2 flex flex-col gap-2">
                             <h3 className="m-0 text-sm">Transfer Ownership</h3>
-                            <FilterDropdown
+                            <VolunteerSelect
                               id="transfer-to"
                               label="Transfer to"
                               ariaLabel="Transfer to"
                               value={transferTo}
-                              options={[
-                                { value: '', label: '— Select volunteer —' },
-                                ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                              ]}
                               onChange={(v) => setTransferTo(v)}
-                              searchable
                             />
                             <Button
                               variant="secondary"
@@ -1341,17 +1337,12 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                       >
                         <span className="text-text-light text-sm shrink-0">+ Add</span>
                         <div className="flex-1 min-w-40">
-                          <FilterDropdown
+                          <VolunteerSelect
                             id="assign-volunteer"
                             label=""
                             ariaLabel="Volunteer to assign"
                             value={assignTo}
-                            options={[
-                              { value: '', label: '— Select volunteer —' },
-                              ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                            ]}
                             onChange={(v) => setAssignTo(v)}
-                            searchable
                           />
                         </div>
                         <Button

--- a/app/quick-tasks/page.tsx
+++ b/app/quick-tasks/page.tsx
@@ -9,6 +9,7 @@ import { Badge, type BadgeVariant } from '@/components/Badge'
 import Button from '@/components/Button'
 import CommentThread from '@/components/CommentThread'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
+import VolunteerSelect from '@/components/VolunteerSelect'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { formatDate } from '@/lib/format-date'
@@ -34,11 +35,6 @@ interface AdminQuickTask {
   reviewNotes: string | null
   estimatedHours: number | null
   createdAt: string
-}
-
-interface Volunteer {
-  id: number
-  name: string
 }
 
 interface FeaturedProjectTask {
@@ -433,12 +429,6 @@ function AdminQuickTasksView() {
     cat.skills.map((s) => ({ ...s, categoryName: cat.name })),
   )
 
-  const { data: volunteersData } = useQuery({
-    ...orpc.volunteers.list.queryOptions({ input: { limit: 100 } }),
-    enabled: !!user?.isAdmin,
-  })
-  const volunteers: Volunteer[] = (volunteersData?.volunteers ?? []) as Volunteer[]
-
   // Cards are always fully expanded now, so a deep link just needs to scroll to the
   // right card rather than toggle anything open.
   useEffect(() => {
@@ -724,17 +714,14 @@ function AdminQuickTasksView() {
               {task.status === QuickTaskStatus.open && (
                 <div className="flex gap-2 items-end mb-3">
                   <div className="flex-1 max-w-75">
-                    <FilterDropdown
+                    <VolunteerSelect
                       id={`assign-task-${task.id}`}
                       label="Assign to"
                       ariaLabel={`Assign volunteer to ${task.title}`}
                       value={taskAssignSelections[task.id] ?? ''}
-                      options={[
-                        { value: '', label: 'Select volunteer…' },
-                        ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                      ]}
                       onChange={(v) => setTaskAssignSelections((s) => ({ ...s, [task.id]: v }))}
-                      searchable
+                      placeholder="Select volunteer…"
+                      enabled={!!user?.isAdmin}
                     />
                   </div>
                   <Button
@@ -833,19 +820,16 @@ function AdminQuickTasksView() {
                 {task.status === TaskStatus.open && (
                   <div className="flex gap-2 items-end mb-3">
                     <div className="flex-1 max-w-75">
-                      <FilterDropdown
+                      <VolunteerSelect
                         id={`assign-project-task-${task.id}`}
                         label="Assign to"
                         ariaLabel={`Assign volunteer to ${task.title}`}
                         value={projectTaskAssignSelections[task.id] ?? ''}
-                        options={[
-                          { value: '', label: 'Select volunteer…' },
-                          ...volunteers.map((v) => ({ value: String(v.id), label: v.name })),
-                        ]}
                         onChange={(v) =>
                           setProjectTaskAssignSelections((s) => ({ ...s, [task.id]: v }))
                         }
-                        searchable
+                        placeholder="Select volunteer…"
+                        enabled={!!user?.isAdmin}
                       />
                     </div>
                     <Button

--- a/components/VolunteerSelect.tsx
+++ b/components/VolunteerSelect.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import FilterDropdown, { FilterOption } from '@/components/FilterDropdown'
+import { orpc } from '@/lib/orpc'
+
+const DEBOUNCE_MS = 300
+const RESULT_LIMIT = 20
+
+interface Props {
+  id: string
+  label: string
+  ariaLabel: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  required?: boolean
+  hideLabel?: boolean
+  triggerClassName?: string
+  enabled?: boolean
+}
+
+// Reusable volunteer picker: typeahead over a server-side search (name/bio) rather than a
+// client-side filter over a preloaded page, since the volunteer list can grow far past
+// what's reasonable to fetch upfront. Each option shows name plus location context
+// (local group or country) so admins can make location-aware assignments.
+export default function VolunteerSelect({
+  id,
+  label,
+  ariaLabel,
+  value,
+  onChange,
+  placeholder = '— Select volunteer —',
+  required,
+  hideLabel,
+  triggerClassName,
+  enabled = true,
+}: Props) {
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setSearch(searchInput), DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const { data } = useQuery({
+    ...orpc.volunteers.list.queryOptions({
+      input: { limit: RESULT_LIMIT, search: search || undefined },
+    }),
+    enabled,
+  })
+  const volunteers = data?.volunteers ?? []
+
+  // Remember whichever option was last picked so the trigger keeps showing its label
+  // even after a later search no longer includes it in the fetched page.
+  const [selectedOption, setSelectedOption] = useState<FilterOption | null>(null)
+
+  // Label stays just the name — it's what the trigger shows once selected, and what the
+  // e2e suite matches on. Location context is rendered separately per-option below and
+  // marked aria-hidden so it doesn't change the option's accessible name.
+  const volunteerOptions: FilterOption[] = volunteers.map((v) => ({
+    value: String(v.id),
+    label: v.name,
+  }))
+  const locationById = new Map(
+    volunteers.map((v) => [String(v.id), [v.localGroup, v.country].filter(Boolean).join(', ')]),
+  )
+  const options: FilterOption[] = [
+    { value: '', label: placeholder },
+    ...(selectedOption && !volunteerOptions.some((o) => o.value === selectedOption.value)
+      ? [selectedOption]
+      : []),
+    ...volunteerOptions,
+  ]
+
+  return (
+    <FilterDropdown
+      id={id}
+      label={label}
+      ariaLabel={ariaLabel}
+      value={value}
+      options={options}
+      onChange={(v) => {
+        setSelectedOption(options.find((o) => o.value === v) ?? null)
+        onChange(v)
+      }}
+      onQueryChange={setSearchInput}
+      searchable
+      required={required}
+      hideLabel={hideLabel}
+      triggerClassName={triggerClassName}
+      renderOption={(opt) => {
+        const location = locationById.get(opt.value)
+        return (
+          <span className="flex flex-col">
+            <span>{opt.label}</span>
+            {location && (
+              <span aria-hidden="true" className="text-xs text-text-light">
+                {location}
+              </span>
+            )}
+          </span>
+        )
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- New `VolunteerSelect` component: debounced server-side search (name/bio) via `orpc.volunteers.list`, showing each volunteer's local group/country alongside their name.
- Replaces the ad-hoc search built into the teams page, and the 4 spots preloading up to 100 volunteers client-side: bug report assign, project transfer-ownership/direct-assign, quick tasks assign (+ featured project tasks).
- Left the project's per-task assign dropdown alone — it groups a fixed "interested volunteers" set ahead of the rest, which doesn't compose with server-side search.

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite) — all green
- [x] Re-ran the e2e specs touching these assign flows individually to confirm

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McggDx77Jhgc7RWhofWVHK