### PR TITLE
Modal focus trapping, skip-to-content link, em dash copy sweep

### DIFF
--- a/app/admin/cron-runs/page.tsx
+++ b/app/admin/cron-runs/page.tsx
@@ -144,7 +144,7 @@ export default function AdminCronRunsPage() {
 
       <Modal
         id="cron-run-detail"
-        title={selectedRun ? `${selectedRun.jobName} — ${selectedRun.status}` : ''}
+        title={selectedRun ? `${selectedRun.jobName}: ${selectedRun.status}` : ''}
         isOpen={!!selectedRun}
         onClose={() => setSelectedRun(null)}
       >

--- a/app/admin/email-preview/page.tsx
+++ b/app/admin/email-preview/page.tsx
@@ -55,7 +55,7 @@ const EMAIL_TYPES: { value: string; label: string; params: Record<string, Param>
       name: 'Alex',
       subject: 'Your project has been approved',
       message:
-        'Great news — your project AI Safety Explainer Series has been reviewed and approved.',
+        'Great news: your project AI Safety Explainer Series has been reviewed and approved.',
       project_id: 1,
     },
   },

--- a/app/admin/local-groups/page.tsx
+++ b/app/admin/local-groups/page.tsx
@@ -216,7 +216,7 @@ export default function AdminLocalGroupsPage() {
     { value: '', label: 'Select an existing group…' },
     ...allGroups.map((g) => ({
       value: String(g.id),
-      label: `${countryLabel(g.country)} — ${g.name}`,
+      label: `${countryLabel(g.country)}, ${g.name}`,
     })),
   ]
 
@@ -384,7 +384,7 @@ export default function AdminLocalGroupsPage() {
                   <div className="flex-1">
                     <div className="flex items-center gap-2 flex-wrap">
                       <span className="font-semibold">
-                        {countryLabel(item.country)} — {item.name}
+                        {countryLabel(item.country)}, {item.name}
                       </span>
                       <span
                         className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_BADGE[status] ?? ''}`}
@@ -567,7 +567,7 @@ export default function AdminLocalGroupsPage() {
                 Suggested by {reviewSuggestion.suggestedBy.name}
               </p>
               <p className="font-semibold mb-5">
-                {countryLabel(reviewSuggestion.country)} — {reviewSuggestion.name}
+                {countryLabel(reviewSuggestion.country)}, {reviewSuggestion.name}
               </p>
 
               <form onSubmit={submitReview}>
@@ -590,7 +590,7 @@ export default function AdminLocalGroupsPage() {
                         onChange={() => setReviewAction(opt.value)}
                       >
                         <span>
-                          <strong>{opt.label}</strong> — {opt.desc}
+                          <strong>{opt.label}</strong>: {opt.desc}
                         </span>
                       </Radio>
                     ))}
@@ -711,7 +711,7 @@ export default function AdminLocalGroupsPage() {
               <p>
                 Delete{' '}
                 <strong>
-                  {countryLabel(deleteTarget.country)} — {deleteTarget.name}
+                  {countryLabel(deleteTarget.country)}, {deleteTarget.name}
                 </strong>
                 ? This cannot be undone.
               </p>

--- a/app/admin/teams/page.tsx
+++ b/app/admin/teams/page.tsx
@@ -527,7 +527,7 @@ export default function AdminTeamsPage() {
                         onChange={() => setReviewAction(opt.value)}
                       >
                         <span>
-                          <strong>{opt.label}</strong> — {opt.desc}
+                          <strong>{opt.label}</strong>: {opt.desc}
                         </span>
                       </Radio>
                     ))}
@@ -578,8 +578,7 @@ export default function AdminTeamsPage() {
                         searchable
                       />
                       <p className="text-sm text-text-light mt-1">
-                        Defaults to the suggester — pick someone else if they shouldn&apos;t lead
-                        it.
+                        Defaults to the suggester, pick someone else if they shouldn&apos;t lead it.
                       </p>
                     </div>
                   </>

--- a/app/admin/volunteers/[id]/page.tsx
+++ b/app/admin/volunteers/[id]/page.tsx
@@ -291,7 +291,7 @@ export default function AdminVolunteerDetailPage({ params }: { params: Promise<{
             {vol.endorsements.length > 0 ? (
               vol.endorsements.map((e) => (
                 <div key={e.id} className="py-1.5 border-b border-brand-border text-sm">
-                  <strong>{e.skillName}</strong> — {e.rating} · by {e.endorsedByName}
+                  <strong>{e.skillName}</strong>: {e.rating} · by {e.endorsedByName}
                 </div>
               ))
             ) : (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -219,7 +219,7 @@ export default function DashboardPage() {
         {showEmailBanner && (
           <div className="flex items-center justify-between gap-3 p-4 rounded-lg mb-5 bg-blue-100 text-blue-800 border border-blue-300 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-600">
             <span>
-              Stay in the loop — set your email notification preference in your{' '}
+              Stay in the loop: set your email notification preference in your{' '}
               <Link href="/profile" className="underline font-semibold">
                 profile
               </Link>

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -87,7 +87,7 @@ export default function ForgotPasswordPage() {
               </div>
               {devUrl && (
                 <div className="mt-6 pt-4 border-t border-brand-border">
-                  <p className="text-[12px] text-text-light">Dev mode — Reset link:</p>
+                  <p className="text-[12px] text-text-light">Dev mode, Reset link:</p>
                   <a href={devUrl} className="break-all">
                     {devUrl}
                   </a>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,6 +58,12 @@ export default function RootLayout({
         >{`try{var t=localStorage.getItem('theme');document.documentElement.setAttribute('data-theme',t==='dark'?'dark':t==='light'?'light':window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light')}catch(e){}`}</Script>
       </head>
       <body className="min-h-screen flex flex-col">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:rounded-md focus:bg-surface focus:px-4 focus:py-2 focus:shadow-lg"
+        >
+          Skip to content
+        </a>
         <Providers>
           <ThemeProvider>
             <AuthProvider>
@@ -65,7 +71,7 @@ export default function RootLayout({
                 <CookieConsentProvider>
                   <LocationModalProvider>
                     <Header />
-                    {children}
+                    <main id="main-content">{children}</main>
                     <Footer />
                     <FloatingActions />
                     <CookieConsentBanner />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 const TRACK_RECORD: { when: string; body: React.ReactNode }[] = [
   {
-    when: 'Open Letter to Demis Hassabis — August 2025',
+    when: 'Open Letter to Demis Hassabis, August 2025',
     body: (
       <>
         We published an{' '}
@@ -43,11 +43,11 @@ const TRACK_RECORD: { when: string; body: React.ReactNode }[] = [
     ),
   },
   {
-    when: 'Westminster Hall Debate — December 2025',
+    when: 'Westminster Hall Debate, December 2025',
     body: 'We proposed and helped to organise a Westminster Hall debate in Parliament on AI Safety. We wrote a memo which was sent out to all MPs prior to the debate and also helped to draft some proposition speeches, putting us in a strong position to work with those MPs when proposing amendments to the Cyber Security and Resilience Bill.',
   },
   {
-    when: 'March for AI Safety — February 2026',
+    when: 'March for AI Safety, February 2026',
     body: (
       <>
         We co-organised a march past the offices of OpenAI and Big Tech companies in King&apos;s

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -77,17 +77,17 @@ export default function PrivacyPage() {
             <p className="text-text-light">We process your data based on:</p>
             <ul className="list-disc text-text-light mb-4 pl-5">
               <li>
-                <strong>Consent</strong> — for sharing your profile with other volunteers and
+                <strong>Consent</strong>: for sharing your profile with other volunteers and
                 allowing project owners to contact you (you can withdraw consent at any time via
                 your privacy settings)
               </li>
               <li>
-                <strong>Legitimate interest</strong> — for operating the platform, matching
+                <strong>Legitimate interest</strong>: for operating the platform, matching
                 volunteers with projects, platform administration, and sending inactivity reminders
                 to volunteers who have claimed a task
               </li>
               <li>
-                <strong>Contract performance</strong> — for providing you the service you signed up
+                <strong>Contract performance</strong>: for providing you the service you signed up
                 for
               </li>
             </ul>
@@ -109,7 +109,7 @@ export default function PrivacyPage() {
                 posted an update for a period of time, and to automatically unassign you from the
                 task after continued inactivity so that other volunteers can take it on. Project
                 owners and admins are notified when a volunteer is unassigned due to inactivity
-                (legitimate interest basis — keeping projects moving)
+                (legitimate interest basis: keeping projects moving)
               </li>
               <li>
                 To notify project owners and admins when task updates are posted, so they can stay
@@ -125,7 +125,7 @@ export default function PrivacyPage() {
               <li>
                 We don&apos;t use your data for profiling or to make decisions that have legal or
                 significant effects on you. Automated task unassignment due to inactivity is a minor
-                operational measure to keep projects moving — it does not affect your account,
+                operational measure to keep projects moving, it does not affect your account,
                 profile, or ability to claim other tasks
               </li>
             </ul>
@@ -137,24 +137,24 @@ export default function PrivacyPage() {
             </p>
             <ul className="list-disc text-text-light mb-4 pl-5">
               <li>
-                <strong>Railway</strong> (hosting) — our application and database are hosted on
+                <strong>Railway</strong> (hosting): our application and database are hosted on
                 Railway&apos;s cloud infrastructure. Data may be processed in the United States. We
                 rely on Railway&apos;s standard contractual safeguards for international transfers.
               </li>
               <li>
-                <strong>Resend</strong> (email delivery) — used to send transactional emails
+                <strong>Resend</strong> (email delivery): used to send transactional emails
                 (password resets, welcome emails, admin invites) and relay messages between
                 volunteers. Resend processes your email address and name for delivery purposes only.
                 Data may be processed in the United States.
               </li>
               <li>
-                <strong>Backblaze B2</strong> (encrypted backups) — daily encrypted backups of the
+                <strong>Backblaze B2</strong> (encrypted backups): daily encrypted backups of the
                 database are stored in Backblaze&apos;s EU data centre (Amsterdam). Backups are
                 retained for 30 days and then automatically deleted. Backups are used solely for
                 disaster recovery and are never accessed for any other purpose.
               </li>
               <li>
-                <strong>Google Analytics</strong> (usage analytics) — used to understand how the
+                <strong>Google Analytics</strong> (usage analytics): used to understand how the
                 platform is used so we can improve it. Collects anonymised page view and interaction
                 data via cookies. IP addresses are anonymised. Only loaded if you accept cookies via
                 the consent banner. You can withdraw consent at any time by clearing your browser
@@ -162,7 +162,7 @@ export default function PrivacyPage() {
                 States.
               </li>
               <li>
-                <strong>Google Sign-In</strong> (authentication) — if you choose to sign in with
+                <strong>Google Sign-In</strong> (authentication): if you choose to sign in with
                 Google, Google verifies your identity and shares your name and email with us to
                 create or log into your account. No other Google data is accessed.
               </li>
@@ -193,12 +193,12 @@ export default function PrivacyPage() {
             <h4>Cookies</h4>
             <ul className="list-disc text-text-light mb-4 pl-5">
               <li>
-                <strong>Essential cookies</strong> — we use localStorage (not cookies) to store your
+                <strong>Essential cookies</strong>: we use localStorage (not cookies) to store your
                 login session and preferences (dark mode, cookie consent choice). These are
                 necessary for the site to function.
               </li>
               <li>
-                <strong>Analytics cookies</strong> — Google Analytics uses cookies to collect
+                <strong>Analytics cookies</strong>: Google Analytics uses cookies to collect
                 anonymised usage data. These are only loaded after you accept the cookie consent
                 banner. You can decline or withdraw consent at any time.
               </li>
@@ -221,28 +221,28 @@ export default function PrivacyPage() {
             </p>
             <ul className="list-disc text-text-light pl-5">
               <li>
-                <strong>Access</strong> (Article 15) — Download all your data using the export
+                <strong>Access</strong> (Article 15): Download all your data using the export
                 feature above
               </li>
               <li>
-                <strong>Rectification</strong> (Article 16) — Update your profile at any time
+                <strong>Rectification</strong> (Article 16): Update your profile at any time
               </li>
               <li>
-                <strong>Erasure</strong> (Article 17) — Delete your account and all personal data
+                <strong>Erasure</strong> (Article 17): Delete your account and all personal data
               </li>
               <li>
-                <strong>Restrict processing</strong> (Article 18) — Contact us to limit how we use
+                <strong>Restrict processing</strong> (Article 18): Contact us to limit how we use
                 your data
               </li>
               <li>
-                <strong>Portability</strong> (Article 20) — Export your data in a machine-readable
+                <strong>Portability</strong> (Article 20): Export your data in a machine-readable
                 format (JSON)
               </li>
               <li>
-                <strong>Object</strong> (Article 21) — Contact us to opt out of specific processing
+                <strong>Object</strong> (Article 21): Contact us to opt out of specific processing
               </li>
               <li>
-                <strong>Withdraw consent</strong> (Article 7) — Update your privacy settings or
+                <strong>Withdraw consent</strong> (Article 7): Update your privacy settings or
                 delete your account at any time
               </li>
             </ul>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -268,7 +268,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               ariaLabel="Select team"
               value={teamId}
               options={[
-                { value: '', label: 'No team — visible to everyone' },
+                { value: '', label: 'No team: visible to everyone' },
                 ...teams.map((t) => ({ value: String(t.id), label: t.name })),
               ]}
               onChange={setTeamId}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -452,7 +452,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
                           tabIndex={0}
                           onKeyDown={(e) => e.key === 'Enter' && setCompletedOpen((o) => !o)}
                         >
-                          {g.label} — {g.total} project
+                          {g.label}: {g.total} project
                           {g.total !== 1 ? 's' : ''}
                           <svg
                             className={`text-text-light shrink-0 transition-transform ${completedOpen ? 'rotate-180' : 'rotate-0'}`}
@@ -470,7 +470,7 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
                         </h2>
                       ) : (
                         <h2 className={`text-lg mb-1 ${g.color}`}>
-                          {g.label} — {g.total} project
+                          {g.label}: {g.total} project
                           {g.total !== 1 ? 's' : ''}
                         </h2>
                       )}

--- a/app/quick-tasks/page.tsx
+++ b/app/quick-tasks/page.tsx
@@ -79,7 +79,7 @@ const RATING_LABELS: Record<string, string> = {
 
 const STATUS_LABELS: Record<string, string> = {
   in_progress: 'Assigned',
-  under_review: 'Submitted — awaiting review',
+  under_review: 'Submitted, awaiting review',
   completed: 'Completed',
 }
 
@@ -261,7 +261,7 @@ function VolunteerQuickTasksView() {
 
         <h2 className="mt-8">Browse Quick Tasks</h2>
         <p className="text-text-light mb-6">
-          Open tasks to pick up right now — no need to browse projects first.
+          Open tasks to pick up right now, no need to browse projects first.
         </p>
 
         {loadingAvailable ? (
@@ -1082,10 +1082,10 @@ function AdminQuickTasksView() {
                         <span>
                           <strong>{RATING_LABELS[r]}</strong>
                           {r === 'excellent'
-                            ? ' — Exceeded expectations'
+                            ? ': Exceeded expectations'
                             : r === 'good'
-                              ? ' — Met expectations'
-                              : ' — Not quite there yet'}
+                              ? ': Met expectations'
+                              : ': Not quite there yet'}
                         </span>
                       </label>
                     ))}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -381,7 +381,7 @@ function SettingsPageContent() {
           </Button>
           <p className="text-sm text-text-light mt-3">
             Update your skills, contact details, or availability below, then resubmit when
-            you&apos;re ready — an admin will review your application again.
+            you&apos;re ready: an admin will review your application again.
           </p>
         </div>
       )}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -872,7 +872,7 @@ export default function SignupPage() {
                 }}
               />
               <p className="text-sm text-text-light mt-1">
-                Used for login and notifications. Not shown publicly — see contact settings below.
+                Used for login and notifications. Not shown publicly: see contact settings below.
               </p>
             </div>
 

--- a/app/suggest-local-group/page.tsx
+++ b/app/suggest-local-group/page.tsx
@@ -125,7 +125,7 @@ export default function SuggestLocalGroupPage() {
                   >
                     <div>
                       <p className="font-semibold m-0">
-                        {countryLabel(s.country)} — {s.name}
+                        {countryLabel(s.country)}, {s.name}
                         {s.mergedInto && (
                           <span className="text-text-light font-normal text-sm">
                             {' '}

--- a/app/teams/[id]/page.tsx
+++ b/app/teams/[id]/page.tsx
@@ -29,7 +29,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   const applyMutation = useMutation({
     ...orpc.teams.apply.mutationOptions(),
     onSuccess: () => {
-      showToast('Application submitted — a team leader will review it', 'success')
+      showToast('Application submitted, a team leader will review it', 'success')
       void invalidate()
     },
     onError: (err: unknown) => {

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -20,7 +20,7 @@ export default function TeamsPage() {
   const applyMutation = useMutation({
     ...orpc.teams.apply.mutationOptions(),
     onSuccess: () => {
-      showToast('Application submitted — a team leader will review it', 'success')
+      showToast('Application submitted, a team leader will review it', 'success')
       void invalidate()
     },
     onError: (err: unknown) => {
@@ -52,7 +52,7 @@ export default function TeamsPage() {
         </Link>
       </div>
       <p className="text-text-light mb-6">
-        Teams are standing groups of volunteers with a recurring meeting and shared doc — apply to
+        Teams are standing groups of volunteers with a recurring meeting and shared doc, apply to
         join any number of teams alongside your local group. A team leader reviews applications.
       </p>
 

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -56,7 +56,7 @@ function VerifyEmailContent() {
       <div className="bg-surface rounded-xl shadow p-8 text-center">
         <h1>Email confirmed!</h1>
         <p className="text-text-light mt-4 mb-6">
-          Your email address has been confirmed. Your application is now under review — we&#39;ll
+          Your email address has been confirmed. Your application is now under review, we&#39;ll
           notify you by email once it&#39;s been assessed.
         </p>
         <p className="text-text-light mb-6">In the meantime, you can browse available projects.</p>

--- a/components/BugReportDialog.tsx
+++ b/components/BugReportDialog.tsx
@@ -6,6 +6,7 @@ import { useMutation } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import FilterDropdown, { useFilterOptions } from '@/components/FilterDropdown'
 import { orpc } from '@/lib/orpc'
+import { useFocusTrap } from '@/lib/hooks/useFocusTrap'
 
 interface BugReportDialogProps {
   isOpen: boolean
@@ -29,10 +30,10 @@ export default function BugReportDialog({ isOpen, onClose }: BugReportDialogProp
     options: severityOptions,
   } = useFilterOptions(
     [
-      { value: 'low', label: 'Low — minor inconvenience' },
-      { value: 'medium', label: 'Medium — affects workflow' },
-      { value: 'high', label: 'High — blocking' },
-      { value: 'critical', label: 'Critical — site is broken' },
+      { value: 'low', label: 'Low: minor inconvenience' },
+      { value: 'medium', label: 'Medium: affects workflow' },
+      { value: 'high', label: 'High: blocking' },
+      { value: 'critical', label: 'Critical: site is broken' },
     ],
     'medium',
   )
@@ -85,6 +86,8 @@ export default function BugReportDialog({ isOpen, onClose }: BugReportDialogProp
     )
   }
 
+  const trapRef = useFocusTrap(isOpen)
+
   if (!isOpen) return null
 
   return (
@@ -93,6 +96,7 @@ export default function BugReportDialog({ isOpen, onClose }: BugReportDialogProp
       onClick={handleClose}
     >
       <div
+        ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label="Report an Issue"

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -321,7 +321,7 @@ export default function ProjectForm({
           ariaLabel="Select team"
           value={teamId}
           options={[
-            { value: '', label: 'No team — visible to everyone' },
+            { value: '', label: 'No team: visible to everyone' },
             ...teams.map((t) => ({ value: String(t.id), label: t.name })),
           ]}
           onChange={setTeamId}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import Button from '@/components/Button'
+import { useFocusTrap } from '@/lib/hooks/useFocusTrap'
 
 interface ModalProps {
   id: string
@@ -21,6 +22,8 @@ export default function Modal({ id, title, children, isOpen, onClose }: ModalPro
     return () => document.removeEventListener('keydown', handler)
   }, [isOpen, onClose])
 
+  const trapRef = useFocusTrap(isOpen)
+
   if (!isOpen) return null
 
   return (
@@ -29,6 +32,7 @@ export default function Modal({ id, title, children, isOpen, onClose }: ModalPro
       onClick={onClose}
     >
       <div
+        ref={trapRef}
         id={id}
         className="bg-surface max-h-[90vh] w-full max-w-md overflow-y-auto rounded-lg p-6 shadow-lg"
         role="dialog"

--- a/e2e/actions/bugs.ts
+++ b/e2e/actions/bugs.ts
@@ -2,10 +2,10 @@ import { Page, expect } from '@playwright/test'
 import { selectFilterDropdown } from './ui'
 
 const SEVERITY_LABELS: Record<string, string> = {
-  low: 'Low — minor inconvenience',
-  medium: 'Medium — affects workflow',
-  high: 'High — blocking',
-  critical: 'Critical — site is broken',
+  low: 'Low: minor inconvenience',
+  medium: 'Medium: affects workflow',
+  high: 'High: blocking',
+  critical: 'Critical: site is broken',
 }
 
 export async function openBugReportForm(page: Page): Promise<void> {

--- a/e2e/tests/05-volunteer-profile.spec.ts
+++ b/e2e/tests/05-volunteer-profile.spec.ts
@@ -247,7 +247,7 @@ test.describe('Volunteer Profile', () => {
     await selectFilterDropdown(
       volunteer.page,
       'Select local group',
-      "None of these — I'll enter my city",
+      "None of these, I'll enter my city",
     )
     await expect(volunteer.page.getByLabel('City / Area')).toBeVisible({ timeout: 5_000 })
 

--- a/e2e/tests/19-local-group-suggestions.spec.ts
+++ b/e2e/tests/19-local-group-suggestions.spec.ts
@@ -146,7 +146,7 @@ test.describe('Local Group Suggestions', () => {
     await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'merge', {
-      mergeTarget: 'United Kingdom — London',
+      mergeTarget: 'United Kingdom, London',
     })
 
     await expect(getAlert(adminPage)).toContainText('merged', { timeout: 10_000 })

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -116,7 +116,7 @@ export async function sendWelcomeAndConfirmEmail({
   const confirmUrl = `${env.APP_URL}/verify-email?token=${token}`
   return sendEmail(
     to,
-    'Welcome to Catalyse — please confirm your email',
+    'Welcome to Catalyse: please confirm your email',
     buildWelcomeAndConfirmHtml(name, confirmUrl),
   )
 }
@@ -686,9 +686,9 @@ export function buildTaskNudgeHtml(
   <h2>How's it going?</h2>
   <p>Hi ${n},</p>
   <p>It's been ${daysInactive} days since ${activityPhrase} <strong>${tt}</strong> in the project <strong>${pt}</strong> (on ${lastActivityDate}).</p>
-  <p>Could you leave a quick comment with a progress update? Even a brief note — like "ticking along, awaiting XYZ, will post another update in 2 weeks" — is really helpful so the project team knows things are in good hands.</p>
+  <p>Could you leave a quick comment with a progress update? Even a brief note, like "ticking along, awaiting XYZ, will post another update in 2 weeks", is really helpful so the project team knows things are in good hands.</p>
   <p>If you don't have capacity for the task right now, it's much better to update the project page with an ETA than for the team not to know what's happening.</p>
-  <p>We'll send another reminder in a week if we haven't heard from you — it's important that things move along smoothly so everyone can make progress.</p>
+  <p>We'll send another reminder in a week if we haven't heard from you, it's important that things move along smoothly so everyone can make progress.</p>
   <p style="text-align: center; margin: 32px 0;"><a href="${taskUrl}" class="button">Leave an update</a></p>
   <p>If you can no longer work on this task, please release it so someone else can pick it up.</p>
   <p>If you need support, please contact your project owner or admin.</p>
@@ -760,7 +760,7 @@ export function buildTaskFinalWarningHtml(
   <div class="warning">
     <strong>If there is no update by ${surrenderDate}, we'll open the task to other contributors</strong> so the project can keep moving forward.
   </div>
-  <p>Even a quick note is fine — anything to let the project team know you're still on it. If life has got busy, no worries at all, but it would really help to either leave an update or release the task so someone else can step in.</p>
+  <p>Even a quick note is fine: anything to let the project team know you're still on it. If life has got busy, no worries at all, but it would really help to either leave an update or release the task so someone else can step in.</p>
   <p style="text-align: center; margin: 32px 0;"><a href="${taskUrl}" class="button">Leave an update</a></p>
   <p>If you need support, please contact your project owner or a platform admin.</p>
   ${footer([['Leave an update', taskUrl]])}
@@ -870,7 +870,7 @@ export function buildTaskSurrenderedAssigneeHtml(
   <h2>Task now open to other contributors</h2>
   <p>Hi ${n},</p>
   <p>Because we haven't received updates from you on the task <strong>${tt}</strong> in <strong>${pt}</strong> for four weeks, we've opened the task to other contributors and removed you from it.</p>
-  <p>We hope things are going well — if you'd still like to contribute, you're always welcome to claim the task again or pick up something else on the project.</p>
+  <p>We hope things are going well, if you'd still like to contribute, you're always welcome to claim the task again or pick up something else on the project.</p>
   <p style="text-align: center; margin: 32px 0;"><a href="${projectUrl}" class="button">View Project</a></p>
   <p>If you need support, please contact your project owner or a platform admin.</p>
   ${footer([['View Project', projectUrl]])}

--- a/lib/filter-options.ts
+++ b/lib/filter-options.ts
@@ -73,7 +73,7 @@ export function buildLocalGroupOptionsForCountry(
   return [
     { value: '', label: 'Select…' },
     ...countryGroups.map((g) => ({ value: g.name, label: g.name })),
-    { value: NO_LOCAL_GROUP, label: "None of these — I'll enter my city" },
+    { value: NO_LOCAL_GROUP, label: "None of these, I'll enter my city" },
   ]
 }
 

--- a/lib/hooks/useFocusTrap.ts
+++ b/lib/hooks/useFocusTrap.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/** Traps Tab focus within the container while `isOpen`, and restores focus to the trigger on close. */
+export function useFocusTrap(isOpen: boolean) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<Element | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    triggerRef.current = document.activeElement
+    const container = containerRef.current
+    const focusable = container?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    focusable?.[0]?.focus()
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !container) return
+      const focusableEls = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      if (focusableEls.length === 0) return
+      const first = focusableEls[0]
+      const last = focusableEls[focusableEls.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => {
+      document.removeEventListener('keydown', handler)
+      if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus()
+    }
+  }, [isOpen])
+
+  return containerRef
+}

--- a/server/routers/admin/emailPreview.ts
+++ b/server/routers/admin/emailPreview.ts
@@ -55,7 +55,7 @@ const EMAIL_PREVIEW_REGISTRY: Record<string, { subject: string; build: () => str
     build: () => buildWelcomeHtml('Alex', APP_URL),
   },
   'welcome-and-confirm': {
-    subject: 'Welcome to Catalyse — please confirm your email',
+    subject: 'Welcome to Catalyse: please confirm your email',
     build: () =>
       buildWelcomeAndConfirmHtml('Alex', `${APP_URL}/verify-email?token=sample-token-abc123`),
   },
@@ -95,7 +95,7 @@ const EMAIL_PREVIEW_REGISTRY: Record<string, { subject: string; build: () => str
       buildProjectNotificationHtml(
         'Alex',
         'Your project has been approved',
-        'Great news — your project AI Safety Explainer Series has been reviewed and approved.',
+        'Great news: your project AI Safety Explainer Series has been reviewed and approved.',
         1,
         APP_URL,
       ),

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -729,7 +729,7 @@ export const authRouter = {
         const googleUser = await verifyGoogleToken(input.credential ?? '')
         if (!googleUser)
           throw new ORPCError('UNAUTHORIZED', {
-            message: 'Your Google sign-in has expired — please sign in with Google again',
+            message: 'Your Google sign-in has expired, please sign in with Google again',
           })
         ;({ email, name } = googleUser)
       }

--- a/server/routers/localGroupSuggestions.ts
+++ b/server/routers/localGroupSuggestions.ts
@@ -44,7 +44,7 @@ export const localGroupSuggestionsRouter = {
 
       await notifyAdmins(
         'local_group_suggestion',
-        `New local group suggestion: ${input.country} — ${input.name}`,
+        `New local group suggestion: ${input.country}, ${input.name}`,
         null,
         '/admin/local-groups',
         undefined,

--- a/server/routers/teams.ts
+++ b/server/routers/teams.ts
@@ -174,7 +174,7 @@ export const teamsRouter = {
         },
       })
       if (existingRequest) {
-        throw new ORPCError('BAD_REQUEST', { message: 'Already applied — awaiting review' })
+        throw new ORPCError('BAD_REQUEST', { message: 'Already applied, awaiting review' })
       }
 
       await prisma.teamJoinRequest.create({


### PR DESCRIPTION
## Summary
- Adds a shared `useFocusTrap` hook, wired into `Modal.tsx` and `BugReportDialog.tsx`, so keyboard users can no longer tab out of an open dialog into the background page
- Adds a skip-to-content link and a `<main id="main-content">` landmark in the root layout so keyboard users can bypass the header nav
- Sweeps em dashes out of user-facing copy (UI text, toasts, error messages, notifications, email templates), replacing with commas or colons as appropriate, with matching e2e fixture/assertion updates

Closes #131
Closes #132

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite) passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McggDx77Jhgc7RWhofWVHK