### PR TITLE
Low-hanging fruit: robots/sitemap, bounded queries, responsive grids, serializers, approval stepper

### DIFF
--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -187,7 +187,7 @@ function ApplicationCard({
         app.whatsappNumber ||
         app.discordHandle ||
         app.contactNotes) && (
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-2 gap-4 mb-4 max-[600px]:grid-cols-1">
           {app.availabilityHoursPerWeek && (
             <div>
               <h4 className="text-text-light">Availability</h4>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import Tabs from '@/components/Tabs'
 import type { InferRouterOutputs } from '@orpc/server'
 import type { AppRouter } from '@/server/router'
 import { ApprovalStatus, QuickTaskStatus } from '@/generated/prisma/enums'
+import { ApprovalStepper } from '@/components/ApprovalStepper'
 import { friendlyDate } from '@/lib/format-date'
 
 const NOTIFICATIONS_PAGE_SIZE = 20
@@ -196,12 +197,14 @@ export default function DashboardPage() {
         <h1 role="heading">Welcome back, {user.name}!</h1>
 
         {/* Pending approval banner */}
-        {user.approvalStatus === ApprovalStatus.pending && (
-          <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-yellow-100 text-yellow-800 border border-yellow-300 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-800">
+        {(user.approvalStatus === ApprovalStatus.pending ||
+          user.approvalStatus === ApprovalStatus.under_review) && (
+          <div className="flex flex-col gap-3 p-4 rounded-lg mb-5 bg-yellow-100 text-yellow-800 border border-yellow-300 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-800">
             <span>
               Your account is pending approval. You&apos;ll be able to browse and join projects once
               an admin reviews your application.
             </span>
+            <ApprovalStepper status={user.approvalStatus} />
           </div>
         )}
 

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -206,7 +206,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-5 mb-5">
+          <div className="grid grid-cols-2 gap-5 mb-5 max-[600px]:grid-cols-1">
             <div>
               <label htmlFor="hours-per-week">Hours per Week</label>
               <input

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from 'next'
+import { env } from '@/lib/env'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/admin',
+        '/api',
+        '/dashboard',
+        '/settings',
+        '/profile',
+        '/bugs',
+        '/component-preview',
+        '/projects',
+        '/quick-tasks',
+        '/teams',
+        '/suggest',
+        '/suggest-team',
+        '/suggest-local-group',
+        '/verify-email',
+        '/reset-password',
+        '/accept-invite',
+      ],
+    },
+    sitemap: `${env.APP_URL}/sitemap.xml`,
+  }
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -533,7 +533,6 @@ function SettingsPageContent() {
                 id="location"
                 value={location}
                 onChange={(e) => setLocation(e.target.value)}
-                placeholder="e.g. Shoreditch"
               />
             </div>
           )}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1098,7 +1098,6 @@ export default function SignupPage() {
                   id="location"
                   name="location"
                   autoComplete="address-level2"
-                  placeholder="e.g., Shoreditch"
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
                 />

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next'
+import { env } from '@/lib/env'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = ['', '/login', '/signup', '/forgot-password', '/privacy', '/local-groups']
+
+  return routes.map((route) => ({
+    url: `${env.APP_URL}${route}`,
+    lastModified: new Date(),
+  }))
+}

--- a/app/volunteers/[id]/page.tsx
+++ b/app/volunteers/[id]/page.tsx
@@ -102,7 +102,7 @@ export default function VolunteerDetailPage({ params }: { params: Promise<{ id: 
               </div>
             )}
 
-            <div className="grid grid-cols-2 gap-4 mt-5">
+            <div className="grid grid-cols-2 gap-4 mt-5 max-[600px]:grid-cols-1">
               {volunteer.availabilityHoursPerWeek && (
                 <div>
                   <h4 className="text-text-light">Availability</h4>

--- a/components/ApprovalStepper.tsx
+++ b/components/ApprovalStepper.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Badge, type BadgeVariant } from '@/components/Badge'
+import { ApprovalStatus } from '@/generated/prisma/enums'
+
+type Step = { label: string; variant: BadgeVariant }
+
+/**
+ * Three-stage progress badge for an application awaiting approval: Applied →
+ * Under Review → Approved/Rejected. Only meaningful before a final decision —
+ * callers gate on that (e.g. the dashboard's pending-approval banner).
+ */
+export function ApprovalStepper({ status }: { status: ApprovalStatus }) {
+  const reachedReview =
+    status === ApprovalStatus.under_review ||
+    status === ApprovalStatus.needs_info ||
+    status === ApprovalStatus.approved ||
+    status === ApprovalStatus.rejected
+  const inReview = status === ApprovalStatus.under_review || status === ApprovalStatus.needs_info
+
+  const finalStep: Step =
+    status === ApprovalStatus.approved
+      ? { label: 'Approved', variant: 'success' }
+      : status === ApprovalStatus.rejected
+        ? { label: 'Rejected', variant: 'danger' }
+        : { label: 'Approved', variant: 'neutral' }
+
+  const steps: Step[] = [
+    { label: 'Applied', variant: 'success' },
+    { label: 'Under Review', variant: reachedReview ? (inReview ? 'info' : 'success') : 'neutral' },
+    finalStep,
+  ]
+
+  return (
+    <div className="flex items-center gap-1 flex-wrap" aria-label="Application status">
+      {steps.map((step, i) => (
+        <React.Fragment key={step.label}>
+          {i > 0 && <span className="text-text-light text-xs">→</span>}
+          <Badge variant={step.variant}>{step.label}</Badge>
+        </React.Fragment>
+      ))}
+    </div>
+  )
+}

--- a/components/ConfirmLocationModal.tsx
+++ b/components/ConfirmLocationModal.tsx
@@ -111,7 +111,6 @@ export default function ConfirmLocationModal() {
             id="confirm-location-city"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
-            placeholder="e.g. Shoreditch"
           />
         </div>
       )}

--- a/lib/work-item.ts
+++ b/lib/work-item.ts
@@ -270,3 +270,79 @@ export const projectInclude = {
     },
   },
 } satisfies Prisma.WorkItemInclude
+
+// ── Task / starter-task serialization ───────────────────────────────────────────
+// The core fields shared by every route that returns a project TASK or a
+// QUICK_TASK ("starter task") in detail. Callers spread this and add whatever
+// denormalized display fields their own `include` fetched (assignedToName,
+// projectTitle, etc.) plus any route-specific extras.
+
+export type TaskLike = {
+  id: number
+  parentId: number | null
+  title: string
+  description: string | null
+  assigneeId: number | null
+  creatorId: number | null
+  status: string
+  estimatedHours: number | null
+  deadline: Date | null
+  completedAt: Date | null
+  createdAt: Date | null
+  updatedAt: Date | null
+}
+
+export function serializeTask(t: TaskLike) {
+  return {
+    id: t.id,
+    projectId: t.parentId,
+    title: t.title,
+    description: t.description,
+    assignedToId: t.assigneeId,
+    createdById: t.creatorId,
+    status: t.status,
+    estimatedHours: t.estimatedHours,
+    deadline: t.deadline,
+    completedAt: t.completedAt,
+    createdAt: t.createdAt,
+    updatedAt: t.updatedAt,
+  }
+}
+
+export type StarterTaskLike = {
+  id: number
+  contextProjectId: number | null
+  title: string
+  description: string | null
+  skillId: number | null
+  assigneeId: number | null
+  creatorId: number | null
+  status: string
+  reviewRating: string | null
+  reviewNotes: string | null
+  reviewedById: number | null
+  reviewedAt: Date | null
+  estimatedHours: number | null
+  createdAt: Date | null
+  updatedAt: Date | null
+}
+
+export function serializeStarterTask(t: StarterTaskLike) {
+  return {
+    id: t.id,
+    projectId: t.contextProjectId,
+    title: t.title,
+    description: t.description,
+    skillId: t.skillId,
+    assignedToId: t.assigneeId,
+    assignedById: t.creatorId,
+    status: t.status,
+    reviewRating: t.reviewRating,
+    reviewNotes: t.reviewNotes,
+    reviewedById: t.reviewedById,
+    reviewedAt: t.reviewedAt,
+    estimatedHours: t.estimatedHours,
+    createdAt: t.createdAt,
+    updatedAt: t.updatedAt,
+  }
+}

--- a/server/routers/admin/volunteers.ts
+++ b/server/routers/admin/volunteers.ts
@@ -5,6 +5,8 @@ import { redactVolunteer } from '@/lib/auth'
 import { adminProcedure } from '../../procedures'
 import { WorkItemType } from '@/generated/prisma/enums'
 
+const MAX_DETAIL_ROWS = 100
+
 const EndorsementInputSchema = z.object({
   skillId: z.number().int({ message: 'skillId is required' }),
   rating: z.string().optional().default('verified'),
@@ -35,6 +37,7 @@ export const adminVolunteersRouter = {
         where: { volunteerId: input.id },
         include: { author: { select: { name: true } } },
         orderBy: { createdAt: 'desc' },
+        take: MAX_DETAIL_ROWS,
       }),
       prisma.skillEndorsement.findMany({
         where: { volunteerId: input.id },
@@ -43,11 +46,13 @@ export const adminVolunteersRouter = {
           endorsedBy: { select: { name: true } },
         },
         orderBy: { createdAt: 'desc' },
+        take: MAX_DETAIL_ROWS,
       }),
       prisma.workItem.findMany({
         where: { type: WorkItemType.QUICK_TASK, assigneeId: input.id },
         include: { skill: { select: { name: true } } },
         orderBy: { createdAt: 'desc' },
+        take: MAX_DETAIL_ROWS,
       }),
       prisma.workItem.findMany({
         where: {
@@ -55,6 +60,7 @@ export const adminVolunteersRouter = {
           OR: [{ assigneeId: input.id }, { creatorId: input.id }],
         },
         orderBy: { createdAt: 'desc' },
+        take: MAX_DETAIL_ROWS,
       }),
     ])
 
@@ -149,6 +155,7 @@ export const adminVolunteersRouter = {
           endorsedBy: { select: { name: true } },
         },
         orderBy: { createdAt: 'desc' },
+        take: MAX_DETAIL_ROWS,
       })
       return endorsements.map((e) => ({
         id: e.id,

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -9,6 +9,7 @@ import {
   canViewWorkItem,
   resolveTeamPrivy,
   CLAIM_BLOCKING_INTEREST_STATUSES,
+  serializeTask,
 } from '@/lib/work-item'
 import { notifyUser, notifyAdmins, notifyTeamOfProject, clearNotifications } from '@/lib/notify'
 import { html } from '@/lib/email'
@@ -534,21 +535,10 @@ export const projectsRouter = {
       })
 
       const mappedTasks = sortedTasks.map((t) => ({
-        id: t.id,
-        projectId: t.parentId,
-        title: t.title,
-        description: t.description,
-        assignedToId: t.assigneeId,
+        ...serializeTask(t),
         assignedToName: t.assignee?.name ?? null,
-        createdById: t.creatorId,
         createdByName: t.creator?.name ?? null,
-        status: t.status,
         sortOrder: t.sortOrder,
-        estimatedHours: t.estimatedHours,
-        deadline: t.deadline,
-        completedAt: t.completedAt,
-        createdAt: t.createdAt,
-        updatedAt: t.updatedAt,
         commentCount: t._count.comments,
         featuredAsQuickTask: t.featuredAsQuickTask ?? false,
       }))
@@ -1178,21 +1168,10 @@ export const projectsRouter = {
       })
 
       return tasks.map((t) => ({
-        id: t.id,
-        projectId: t.parentId,
-        title: t.title,
-        description: t.description,
-        assignedToId: t.assigneeId,
+        ...serializeTask(t),
         assignedToName: t.assignee?.name ?? null,
-        createdById: t.creatorId,
         createdByName: t.creator?.name ?? null,
-        status: t.status,
         sortOrder: t.sortOrder,
-        estimatedHours: t.estimatedHours,
-        deadline: t.deadline,
-        completedAt: t.completedAt,
-        createdAt: t.createdAt,
-        updatedAt: t.updatedAt,
       }))
     }),
 
@@ -1237,23 +1216,12 @@ export const projectsRouter = {
         !(await isBlockedFromClaiming(input.projectId, volunteer.id))
 
       return {
-        id: task.id,
-        projectId: task.parentId,
+        ...serializeTask(task),
         projectTitle: project.title,
         projectOwnerId: project.assigneeId,
         canClaim,
-        title: task.title,
-        description: task.description,
-        assignedToId: task.assigneeId,
         assignedToName: task.assignee?.name ?? null,
-        createdById: task.creatorId,
         createdByName: task.creator?.name ?? null,
-        status: task.status,
-        estimatedHours: task.estimatedHours,
-        deadline: task.deadline,
-        completedAt: task.completedAt,
-        createdAt: task.createdAt,
-        updatedAt: task.updatedAt,
         featuredAsQuickTask: task.featuredAsQuickTask ?? false,
       }
     }),

--- a/server/routers/quickTasks.ts
+++ b/server/routers/quickTasks.ts
@@ -3,7 +3,7 @@ import { ORPCError } from '@orpc/server'
 import { prisma } from '@/lib/prisma'
 import { notifyUser, clearNotifications } from '@/lib/notify'
 import { CreateQuickTaskSchema, AssignQuickTaskSchema, ReviewQuickTaskSchema } from '@/lib/schemas'
-import { CLAIM_BLOCKING_INTEREST_STATUSES } from '@/lib/work-item'
+import { CLAIM_BLOCKING_INTEREST_STATUSES, serializeStarterTask } from '@/lib/work-item'
 import { adminProcedure, approvedProcedure, authedProcedure } from '../procedures'
 import { ApprovalStatus, QuickTaskStatus, TaskStatus, WorkItemType } from '@/generated/prisma/enums'
 
@@ -32,26 +32,12 @@ export const quickTasksRouter = {
       })
 
       return tasks.map((t) => ({
-        id: t.id,
-        projectId: t.contextProjectId,
-        title: t.title,
-        description: t.description,
-        skillId: t.skillId,
+        ...serializeStarterTask(t),
         skillName: t.skill?.name ?? null,
         skillCategory: t.skill?.category?.name ?? null,
         projectTitle: t.contextProject?.title ?? null,
-        assignedToId: t.assigneeId,
         assignedToName: t.assignee?.name ?? null,
-        assignedById: t.creatorId,
-        status: t.status,
-        reviewRating: t.reviewRating,
-        reviewNotes: t.reviewNotes,
-        reviewedById: t.reviewedById,
         reviewedByName: t.reviewedBy?.name ?? null,
-        reviewedAt: t.reviewedAt,
-        estimatedHours: t.estimatedHours,
-        createdAt: t.createdAt,
-        updatedAt: t.updatedAt,
       }))
     }),
 
@@ -170,23 +156,9 @@ export const quickTasksRouter = {
         throw new ORPCError('FORBIDDEN', { message: 'You do not have access to this task' })
       }
       return {
-        id: task.id,
-        projectId: task.contextProjectId,
+        ...serializeStarterTask(task),
         projectTitle: task.contextProject?.title ?? null,
-        title: task.title,
-        description: task.description,
-        skillId: task.skillId,
         skillName: task.skill?.name ?? null,
-        assignedToId: task.assigneeId,
-        assignedById: task.creatorId,
-        status: task.status,
-        reviewRating: task.reviewRating,
-        reviewNotes: task.reviewNotes,
-        reviewedById: task.reviewedById,
-        reviewedAt: task.reviewedAt,
-        estimatedHours: task.estimatedHours,
-        createdAt: task.createdAt,
-        updatedAt: task.updatedAt,
       }
     }),
 


### PR DESCRIPTION
## Summary
- Add `app/robots.ts` and `app/sitemap.ts`, disallowing auth-gated routes and listing only genuinely public pages
- Bound the remaining unbounded admin volunteer detail queries (adminNote, skillEndorsement, workItem) to 100 rows, matching the existing volunteer list procedure
- Make the last bare `grid-cols-2` layouts on project edit, volunteer detail, and admin applications pages responsive below 600px, matching the dashboard's existing pattern
- Add `serializeTask`/`serializeStarterTask` helpers in `lib/work-item.ts` to dedupe the repeated inline field-mapping in `projects.ts` and `quickTasks.ts` (no response shape changes)
- Add a stepped approval status badge (`ApprovalStepper`) to the dashboard's pending-approval banner (Applied → Under Review → Approved/Rejected), and widen that banner to also cover `under_review` (previously showed nothing for that stage)
- Remove the UK-specific "e.g. Shoreditch" placeholder from the three location inputs (signup, settings, confirm-location modal)

Closes #137, #134, #142 (partial — dashboard grid was already responsive), #83, #116

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite — 217 passed, 5 skipped)
- [x] Manually verified the approval stepper against a seeded `under_review` volunteer in the local dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tR28Bp8KTrowk3eHWCEYP