### PR TITLE
Add error/not-found pages, contact visibility copy, and e2e coverage gaps

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+import Button from '@/components/Button'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <main className="container py-5 pb-15">
+      <div className="max-w-[400px] my-15 mx-auto text-center">
+        <h1>Something Went Wrong</h1>
+        <p className="text-text-light mb-8">
+          An unexpected error occurred. You can try again, or head back home.
+        </p>
+        <div className="flex flex-col gap-3 items-center">
+          <Button onClick={reset}>Try Again</Button>
+          <Button href="/" variant="outline">
+            Go Home
+          </Button>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import Button from '@/components/Button'
+
+export default function NotFound() {
+  return (
+    <main className="container py-5 pb-15">
+      <div className="max-w-[400px] my-15 mx-auto text-center">
+        <h1>Page Not Found</h1>
+        <p className="text-text-light mb-8">
+          The page you&apos;re looking for doesn&apos;t exist or may have moved.
+        </p>
+        <div className="flex flex-col gap-3 items-center">
+          <Button href="/">Go Home</Button>
+          <Link href="/projects" className="text-sm">
+            Browse Projects
+          </Link>
+          <Link href="/dashboard" className="text-sm">
+            Go to Dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -429,6 +429,10 @@ function SettingsPageContent() {
           </div>
 
           <h3 className="mt-6 mb-4">Contact Information</h3>
+          <aside className="bg-brand-bg border border-brand-border rounded-lg px-4 py-3 mb-4 text-sm text-text-light">
+            Always visible to you and admins. Shared with other volunteers and project owners only
+            if you enable both consent checkboxes in the Privacy &amp; Data tab.
+          </aside>
           <div className="grid grid-cols-2 gap-5 mb-5 max-sm:grid-cols-1">
             <div>
               <label htmlFor="discord_handle">Discord Handle</label>

--- a/e2e/tests/30-project-edit-regression.spec.ts
+++ b/e2e/tests/30-project-edit-regression.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, getAlert } from '../fixtures'
+import { proposeProject, adminApproveProject, transferProjectOwnership } from '../actions/projects'
+import { Page } from '@playwright/test'
+import { fake } from '../fake'
+
+// Regression coverage for bug 12 (checkbox-only edit wiping the save) and bug 13 (tasks wiped
+// on unrelated project edits). See TODO #141/#143/#144.
+
+async function setupOwnedProject(
+  baseUrl: string,
+  adminPage: Page,
+  volunteer: { page: Page; name: string },
+): Promise<number> {
+  const title = fake.projectTitle()
+  const projectId = await proposeProject(
+    baseUrl,
+    volunteer.page,
+    title,
+    'Setup description for edit regression tests',
+  )
+  await adminApproveProject(baseUrl, adminPage, title)
+  await transferProjectOwnership(baseUrl, adminPage, projectId, volunteer.name)
+  return projectId
+}
+
+test.describe('Project Edit Regressions', () => {
+  test('Toggling only the seeking-help checkbox persists on reload (bug 12)', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupOwnedProject(baseUrl, adminPage, volunteer)
+
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}/edit`)
+    await expect(volunteer.page.getByRole('heading', { name: 'Edit Project' })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    const checkbox = volunteer.page.getByLabel('Help / contributors')
+    const wasChecked = await checkbox.isChecked()
+
+    // The visible box is a decorative sibling of the sr-only input, so a plain click on
+    // the input is reported as intercepted even though the label's native click still works.
+    await checkbox.click({ force: true })
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await volunteer.page.waitForURL(`${baseUrl}/projects/${projectId}`, { timeout: 15_000 })
+
+    const badge = volunteer.page.getByText('Seeking Help')
+    if (wasChecked) {
+      await expect(badge).toBeHidden({ timeout: 10_000 })
+    } else {
+      await expect(badge).toBeVisible({ timeout: 10_000 })
+    }
+
+    // Reload to rule out stale client state masking a save that didn't actually persist.
+    await volunteer.page.reload()
+    if (wasChecked) {
+      await expect(badge).toBeHidden({ timeout: 10_000 })
+    } else {
+      await expect(badge).toBeVisible({ timeout: 10_000 })
+    }
+  })
+
+  test('Tasks survive an unrelated project field edit (bug 13)', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await setupOwnedProject(baseUrl, adminPage, volunteer)
+    const taskTitle = `regression task ${Date.now()}`
+
+    // Add a task on the project detail page.
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.getByRole('button', { name: 'Add Task' }).click()
+    await volunteer.page.getByLabel('Task title').fill(taskTitle)
+    await volunteer.page.getByRole('button', { name: 'Create Task' }).click()
+    await expect(getAlert(volunteer.page)).toContainText('Task added!', { timeout: 10_000 })
+    await expect(volunteer.page.getByText(taskTitle)).toBeVisible({ timeout: 10_000 })
+
+    // Edit and save an unrelated project field.
+    const newDescription = 'Updated description that should not touch the task list'
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}/edit`)
+    await expect(volunteer.page.getByRole('heading', { name: 'Edit Project' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await volunteer.page.getByLabel('Description').fill(newDescription)
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await volunteer.page.waitForURL(`${baseUrl}/projects/${projectId}`, { timeout: 15_000 })
+
+    // Task must still be there, both immediately and after a reload.
+    await expect(volunteer.page.getByText(taskTitle)).toBeVisible({ timeout: 10_000 })
+    await volunteer.page.reload()
+    await expect(volunteer.page.getByText(taskTitle)).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/e2e/tests/31-password-reset.spec.ts
+++ b/e2e/tests/31-password-reset.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, getAlert } from '../fixtures'
+import { login } from '../actions/auth'
+import { createApiClient } from '../client'
+import { fake } from '../fake'
+
+test.describe('Password Reset', () => {
+  test('Volunteer resets their password via the emailed link and logs in with it', async ({
+    browser,
+    volunteer,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/forgot-password`)
+      await page.getByLabel('Email').fill(volunteer.email)
+
+      const [response] = await Promise.all([
+        page.waitForResponse((resp) => resp.url().includes('/api/rpc/auth/forgotPassword')),
+        page.getByRole('button', { name: 'Send Reset Link' }).click(),
+      ])
+      const { json } = await response.json()
+      const devResetUrl = json._devResetUrl as string
+      expect(devResetUrl).toBeTruthy()
+
+      await expect(page.getByRole('heading', { name: 'Check Your Email' })).toBeVisible({
+        timeout: 10_000,
+      })
+
+      const newPassword = 'newtestpassword2'
+      await page.goto(`${baseUrl}${devResetUrl}`)
+      await expect(page.getByRole('heading', { name: 'Set New Password' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await page.getByLabel('New Password').fill(newPassword)
+      await page.getByLabel('Confirm Password').fill(newPassword)
+      await page.getByRole('button', { name: 'Reset Password' }).click()
+      await page.waitForURL(`${baseUrl}/login`, { timeout: 15_000 })
+
+      await login(baseUrl, page, volunteer.email, newPassword)
+      await expect(page).toHaveURL(`${baseUrl}/dashboard`)
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('Reset fails with a mismatched password confirmation', async ({ browser, baseUrl }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/reset-password?token=irrelevant-for-this-check`)
+      await expect(page.getByRole('heading', { name: 'Set New Password' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await page.getByLabel('New Password').fill('testpassword1')
+      await page.getByLabel('Confirm Password').fill('differentpassword1')
+      await page.getByRole('button', { name: 'Reset Password' }).click()
+      await expect(page.getByText('Passwords do not match')).toBeVisible({ timeout: 10_000 })
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('An invalid or expired reset token shows an error and lets the user request a new link', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/reset-password?token=not-a-real-token`)
+      await page.getByLabel('New Password').fill('testpassword1')
+      await page.getByLabel('Confirm Password').fill('testpassword1')
+      await page.getByRole('button', { name: 'Reset Password' }).click()
+      await expect(getAlert(page)).toContainText('Invalid or expired reset token', {
+        timeout: 10_000,
+      })
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('Visiting the reset page without a token shows an invalid link message', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/reset-password`)
+      await expect(page.getByRole('heading', { name: 'Invalid Link' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await page.getByRole('link', { name: 'Request New Link' }).click()
+      await page.waitForURL(`${baseUrl}/forgot-password`)
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('Forgot-password does not reveal whether an email is registered', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/forgot-password`)
+      await page.getByLabel('Email').fill(fake.uniqueEmail())
+      await page.getByRole('button', { name: 'Send Reset Link' }).click()
+      await expect(page.getByRole('heading', { name: 'Check Your Email' })).toBeVisible({
+        timeout: 10_000,
+      })
+    } finally {
+      await context.close()
+    }
+  })
+})
+
+test.describe('Password Reset (API)', () => {
+  test('A used reset token cannot be reused', async ({ volunteer, baseUrl }) => {
+    const api = createApiClient(baseUrl)
+    const forgot = await api.auth.forgotPassword({ body: { email: volunteer.email } })
+    expect(forgot.status).toBe(200)
+    const token = (forgot.body as { _devResetToken?: string })._devResetToken
+    expect(token).toBeTruthy()
+
+    const first = await api.auth.resetPassword({
+      body: { token: token!, newPassword: 'anothernewpassword1' },
+    })
+    expect(first.status).toBe(200)
+
+    const second = await api.auth.resetPassword({
+      body: { token: token!, newPassword: 'yetanotherpassword1' },
+    })
+    expect(second.status).toBe(400)
+  })
+})

--- a/e2e/tests/32-admin-stats-and-platform-settings.spec.ts
+++ b/e2e/tests/32-admin-stats-and-platform-settings.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../fixtures'
+import { createApiClient } from '../client'
+
+test.describe('Admin Landing Page Stats', () => {
+  test('Admin landing page shows volunteer/project/interest stat tiles and admin nav groups', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    await adminPage.goto(`${baseUrl}/admin`)
+    await expect(adminPage.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+
+    await expect(adminPage.getByRole('heading', { name: 'Volunteers' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(adminPage.getByText('Total Registered')).toBeVisible()
+    await expect(adminPage.getByText('Joined This Month')).toBeVisible()
+
+    await expect(adminPage.getByText('Seeking Help')).toBeVisible()
+    await expect(adminPage.getByText('In Progress')).toBeVisible()
+    await expect(adminPage.getByText('Completed')).toBeVisible()
+
+    await expect(adminPage.getByRole('heading', { name: 'Volunteer Interest' })).toBeVisible()
+    await expect(adminPage.getByText('Total Interests')).toBeVisible()
+    await expect(adminPage.getByText('Pending Response')).toBeVisible()
+
+    await expect(adminPage.getByRole('link', { name: 'Manage Applications' })).toBeVisible()
+    await expect(adminPage.getByRole('link', { name: 'Triage Queue' })).toBeVisible()
+    await expect(adminPage.getByRole('link', { name: 'Platform Settings' })).toBeVisible()
+  })
+
+  test('A non-admin visiting /admin is redirected away', async ({ volunteer, baseUrl }) => {
+    await volunteer.page.goto(`${baseUrl}/admin`)
+    await expect(volunteer.page).not.toHaveURL(`${baseUrl}/admin`, { timeout: 10_000 })
+  })
+})
+
+test.describe('Admin Platform Settings', () => {
+  test('Super admin toggles application approval requirement and it persists on reload', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    await adminPage.goto(`${baseUrl}/admin/platform-settings`)
+    await expect(adminPage.getByRole('heading', { name: 'Platform Settings' })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    const toggle = adminPage.getByRole('checkbox')
+    await expect(toggle).toBeVisible({ timeout: 10_000 })
+    const wasChecked = await toggle.isChecked()
+
+    // The visible switch is a decorative sibling of the sr-only input, so a plain click on
+    // the input is reported as intercepted even though the label's native click still works.
+    await toggle.click({ force: true })
+    await expect(adminPage.getByText('Settings saved')).toBeVisible({ timeout: 10_000 })
+    await expect(toggle).toBeChecked({ checked: !wasChecked })
+
+    await adminPage.reload()
+    await expect(adminPage.getByRole('checkbox')).toBeChecked({
+      checked: !wasChecked,
+      timeout: 10_000,
+    })
+
+    // Restore original state so this test doesn't leak into others that assume approval is on.
+    await adminPage.getByRole('checkbox').click({ force: true })
+    await expect(adminPage.getByText('Settings saved')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('A plain admin (not super admin) cannot access platform settings', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    // Make the volunteer a plain (non-super) admin via the invite flow — accepting an
+    // admin invite grants isAdmin without isSuperAdmin, which is keyed off ADMIN_EMAILS.
+    // Navigate first: a brand new page is about:blank, and localStorage is inaccessible there.
+    await adminPage.goto(`${baseUrl}/dashboard`)
+    const adminToken = await adminPage.evaluate(() => localStorage.getItem('authToken'))
+    const inviteResult = await createApiClient(baseUrl, adminToken).admin.admins.invite({
+      body: { email: volunteer.email },
+    })
+    expect(inviteResult.status).toBe(200)
+    const inviteToken = (inviteResult.body as { _dev_invite_token?: string })._dev_invite_token
+    expect(inviteToken).toBeTruthy()
+
+    await volunteer.page.goto(`${baseUrl}/dashboard`)
+    const volunteerToken = await volunteer.page.evaluate(() => localStorage.getItem('authToken'))
+    const acceptResult = await createApiClient(baseUrl, volunteerToken).admin.admins.acceptInvite({
+      body: { inviteToken: inviteToken! },
+    })
+    expect(acceptResult.status).toBe(200)
+
+    await volunteer.page.goto(`${baseUrl}/admin/platform-settings`)
+    await expect(volunteer.page).not.toHaveURL(`${baseUrl}/admin/platform-settings`, {
+      timeout: 10_000,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add branded `app/error.tsx` and `app/not-found.tsx` (Closes #103)
- Explain contact-field visibility on the settings page, matching the actual sharing logic in `server/routers/volunteers.ts` (Closes #117)
- Add e2e regression coverage for checkbox-only project edits (bug 12) (Closes #143) and task persistence across unrelated project edits (bug 13) (Closes #144)
- Additional e2e gaps discovered and closed while auditing #141: password reset flow, admin landing page stats, and admin platform settings (including the super-admin-only gate)

## Test plan
- [x] `npm run check-all` equivalents run individually: typecheck, lint, format all pass
- [x] New/changed e2e specs run directly and pass (12/12): `30-project-edit-regression.spec.ts`, `31-password-reset.spec.ts`, `32-admin-stats-and-platform-settings.spec.ts`
- [ ] Full `npm run check-all` / full e2e suite not run in this session — worth a CI pass before merge

Closes #103
Closes #117
Closes #143
Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McggDx77Jhgc7RWhofWVHK