### PR TITLE
Security sweep: auth, access control, email injection, transport hardening

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -43,7 +43,7 @@ export default function SettingsPage() {
 }
 
 function SettingsPageContent() {
-  const { user, loading, refreshUser, logout } = useRequireAuth()
+  const { user, loading, refreshUser, logout, setToken } = useRequireAuth()
   const showToast = useToast()
   const queryClient = useQueryClient()
 
@@ -209,7 +209,10 @@ function SettingsPageContent() {
 
   const changePasswordMutation = useMutation({
     ...orpc.auth.changePassword.mutationOptions(),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
+      // The server rotates the session token on a password change; adopt the new one
+      // so this tab stays signed in.
+      await setToken(data.token)
       showToast(data.message, 'success')
       setCurrentPassword('')
       setNewPassword('')

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -77,6 +77,9 @@ function startWorkerNextJs(parallelIndex: number): number {
       STUB_EMAIL: 'true',
       STUB_GOOGLE: 'true',
       DISABLE_RATE_LIMIT: 'true',
+      // These stubs are refused in a production deployment (lib/env.ts); mark this
+      // production build as the test harness so startup validation lets them through.
+      E2E: '1',
     },
     cwd: PROJECT_ROOT,
     detached: false,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -30,14 +30,26 @@ export function generateAuthToken(): string {
   return randomBytes(32).toString('base64url')
 }
 
+// Sessions expire 30 days after the token was issued. Every write of `authToken`
+// must set `authTokenExpiresAt` alongside it — a null expiry means "never expires",
+// which is what getCurrentVolunteer falls back to for pre-existing rows.
+export const AUTH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+export function authTokenExpiry(): Date {
+  return new Date(Date.now() + AUTH_TOKEN_TTL_MS)
+}
+
 export async function getCurrentVolunteer(authorization: string | null | undefined) {
   if (!authorization) return null
   const token = authorization.startsWith('Bearer ') ? authorization.slice(7) : authorization
+  // A null expiry is treated as expired, not as "never expires" — every code path that
+  // issues a token sets one (see authTokenExpiry), and the backfill migration gave
+  // pre-existing sessions an expiry too.
   return prisma.volunteer.findFirst({
     where: {
       authToken: token,
       deletedAt: null,
-      OR: [{ authTokenExpiresAt: null }, { authTokenExpiresAt: { gt: new Date() } }],
+      authTokenExpiresAt: { gt: new Date() },
     },
   })
 }

--- a/lib/cron-auth.ts
+++ b/lib/cron-auth.ts
@@ -1,5 +1,14 @@
+import { timingSafeEqual } from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { env } from './env'
+
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  // timingSafeEqual throws on a length mismatch, which would itself leak the length.
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
 
 export function checkCronAuth(request: NextRequest): NextResponse | null {
   const secret = env.CRON_SECRET
@@ -8,7 +17,7 @@ export function checkCronAuth(request: NextRequest): NextResponse | null {
     return NextResponse.json({ error: 'Cron not configured' }, { status: 500 })
   }
   const auth = request.headers.get('authorization')
-  if (auth !== `Bearer ${secret}`) {
+  if (!auth || !secretsMatch(auth, `Bearer ${secret}`)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   return null

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -10,6 +10,34 @@ function escapeHtml(s: string): string {
     .replace(/'/g, '&#39;')
 }
 
+/**
+ * Marks a string as already-safe HTML so `html` won't escape it again — for fragments
+ * this module (or a caller) has itself built out of escaped pieces.
+ */
+class SafeHtml {
+  constructor(readonly value: string) {}
+}
+
+export function rawHtml(value: string): SafeHtml {
+  return new SafeHtml(value)
+}
+
+/**
+ * Tagged template for the HTML bodies passed to notifyUser/notifyAdmins as `message`
+ * and `extraHtml`. Every interpolated value is escaped, so volunteer names, project
+ * titles and free-text messages can't inject markup into an email we send. Wrap a
+ * deliberate fragment in `rawHtml()` to opt out.
+ */
+export function html(strings: TemplateStringsArray, ...values: unknown[]): string {
+  let out = strings[0]
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i]
+    out += v instanceof SafeHtml ? v.value : escapeHtml(String(v ?? ''))
+    out += strings[i + 1]
+  }
+  return out
+}
+
 const resend = env.RESEND_API_KEY ? new Resend(env.RESEND_API_KEY) : null
 
 export function isEmailConfigured(): boolean {
@@ -74,7 +102,7 @@ function footer(buttons: Array<[string, string]> = []): string {
   const fallbacks = buttons
     .map(
       ([label, url]) =>
-        `<p style="font-size: 12px;">If the "${label}" button doesn't work, copy this link: <a href="${url}" style="color: #718096; word-break: break-all;">${url}</a></p>`,
+        `<p style="font-size: 12px;">If the "${escapeHtml(label)}" button doesn't work, copy this link: <a href="${escapeHtml(url)}" style="color: #718096; word-break: break-all;">${escapeHtml(url)}</a></p>`,
     )
     .join('')
   return `<div class="footer">
@@ -412,7 +440,7 @@ export function buildProjectNotificationHtml(
   const n = escapeHtml(name)
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
 <body><div class="container">
-  <h2>${subject}</h2>
+  <h2>${escapeHtml(subject)}</h2>
   <p>Hi ${n},</p>
   <p>${message}</p>
   ${extraHtml}
@@ -433,11 +461,11 @@ export function buildAdminAlertHtml(
   const n = escapeHtml(name)
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${baseStyle}</style></head>
 <body><div class="container">
-  <h2>${subject}</h2>
+  <h2>${escapeHtml(subject)}</h2>
   <p>Hi ${n},</p>
   <p>${message}</p>
   <p style="text-align: center; margin: 32px 0;">
-    <a href="${ctaUrl}" class="button">${ctaLabel}</a>
+    <a href="${escapeHtml(ctaUrl)}" class="button">${escapeHtml(ctaLabel)}</a>
   </p>
   ${footer([[ctaLabel, ctaUrl]])}
 </div></body></html>`

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -27,6 +27,9 @@ export function validateEnv(): void {
   // Railway PR deployments run as NODE_ENV=production but aren't the live environment
   if (process.env.RAILWAY_ENVIRONMENT_NAME && process.env.RAILWAY_ENVIRONMENT_NAME !== 'production')
     return
+  // The e2e harness serves a production build locally with the stub flags on (see
+  // e2e/global-setup.ts); it is not a deployment and must not be held to these rules.
+  if (process.env.E2E === '1') return
 
   const errors: EnvError[] = []
 
@@ -38,11 +41,23 @@ export function validateEnv(): void {
     errors.push({ var: 'CRON_SECRET', reason: 'required to authenticate cron endpoints' })
   }
 
-  if (!env.STUB_EMAIL && !env.RESEND_API_KEY) {
-    errors.push({
-      var: 'RESEND_API_KEY',
-      reason: 'required to send emails (or set STUB_EMAIL=true)',
-    })
+  if (!env.RESEND_API_KEY) {
+    errors.push({ var: 'RESEND_API_KEY', reason: 'required to send emails' })
+  }
+
+  // Development shortcuts that are unsafe in the live environment: STUB_GOOGLE accepts a
+  // sign-in for any email with no Google credential, STUB_EMAIL returns password-reset and
+  // invite tokens in API responses instead of mailing them, and DISABLE_RATE_LIMIT turns
+  // off every limiter. Refuse to boot rather than run with any of them on.
+  const unsafeStubs: Array<[string, boolean]> = [
+    ['STUB_GOOGLE', env.STUB_GOOGLE],
+    ['STUB_EMAIL', env.STUB_EMAIL],
+    ['DISABLE_RATE_LIMIT', env.DISABLE_RATE_LIMIT],
+  ]
+  for (const [name, enabled] of unsafeStubs) {
+    if (enabled) {
+      errors.push({ var: name, reason: 'development-only flag, must be off in production' })
+    }
   }
 
   const b2Vars = ['B2_KEY_ID', 'B2_APP_KEY', 'B2_BUCKET_NAME'] as const

--- a/lib/google-auth.ts
+++ b/lib/google-auth.ts
@@ -1,0 +1,92 @@
+import { createPublicKey, createVerify, type JsonWebKey } from 'node:crypto'
+import { env } from './env'
+
+// Google ID tokens are verified locally: fetch Google's public keys, check the RS256
+// signature ourselves, then check the claims. The previous implementation POSTed the
+// credential to the deprecated /tokeninfo endpoint and trusted the JSON it got back,
+// which meant a network-level failure mode decided who was signed in, and `iss` was
+// never checked at all.
+
+const GOOGLE_JWKS_URL = 'https://www.googleapis.com/oauth2/v3/certs'
+const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com']
+const DEFAULT_JWKS_TTL_MS = 60 * 60 * 1000
+// Tolerance for clock skew between Google and this server, in seconds.
+const CLOCK_SKEW_S = 300
+
+type Jwk = { kid?: string; kty: string; alg?: string; n: string; e: string }
+
+let jwksCache: { keys: Jwk[]; expiresAt: number } | null = null
+
+async function googleSigningKeys(): Promise<Jwk[]> {
+  if (jwksCache && jwksCache.expiresAt > Date.now()) return jwksCache.keys
+
+  const res = await fetch(GOOGLE_JWKS_URL)
+  if (!res.ok) throw new Error(`Google JWKS fetch failed: ${res.status}`)
+  const { keys } = (await res.json()) as { keys?: Jwk[] }
+  if (!keys?.length) throw new Error('Google JWKS response contained no keys')
+
+  const maxAge = /max-age=(\d+)/.exec(res.headers.get('cache-control') ?? '')
+  const ttl = maxAge ? Number(maxAge[1]) * 1000 : DEFAULT_JWKS_TTL_MS
+  jwksCache = { keys, expiresAt: Date.now() + ttl }
+  return keys
+}
+
+type IdTokenClaims = {
+  iss?: string
+  aud?: string
+  exp?: number
+  iat?: number
+  email?: string
+  email_verified?: boolean | string
+  name?: string
+}
+
+function decodeSegment(segment: string): unknown {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'))
+}
+
+/**
+ * Returns the verified account, or null if the credential is missing, malformed,
+ * expired, signed by an unknown key, or issued for a different client.
+ */
+export async function verifyGoogleToken(
+  credential: string,
+): Promise<{ email: string; name: string } | null> {
+  const clientId = env.GOOGLE_CLIENT_ID
+  if (!clientId || !credential) return null
+
+  try {
+    const [headerB64, payloadB64, signatureB64, ...rest] = credential.split('.')
+    if (!headerB64 || !payloadB64 || !signatureB64 || rest.length > 0) return null
+
+    const header = decodeSegment(headerB64) as { alg?: string; kid?: string }
+    if (header.alg !== 'RS256' || !header.kid) return null
+
+    const jwk = (await googleSigningKeys()).find((k) => k.kid === header.kid)
+    if (!jwk) return null
+
+    const signatureValid = createVerify('RSA-SHA256')
+      .update(`${headerB64}.${payloadB64}`)
+      .verify(
+        createPublicKey({ key: jwk as JsonWebKey, format: 'jwk' }),
+        Buffer.from(signatureB64, 'base64url'),
+      )
+    if (!signatureValid) return null
+
+    const claims = decodeSegment(payloadB64) as IdTokenClaims
+    if (!claims.iss || !GOOGLE_ISSUERS.includes(claims.iss)) return null
+    if (claims.aud !== clientId) return null
+
+    const now = Math.floor(Date.now() / 1000)
+    if (typeof claims.exp !== 'number' || claims.exp <= now - CLOCK_SKEW_S) return null
+    if (typeof claims.iat === 'number' && claims.iat > now + CLOCK_SKEW_S) return null
+
+    // Google sends this as a boolean in the ID token; older docs show the string form.
+    if (claims.email_verified !== true && claims.email_verified !== 'true') return null
+    if (!claims.email) return null
+
+    return { email: claims.email, name: claims.name || claims.email.split('@')[0] }
+  } catch {
+    return null
+  }
+}

--- a/lib/hooks/url-filters.ts
+++ b/lib/hooks/url-filters.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 
 function useSetParam() {
   const searchParams = useSearchParams()
@@ -44,12 +44,18 @@ export function useUrlSearchInput(
   delayMs = 300,
 ): [string, (value: string) => void, string] {
   const searchParams = useSearchParams()
+  const pathname = usePathname()
   const urlValue = searchParams.get(key) ?? ''
   const [input, setInput] = useState(urlValue)
 
   useEffect(() => {
     if (input === urlValue) return
     const t = setTimeout(() => {
+      // Clicking a result navigates away; the timer is cleared on unmount, but the new
+      // route can commit before that cleanup runs. Writing a bare `?q=...` at that point
+      // resolves against whatever page is showing now and stamps the search onto it
+      // (/projects/39?q=...), so bail out once we've left the page this input belongs to.
+      if (window.location.pathname !== pathname) return
       const params = new URLSearchParams(searchParams.toString())
       if (input) params.set(key, input)
       else params.delete(key)
@@ -58,10 +64,10 @@ export function useUrlSearchInput(
       // the router's navigation queue — router.replace() here would otherwise race a
       // pending router.push() from clicking a result (e.g. a search result link clicked
       // just as the debounce fires) and silently cancel that navigation.
-      window.history.replaceState(null, '', `?${params.toString()}`)
+      window.history.replaceState(null, '', `${pathname}?${params.toString()}`)
     }, delayMs)
     return () => clearTimeout(t)
-  }, [input, searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [input, searchParams, pathname]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return [input, setInput, urlValue]
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -3,6 +3,36 @@ import { env } from './env'
 const store = new Map<string, number[]>()
 const DISABLED = env.DISABLE_RATE_LIMIT
 
+// The store is in-process, so it only limits the instance that took the request and it
+// resets on deploy. Good enough for slowing down guessing and spam; it is not a shared
+// quota. Entries are swept so a long-running instance doesn't accumulate one array per
+// IP seen, and MAX_KEYS caps the worst case if a flood outruns the sweep.
+const SWEEP_INTERVAL_MS = 10 * 60 * 1000
+const MAX_KEYS = 10_000
+let lastSweep = Date.now()
+
+function sweep(now: number, windowMs: number): void {
+  if (now - lastSweep < SWEEP_INTERVAL_MS && store.size < MAX_KEYS) return
+  lastSweep = now
+  const cutoff = now - windowMs
+  for (const [key, timestamps] of store) {
+    if (timestamps.every((t) => t <= cutoff)) store.delete(key)
+  }
+  // Still oversized after dropping everything stale (a flood of distinct IPs inside one
+  // window): drop the oldest entries rather than growing without bound.
+  if (store.size > MAX_KEYS) {
+    const excess = store.size - MAX_KEYS
+    let dropped = 0
+    for (const key of store.keys()) {
+      store.delete(key)
+      if (++dropped >= excess) break
+    }
+  }
+}
+
+// Trusts x-forwarded-for, which is only meaningful because the app is served behind a
+// proxy (Railway) that overwrites it. Reachable directly, this header is caller-supplied
+// and a client can rotate it to reset its own limit.
 function getClientIp(request: Request): string {
   return (
     request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
@@ -22,6 +52,7 @@ export function checkRateLimit(
 
   const now = Date.now()
   const cutoff = now - windowMs
+  sweep(now, windowMs)
 
   let timestamps = store.get(key) ?? []
   timestamps = timestamps.filter((t) => t > cutoff)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,40 @@
 import type { NextConfig } from 'next'
 
+// Google Sign-In loads its client script and renders its button in an iframe from
+// accounts.google.com; everything else is same-origin. 'unsafe-inline' stays in
+// script-src because Next.js injects inline bootstrap/flight scripts without a nonce —
+// the CSP still stops any third-party script host.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://accounts.google.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.googleusercontent.com",
+  "font-src 'self' data:",
+  "connect-src 'self' https://accounts.google.com",
+  "frame-src 'self' https://accounts.google.com",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "object-src 'none'",
+].join('; ')
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: CSP },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+]
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }]
+  },
+
   async redirects() {
     return [
       // Dynamic routes — id was a query param in the old HTML version

--- a/prisma/migrations/20260823210000_backfill_auth_token_expiry/migration.sql
+++ b/prisma/migrations/20260823210000_backfill_auth_token_expiry/migration.sql
@@ -1,0 +1,7 @@
+-- Sessions now expire: getCurrentVolunteer treats a NULL auth_token_expires_at as expired.
+-- Give every existing signed-in session 30 days from this migration rather than logging
+-- everyone out on deploy. Rows with no token are left alone.
+UPDATE "volunteers"
+SET "auth_token_expires_at" = (unixepoch() + 30 * 24 * 60 * 60) * 1000
+WHERE "auth_token" IS NOT NULL
+  AND "auth_token_expires_at" IS NULL;

--- a/server/routers/admin/admins.ts
+++ b/server/routers/admin/admins.ts
@@ -69,10 +69,11 @@ export const adminAdminsRouter = {
       include: { invitedBy: { select: { name: true } } },
       orderBy: { createdAt: 'desc' },
     })
+    // The token itself stays server-side: it is the credential in the invite link, and
+    // the admin list only needs to show who was invited and where the invite stands.
     return invites.map((i) => ({
       id: i.id,
       email: i.email,
-      inviteToken: i.inviteToken,
       invitedById: i.invitedById,
       status: i.status,
       acceptedById: i.acceptedById,

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -3,6 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { withProjectExtras, projectInclude, EnrichedProject } from '@/lib/work-item'
 import { notifyUser, notifyTeamOfProject, clearNotifications } from '@/lib/notify'
+import { html } from '@/lib/email'
 import { notifyMatchingVolunteers } from '@/lib/project-match-notify'
 import { AdminCreateProjectSchema, ReviewProjectSchema, OutcomeProjectSchema } from '@/lib/schemas'
 import { adminProcedure } from '../../procedures'
@@ -170,7 +171,11 @@ export const adminProjectsRouter = {
                 'A team lead would like to discuss your project proposal before it goes live.',
               projectTitle: project.title,
               projectId: input.id,
-              extraHtml: `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Feedback:</strong> ${feedback}</div>`,
+              extraHtml: html`<div
+                style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"
+              >
+                <strong>Feedback:</strong> ${feedback}
+              </div>`,
             },
           )
         }

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -465,11 +465,33 @@ export const authRouter = {
       throw new ORPCError('BAD_REQUEST', {
         message: 'This email is already registered to another account',
       })
+    // The new address is unproven: drop confirmed status and send a fresh confirmation
+    // link there, otherwise a verified account could point itself at any address.
+    await prisma.emailVerificationToken.updateMany({
+      where: { volunteerId: context.volunteer.id, usedAt: null },
+      data: { usedAt: new Date() },
+    })
+    const vt = await prisma.emailVerificationToken.create({
+      data: {
+        volunteerId: context.volunteer.id,
+        token: randomBytes(32).toString('hex'),
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+    })
     await prisma.volunteer.update({
       where: { id: context.volunteer.id },
-      data: { email: newEmail, updatedAt: new Date() },
+      data: { email: newEmail, emailConfirmed: false, updatedAt: new Date() },
     })
-    return { message: 'Email changed successfully' }
+    sendWelcomeAndConfirmEmail({
+      to: newEmail,
+      token: vt.token,
+      name: context.volunteer.name,
+    }).catch((e) => console.error('[CHANGE_EMAIL]', e))
+
+    return {
+      message: 'Email changed. Check your new address for a confirmation link.',
+      ...(STUB_EMAIL ? { emailVerificationToken: vt.token } : {}),
+    }
   }),
 
   forgotPassword: publicProcedure

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -21,6 +21,7 @@ import {
   sendApplicationApprovedEmail,
 } from '@/lib/email'
 import { checkRateLimit } from '@/lib/rate-limit'
+import { verifyGoogleToken } from '@/lib/google-auth'
 import { notifyAdmins } from '@/lib/notify'
 import {
   SignupSchema,
@@ -36,20 +37,6 @@ import { ApprovalStatus, ProjectStatus, WorkItemType } from '@/generated/prisma/
 const STUB_EMAIL = env.STUB_EMAIL
 const GOOGLE_CLIENT_ID = env.GOOGLE_CLIENT_ID
 const STUB_GOOGLE = env.STUB_GOOGLE || (!GOOGLE_CLIENT_ID && env.NODE_ENV !== 'production')
-
-async function verifyGoogleToken(credential: string) {
-  if (!GOOGLE_CLIENT_ID) return null
-  try {
-    const resp = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${credential}`)
-    if (!resp.ok) return null
-    const data = (await resp.json()) as Record<string, string>
-    if (data.aud !== GOOGLE_CLIENT_ID) return null
-    if (data.email_verified !== 'true') return null
-    return { email: data.email, name: data.name || data.email.split('@')[0] }
-  } catch {
-    return null
-  }
-}
 
 async function sendAccountDeletionNotifications(deletedId: number, deletedName: string) {
   const taskRows = await prisma.$queryRaw<

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -6,11 +6,14 @@ import {
   verifyPassword,
   hashPassword,
   generateAuthToken,
+  authTokenExpiry,
   checkAdminBootstrap,
   acceptPendingInvite,
   redactVolunteer,
 } from '@/lib/auth'
 import {
+  html,
+  rawHtml,
   sendWelcomeEmail,
   sendWelcomeAndConfirmEmail,
   sendPasswordResetEmail,
@@ -156,14 +159,34 @@ async function sendAccountDeletionNotifications(deletedId: number, deletedName: 
     }
     if (r.email) {
       const allProjects = [...r.taskProjects, ...r.ownerlessProjects]
-      const msgParts = [`<p><strong>${deletedName}</strong> has deleted their account.</p>`]
+      const msgParts = [html`<p><strong>${deletedName}</strong> has deleted their account.</p>`]
       if (r.taskProjects.length)
         msgParts.push(
-          `<p>The following tasks need a new assignee:</p><ul>${r.taskProjects.map((p) => `<li>${p.taskCount} ${p.taskCount === 1 ? 'task' : 'tasks'} in <strong>${p.projectTitle}</strong></li>`).join('')}</ul>`,
+          html`<p>The following tasks need a new assignee:</p>
+            <ul>
+              ${rawHtml(
+                r.taskProjects
+                  .map(
+                    (p) =>
+                      html`<li>
+                        ${p.taskCount} ${p.taskCount === 1 ? 'task' : 'tasks'} in
+                        <strong>${p.projectTitle}</strong>
+                      </li>`,
+                  )
+                  .join(''),
+              )}
+            </ul>`,
         )
       if (r.ownerlessProjects.length)
         msgParts.push(
-          `<p>The following projects need a new owner:</p><ul>${r.ownerlessProjects.map((p) => `<li><strong>${p.projectTitle}</strong></li>`).join('')}</ul>`,
+          html`<p>The following projects need a new owner:</p>
+            <ul>
+              ${rawHtml(
+                r.ownerlessProjects
+                  .map((p) => html`<li><strong>${p.projectTitle}</strong></li>`)
+                  .join(''),
+              )}
+            </ul>`,
         )
       await sendProjectNotificationEmail({
         to: r.email,
@@ -180,7 +203,16 @@ async function sendAccountDeletionNotifications(deletedId: number, deletedName: 
 export const authRouter = {
   login: publicProcedure
     .input(z.object({ email: z.string(), password: z.string() }))
-    .handler(async ({ input }) => {
+    .handler(async ({ input, context }) => {
+      const { allowed, retryAfterMs } = checkRateLimit(context.request, 'login', {
+        limit: 10,
+        windowMs: 15 * 60 * 1000,
+      })
+      if (!allowed)
+        throw new ORPCError('TOO_MANY_REQUESTS', {
+          message: `Rate limited. Retry after ${retryAfterMs}ms`,
+        })
+
       const email = input.email.toLowerCase().trim()
       if (!email || !input.password)
         throw new ORPCError('UNAUTHORIZED', { message: 'Invalid email or password' })
@@ -201,7 +233,7 @@ export const authRouter = {
       const authToken = generateAuthToken()
       await prisma.volunteer.update({
         where: { id: volunteer.id },
-        data: { authToken, updatedAt: new Date() },
+        data: { authToken, authTokenExpiresAt: authTokenExpiry(), updatedAt: new Date() },
       })
 
       return {
@@ -254,6 +286,7 @@ export const authRouter = {
         email,
         passwordHash: hashPassword(input.password),
         authToken,
+        authTokenExpiresAt: authTokenExpiry(),
         applicationMessage: input.applicationMessage ?? null,
         bio: input.bio ?? null,
         discordHandle: input.discordHandle ?? null,
@@ -321,7 +354,8 @@ export const authRouter = {
         `${volunteer.name} has applied to join Catalyse`,
         '/admin/applications',
         {
-          message: `<strong>${volunteer.name}</strong> (${email}) has applied to join Catalyse. Please review their application.`,
+          message: html`<strong>${volunteer.name}</strong> (${email}) has applied to join Catalyse.
+            Please review their application.`,
           ctaLabel: 'Review Application',
           ctaUrl: '/admin/applications',
         },
@@ -340,7 +374,7 @@ export const authRouter = {
   logout: authedProcedure.handler(async ({ context }) => {
     await prisma.volunteer.update({
       where: { id: context.volunteer.id },
-      data: { authToken: null },
+      data: { authToken: null, authTokenExpiresAt: null },
     })
     return { message: 'Logged out' }
   }),
@@ -380,6 +414,15 @@ export const authRouter = {
   changePassword: authedProcedure
     .input(ChangePasswordSchema)
     .handler(async ({ input, context }) => {
+      const { allowed, retryAfterMs } = checkRateLimit(context.request, 'change-password', {
+        limit: 10,
+        windowMs: 15 * 60 * 1000,
+      })
+      if (!allowed)
+        throw new ORPCError('TOO_MANY_REQUESTS', {
+          message: `Rate limited. Retry after ${retryAfterMs}ms`,
+        })
+
       const vol = await prisma.volunteer.findUnique({
         where: { id: context.volunteer.id },
         select: { passwordHash: true },
@@ -387,11 +430,19 @@ export const authRouter = {
       if (!vol?.passwordHash || !verifyPassword(input.currentPassword, vol.passwordHash)) {
         throw new ORPCError('BAD_REQUEST', { message: 'Current password is incorrect' })
       }
+      // Rotate the session token: a password change must invalidate any session opened
+      // with the old password. The caller gets the replacement so it stays signed in.
+      const authToken = generateAuthToken()
       await prisma.volunteer.update({
         where: { id: context.volunteer.id },
-        data: { passwordHash: hashPassword(input.newPassword), updatedAt: new Date() },
+        data: {
+          passwordHash: hashPassword(input.newPassword),
+          authToken,
+          authTokenExpiresAt: authTokenExpiry(),
+          updatedAt: new Date(),
+        },
       })
-      return { message: 'Password changed successfully' }
+      return { message: 'Password changed successfully', token: authToken }
     }),
 
   changeEmail: authedProcedure.input(ChangeEmailSchema).handler(async ({ input, context }) => {
@@ -463,7 +514,16 @@ export const authRouter = {
       }
     }),
 
-  resetPassword: publicProcedure.input(ResetPasswordSchema).handler(async ({ input }) => {
+  resetPassword: publicProcedure.input(ResetPasswordSchema).handler(async ({ input, context }) => {
+    const { allowed, retryAfterMs } = checkRateLimit(context.request, 'reset-password', {
+      limit: 10,
+      windowMs: 15 * 60 * 1000,
+    })
+    if (!allowed)
+      throw new ORPCError('TOO_MANY_REQUESTS', {
+        message: `Rate limited. Retry after ${retryAfterMs}ms`,
+      })
+
     const tokenRecord = await prisma.passwordResetToken.findFirst({
       where: {
         token: input.token,
@@ -480,6 +540,7 @@ export const authRouter = {
       data: {
         passwordHash: hashPassword(input.newPassword),
         authToken: null,
+        authTokenExpiresAt: null,
         updatedAt: new Date(),
       },
     })
@@ -676,7 +737,7 @@ export const authRouter = {
         const authToken = generateAuthToken()
         await prisma.volunteer.update({
           where: { id: existing.id },
-          data: { authToken, updatedAt: new Date() },
+          data: { authToken, authTokenExpiresAt: authTokenExpiry(), updatedAt: new Date() },
         })
         let wasPromoted = await checkAdminBootstrap(email, existing.id)
         if (await acceptPendingInvite(email, existing.id)) wasPromoted = true
@@ -752,6 +813,7 @@ export const authRouter = {
           name,
           email,
           authToken,
+          authTokenExpiresAt: authTokenExpiry(),
           emailConfirmed: true,
           applicationMessage: input.applicationMessage,
           bio: input.bio,

--- a/server/routers/messages.ts
+++ b/server/routers/messages.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { sendRelayMessage, isEmailConfigured } from '@/lib/email'
+import { checkRateLimit } from '@/lib/rate-limit'
 import { authedProcedure, approvedProcedure } from '../procedures'
 import { WorkItemType } from '@/generated/prisma/enums'
 
@@ -68,6 +69,17 @@ export const messagesRouter = {
     }),
 
   send: approvedProcedure.input(ContactSchema).handler(async ({ input, context }) => {
+    // Every send fans out to a real email; without a cap one account can use the relay
+    // to spam the directory.
+    const { allowed, retryAfterMs } = checkRateLimit(context.request, 'messages-send', {
+      limit: 20,
+      windowMs: 60 * 60 * 1000,
+    })
+    if (!allowed)
+      throw new ORPCError('TOO_MANY_REQUESTS', {
+        message: `Rate limited. Retry after ${retryAfterMs}ms`,
+      })
+
     const sender = context.volunteer
     if (sender.id === input.recipientId) {
       throw new ORPCError('BAD_REQUEST', { message: 'Cannot message yourself' })

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -35,6 +35,25 @@ import {
   WorkItemType,
 } from '@/generated/prisma/enums'
 
+/**
+ * Can this volunteer reach a team-restricted project at all? Mirrors the list/getById
+ * gate: a project tagged to a team is only reachable by that team's members, its
+ * owner/proposer, an accepted helper, or an admin.
+ */
+async function canReachProject(
+  project: {
+    id: number
+    teamId: number | null
+    creatorId: number | null
+    assigneeId: number | null
+  },
+  volunteer: { id: number; isAdmin: boolean | null },
+): Promise<boolean> {
+  if (project.teamId === null || volunteer.isAdmin) return true
+  if (project.creatorId === volunteer.id || project.assigneeId === volunteer.id) return true
+  return resolveTeamPrivy(project.teamId, project.id, volunteer.id)
+}
+
 /** Has this volunteer been declined from, or withdrawn from, this project? */
 async function isBlockedFromClaiming(projectId: number, volunteerId: number): Promise<boolean> {
   const blocking = await prisma.workItemInterest.findFirst({
@@ -674,13 +693,53 @@ export const projectsRouter = {
         'outcome',
         'outcomeNotes',
       ] as const
-      if (body.teamId !== undefined) data.teamId = body.teamId
+      // Handing the project to a different owner or team is the owner's call (or an
+      // admin's) — a proposer who never owned it can't appoint themselves. Submitting the
+      // current value is always fine: the edit form posts every field back unchanged.
+      const canReassign = isAssignee || Boolean(volunteer.isAdmin)
+
+      if (body.teamId !== undefined && body.teamId !== project.teamId) {
+        if (!canReassign) {
+          throw new ORPCError('FORBIDDEN', {
+            message: 'Only the project owner or an admin can change the team',
+          })
+        }
+        if (body.teamId !== null) {
+          const team = await prisma.team.findUnique({
+            where: { id: body.teamId },
+            select: { id: true },
+          })
+          if (!team) throw new ORPCError('BAD_REQUEST', { message: 'Team not found' })
+        }
+        data.teamId = body.teamId
+      }
+
       for (const field of stringFields) {
         if (body[field] !== undefined) data[field] = body[field]
       }
       if (body.timeCommitmentHoursPerWeek !== undefined)
         data.timeCommitmentHoursPerWeek = body.timeCommitmentHoursPerWeek
-      if (body.assigneeId !== undefined) data.assigneeId = body.assigneeId
+
+      if (body.assigneeId !== undefined && body.assigneeId !== project.assigneeId) {
+        if (!canReassign) {
+          throw new ORPCError('FORBIDDEN', {
+            message: 'Only the project owner or an admin can change the owner',
+          })
+        }
+        if (body.assigneeId !== null) {
+          const newOwner = await prisma.volunteer.findFirst({
+            where: { id: body.assigneeId, deletedAt: null },
+            select: { approvalStatus: true },
+          })
+          if (!newOwner) throw new ORPCError('BAD_REQUEST', { message: 'Volunteer not found' })
+          if (newOwner.approvalStatus !== ApprovalStatus.approved) {
+            throw new ORPCError('BAD_REQUEST', {
+              message: 'Cannot assign a project to a volunteer who is not yet approved',
+            })
+          }
+        }
+        data.assigneeId = body.assigneeId
+      }
 
       if (newStatus !== undefined) {
         if (volunteer.isAdmin) {
@@ -810,6 +869,10 @@ export const projectsRouter = {
         throw new ORPCError('NOT_FOUND', {
           message: 'This project is not currently seeking volunteers',
         })
+      }
+
+      if (!(await canReachProject(project, volunteer))) {
+        throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
       }
 
       const existing = await prisma.workItemInterest.findFirst({
@@ -1309,15 +1372,16 @@ export const projectsRouter = {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized to update this task' })
       }
 
-      if (
-        isSelfClaim &&
-        !isAssignee &&
-        !volunteer.isAdmin &&
-        (await isBlockedFromClaiming(input.projectId, volunteer.id))
-      ) {
-        throw new ORPCError('FORBIDDEN', {
-          message: 'You are no longer contributing to this project, so you cannot claim its tasks',
-        })
+      if (isSelfClaim && !isAssignee && !volunteer.isAdmin) {
+        if (await isBlockedFromClaiming(input.projectId, volunteer.id)) {
+          throw new ORPCError('FORBIDDEN', {
+            message:
+              'You are no longer contributing to this project, so you cannot claim its tasks',
+          })
+        }
+        if (!(await canReachProject(project, volunteer))) {
+          throw new ORPCError('NOT_FOUND', { message: 'Project or task not found' })
+        }
       }
 
       const data: Record<string, unknown> = {}
@@ -1340,7 +1404,19 @@ export const projectsRouter = {
       data.nudgeSentAt = null
       data.finalWarningSentAt = null
 
-      await prisma.workItem.update({ where: { id: input.taskId }, data })
+      if (isSelfClaim) {
+        // Two volunteers hitting claim at once must not both win — only the update that
+        // still sees the task open and unheld takes it.
+        const claimed = await prisma.workItem.updateMany({
+          where: { id: input.taskId, status: TaskStatus.open, assigneeId: null },
+          data,
+        })
+        if (claimed.count === 0) {
+          throw new ORPCError('BAD_REQUEST', { message: 'This task has already been claimed' })
+        }
+      } else {
+        await prisma.workItem.update({ where: { id: input.taskId }, data })
+      }
 
       if (isSelfClaim) {
         const existingInterest = await prisma.workItemInterest.findFirst({

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -234,8 +234,13 @@ export const projectsRouter = {
         .filter((p): p is NonNullable<typeof p> => p !== undefined)
         .map((p) => withProjectExtras(p as EnrichedProject, volunteerSkillIds, viewerTeamIds))
 
-      if (input.sortBy === 'match' && volunteerSkillIds && volunteerSkillIds.size > 0) {
-        projects.sort((a, b) => (b.match?.overallScore ?? 0) - (a.match?.overallScore ?? 0))
+      // Match sorting can't be done in SQL, so this branch fetched every matching id and
+      // paginates here. The slice has to happen whether or not the volunteer has skills to
+      // sort by — without it, a volunteer with no skills got the entire result set back.
+      if (input.sortBy === 'match') {
+        if (volunteerSkillIds.size > 0) {
+          projects.sort((a, b) => (b.match?.overallScore ?? 0) - (a.match?.overallScore ?? 0))
+        }
         return { projects: projects.slice(input.offset, input.offset + input.limit), total }
       }
 

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -11,6 +11,7 @@ import {
   CLAIM_BLOCKING_INTEREST_STATUSES,
 } from '@/lib/work-item'
 import { notifyUser, notifyAdmins, notifyTeamOfProject, clearNotifications } from '@/lib/notify'
+import { html } from '@/lib/email'
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
@@ -433,7 +434,8 @@ export const projectsRouter = {
       `Proposed by ${volunteer.name}`,
       '/admin/triage',
       {
-        message: `<strong>${volunteer.name}</strong> has submitted a new project proposal: <strong>${project.title}</strong>. Please review it in the triage queue.`,
+        message: html`<strong>${volunteer.name}</strong> has submitted a new project proposal:
+          <strong>${project.title}</strong>. Please review it in the triage queue.`,
         projectTitle: project.title,
         projectId: project.id,
       },
@@ -766,7 +768,8 @@ export const projectsRouter = {
             `Status changed by ${volunteer.name}`,
             `/projects/${input.id}`,
             {
-              message: `The project <strong>${project.title}</strong> has been updated to <strong>${statusLabel}</strong>.`,
+              message: html`The project <strong>${project.title}</strong> has been updated to
+                <strong>${statusLabel}</strong>.`,
               projectTitle: project.title,
               projectId: input.id,
             },
@@ -852,11 +855,16 @@ export const projectsRouter = {
           `/projects/${input.projectId}`,
           {
             subject: `${volunteer.name} wants to ${interestLabel} '${project.title}'`,
-            message: `<strong>${volunteer.name}</strong> has expressed interest in your project <strong>${project.title}</strong>.`,
+            message: html`<strong>${volunteer.name}</strong> has expressed interest in your project
+              <strong>${project.title}</strong>.`,
             projectTitle: project.title,
             projectId: input.projectId,
             extraHtml: message
-              ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Their message:</strong> ${message}</div>`
+              ? html`<div
+                  style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"
+                >
+                  <strong>Their message:</strong> ${message}
+                </div>`
               : undefined,
           },
           interest.id,
@@ -946,11 +954,16 @@ export const projectsRouter = {
         input.responseMessage ?? null,
         `/projects/${input.projectId}`,
         {
-          message: `The team has <strong>${input.status}</strong> your interest in the project <strong>${project.title}</strong>.`,
+          message: html`The team has <strong>${input.status}</strong> your interest in the project
+            <strong>${project.title}</strong>.`,
           projectTitle: project.title,
           projectId: input.projectId,
           extraHtml: input.responseMessage
-            ? `<div style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"><strong>Message:</strong> ${input.responseMessage}</div>`
+            ? html`<div
+                style="padding: 12px; background: #f7fafc; border-radius: 8px; margin: 16px 0;"
+              >
+                <strong>Message:</strong> ${input.responseMessage}
+              </div>`
             : undefined,
         },
       )
@@ -1042,7 +1055,8 @@ export const projectsRouter = {
         `Assigned by ${volunteer.name}`,
         `/projects/${input.projectId}`,
         {
-          message: `<strong>${volunteer.name}</strong> has assigned you to the project <strong>${project.title}</strong>.`,
+          message: html`<strong>${volunteer.name}</strong> has assigned you to the project
+            <strong>${project.title}</strong>.`,
           projectTitle: project.title,
           projectId: input.projectId,
         },
@@ -1053,7 +1067,32 @@ export const projectsRouter = {
 
   listTasks: approvedProcedure
     .input(z.object({ projectId: z.number().int() }))
-    .handler(async ({ input }) => {
+    .handler(async ({ input, context }) => {
+      const volunteer = context.volunteer
+
+      // Task visibility follows the project's: without this any approved volunteer could
+      // read the task list of a team-restricted or still-unapproved project by id.
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.projectId, type: WorkItemType.PROJECT },
+      })
+      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
+
+      const isTeamPrivy = await resolveTeamPrivy(project.teamId, project.id, volunteer.id)
+      if (
+        !canViewWorkItem(
+          project,
+          {
+            id: volunteer.id,
+            isAdmin: Boolean(volunteer.isAdmin),
+            isApproved: volunteer.approvalStatus === ApprovalStatus.approved,
+          },
+          undefined,
+          isTeamPrivy,
+        )
+      ) {
+        throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
+      }
+
       const tasks = await prisma.workItem.findMany({
         where: { parentId: input.projectId, type: WorkItemType.TASK },
         include: {
@@ -1378,7 +1417,8 @@ export const projectsRouter = {
         task.title,
         `/projects/${input.projectId}`,
         {
-          message: `You've been assigned the task <strong>${task.title}</strong> on the project <strong>${project.title}</strong>.`,
+          message: html`You've been assigned the task <strong>${task.title}</strong> on the project
+            <strong>${project.title}</strong>.`,
           projectTitle: project.title,
           projectId: input.projectId,
         },

--- a/server/routers/quickTasks.ts
+++ b/server/routers/quickTasks.ts
@@ -294,18 +294,19 @@ export const quickTasksRouter = {
         where: { id: input.id, type: WorkItemType.QUICK_TASK },
       })
       if (!task) throw new ORPCError('NOT_FOUND', { message: 'Task not found' })
-      if (task.status !== QuickTaskStatus.open || task.assigneeId !== null) {
-        throw new ORPCError('BAD_REQUEST', { message: 'This task has already been claimed' })
-      }
-
-      await prisma.workItem.update({
-        where: { id: input.id },
+      // Guarded update rather than check-then-write: two volunteers claiming at the same
+      // moment must not both succeed, with the second silently taking the task.
+      const claimed = await prisma.workItem.updateMany({
+        where: { id: input.id, status: QuickTaskStatus.open, assigneeId: null },
         data: {
           assigneeId: volunteer.id,
           status: QuickTaskStatus.in_progress,
           updatedAt: new Date(),
         },
       })
+      if (claimed.count === 0) {
+        throw new ORPCError('BAD_REQUEST', { message: 'This task has already been claimed' })
+      }
 
       return { message: 'Task claimed' }
     }),

--- a/server/routers/teamSuggestions.ts
+++ b/server/routers/teamSuggestions.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { TeamSuggestionBodySchema } from '@/lib/schemas'
 import { notifyAdmins } from '@/lib/notify'
+import { html } from '@/lib/email'
 import { authedProcedure, approvedProcedure } from '../procedures'
 
 export const teamSuggestionsRouter = {
@@ -40,7 +41,8 @@ export const teamSuggestionsRouter = {
       '/admin/teams',
       {
         subject: title,
-        message: `${context.volunteer.name} suggested a new team: <strong>${input.name}</strong>.`,
+        message: html`${context.volunteer.name} suggested a new team:
+          <strong>${input.name}</strong>.`,
         ctaLabel: 'Review Suggestion',
         ctaUrl: '/admin/teams',
       },

--- a/server/routers/teams.ts
+++ b/server/routers/teams.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { notifyUser } from '@/lib/notify'
+import { html } from '@/lib/email'
 import { TeamBodySchema } from '@/lib/schemas'
 import { publicProcedure, approvedProcedure } from '../procedures'
 import { TeamMembershipRole, TeamJoinRequestStatus } from '@/generated/prisma/enums'
@@ -197,8 +198,9 @@ export const teamsRouter = {
             notifyUser(id, 'team_join_request', title, null, '/teams', {
               subject: title,
               message: input.message
-                ? `${context.volunteer.name} applied to join <strong>${team.name}</strong>: "${input.message.trim()}"`
-                : `${context.volunteer.name} applied to join <strong>${team.name}</strong>.`,
+                ? html`${context.volunteer.name} applied to join <strong>${team.name}</strong>:
+                    "${input.message.trim()}"`
+                : html`${context.volunteer.name} applied to join <strong>${team.name}</strong>.`,
               ctaLabel: 'Review Application',
               ctaUrl: '/teams',
             }),

--- a/server/routers/teams.ts
+++ b/server/routers/teams.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma'
 import { notifyUser } from '@/lib/notify'
 import { html } from '@/lib/email'
 import { TeamBodySchema } from '@/lib/schemas'
-import { publicProcedure, approvedProcedure } from '../procedures'
+import { authedProcedure, approvedProcedure } from '../procedures'
 import { TeamMembershipRole, TeamJoinRequestStatus } from '@/generated/prisma/enums'
 
 function serializeTeam(
@@ -60,7 +60,7 @@ async function assertCanManageTeam(
 }
 
 export const teamsRouter = {
-  list: publicProcedure.handler(async ({ context }) => {
+  list: authedProcedure.handler(async ({ context }) => {
     const teams = await prisma.team.findMany({
       orderBy: { name: 'asc' },
       include: { members: { include: { volunteer: { select: { id: true, name: true } } } } },
@@ -81,7 +81,7 @@ export const teamsRouter = {
     }
   }),
 
-  getById: publicProcedure
+  getById: authedProcedure
     .input(z.object({ id: z.number().int() }))
     .handler(async ({ input, context }) => {
       const team = await prisma.team.findUnique({

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { redactVolunteer } from '@/lib/auth'
 import { UpdateVolunteerSchema } from '@/lib/schemas'
-import { publicProcedure, authedProcedure } from '../procedures'
+import { approvedProcedure, authedProcedure } from '../procedures'
 import {
   ApprovalStatus,
   ProjectStatus,
@@ -12,7 +12,7 @@ import {
 } from '@/generated/prisma/enums'
 
 export const volunteersRouter = {
-  list: publicProcedure
+  list: approvedProcedure
     .input(
       z.object({
         skillIds: z.array(z.number().int()).optional(),
@@ -25,15 +25,7 @@ export const volunteersRouter = {
     )
     .handler(async ({ input, context }) => {
       const currentVolunteer = context.volunteer
-      if (
-        currentVolunteer &&
-        currentVolunteer.approvalStatus !== ApprovalStatus.approved &&
-        !currentVolunteer.isAdmin
-      ) {
-        throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
-      }
-
-      const isAdmin = currentVolunteer?.isAdmin ?? false
+      const isAdmin = currentVolunteer.isAdmin ?? false
 
       const where: Record<string, unknown> = {
         deletedAt: null,
@@ -125,17 +117,10 @@ export const volunteersRouter = {
       }
     }),
 
-  getById: publicProcedure
+  getById: approvedProcedure
     .input(z.object({ id: z.number().int() }))
     .handler(async ({ input, context }) => {
       const currentVolunteer = context.volunteer
-      if (
-        currentVolunteer &&
-        currentVolunteer.approvalStatus !== ApprovalStatus.approved &&
-        !currentVolunteer.isAdmin
-      ) {
-        throw new ORPCError('FORBIDDEN', { message: 'Your account is pending approval' })
-      }
 
       const vol = await prisma.volunteer.findFirst({
         where: { id: input.id, deletedAt: null, consentMakeProfileVisibleInDirectory: true },

--- a/server/routers/workItemComments.ts
+++ b/server/routers/workItemComments.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { notifyUser } from '@/lib/notify'
 import { canViewWorkItem, canPostComment, resolveTeamPrivy } from '@/lib/work-item'
-import { publicProcedure, authedProcedure } from '../procedures'
+import { authedProcedure } from '../procedures'
 import { ApprovalStatus, InterestStatus, WorkItemType } from '@/generated/prisma/enums'
 
 const WORK_ITEM_SELECT = {
@@ -73,7 +73,7 @@ async function resolveCanPost(
 }
 
 export const workItemCommentsRouter = {
-  list: publicProcedure
+  list: authedProcedure
     .input(z.object({ workItemId: z.number().int() }))
     .handler(async ({ input, context }) => {
       const loaded = await loadWithParent(input.workItemId)


### PR DESCRIPTION
Findings from a survey of the server routers, auth/session handling, email builders and config, fixed in three commits (high, medium, low severity).

## High

- **Login was not rate limited.** Every other credential endpoint called `checkRateLimit`; `login` did not, so password guessing against a known email was unmetered. Added there plus `changePassword` and `resetPassword` (10 / 15 min).
- **Session tokens never expired.** `authTokenExpiresAt` was read by `getCurrentVolunteer` but never written by any code path, so every issued token was valid forever. All four issue paths now set a 30-day expiry, a null expiry counts as expired, and changing a password mints a fresh token (returned to the caller, so the tab stays signed in). Existing sessions are backfilled with 30 days rather than being logged out on deploy.
- **`projects.listTasks` had no visibility check.** It queried by `parentId` with no team or status gate, so any approved volunteer could read the task list of a team-restricted or unapproved project by id. Now gated like `getTask`.
- **Notification emails interpolated user data raw.** `buildProjectNotificationHtml` and `buildAdminAlertHtml` escaped only the recipient name, so project titles, volunteer names and free-text interest messages could inject markup into mail sent from our domain. Adds an `html` tagged template that escapes interpolations (`rawHtml()` to opt out) and converts every call site.

## Medium

- Volunteer directory, team rosters and comment threads required no login at all (`publicProcedure`) — names, bios, locations, skills and rosters were anonymously scrapeable. Now `approvedProcedure` / `authedProcedure`.
- Changing a project's owner or team is owner-or-admin only and validates the target (real team; existing, non-deleted, approved volunteer). A proposer could previously appoint themselves owner or hand the project to anyone. Resubmitting the current value still works, so the edit form's full-payload save is unaffected.
- Expressing interest in, and self-claiming a task on, a team-restricted project now need the same team privity as viewing it.
- Task and quick-task claims are guarded `updateMany` calls, so two simultaneous claims can't both win.
- Message relay rate limited (20/hour) — every send fans out to real email.
- Changing an account's email clears `emailConfirmed` and sends a confirmation link to the new address.
- Rate-limit store is swept and key-capped instead of growing per unique IP forever; its per-instance scope and x-forwarded-for trust are documented.
- Production refuses to boot with `STUB_GOOGLE`, `STUB_EMAIL` or `DISABLE_RATE_LIMIT` on (`STUB_GOOGLE` alone allows signing in as any email, including an `ADMIN_EMAILS` address).
- Added CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy.
- Admin invite list no longer returns raw invite tokens.

## Low

- Google ID tokens are verified locally (JWKS + RS256 signature, `iss`, `aud`, `exp`, `iat`) instead of trusting the deprecated `/tokeninfo` response, which never checked `iss`.
- `CRON_SECRET` compared with `timingSafeEqual`.
- `projects.list` with `sortBy=match` returned the entire result set, ignoring `limit`/`offset`, when the volunteer had no skills to sort by.

## Deploying

`prisma/migrations/20260823210000_backfill_auth_token_expiry` must run before or with this code — once it is live, sessions with a null expiry are rejected, and the migration is what gives existing sessions an expiry instead of logging everyone out.

The e2e harness serves a production build with the stub flags on, so it now marks itself `E2E=1` and is exempt from the new startup validation. Note that it also sets `DISABLE_RATE_LIMIT`, so the new limiters are not exercised by the suite.

## Verification

`npm run check-all` clean: typecheck, lint, format, and 217 passed / 5 skipped e2e.

The Google verifier was checked out-of-band with a generated keypair and stubbed JWKS: valid token accepted; wrong `aud`, wrong `iss`, expired, future `iat`, unverified email, foreign signing key, unknown `kid`, `alg: none`, garbage input and a tampered payload with the original signature all rejected. Not committed as a test — the repo has no unit-test runner, only the browser e2e suite.

## Not addressed

- **Backups are uploaded to B2 unencrypted** and the DB holds full volunteer PII. Needs a decision on key management (and B2 access) before it can be fixed.
- **Sessions are a single `authToken` column per volunteer**, so signing in on a second device silently ends the first session. Fixing it means a `sessions` table — left as a design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tR28Bp8KTrowk3eHWCEYP