### PR TITLE
Finish #142: remaining mobile responsive gaps

### DIFF
--- a/app/admin/email-preview/page.tsx
+++ b/app/admin/email-preview/page.tsx
@@ -203,25 +203,27 @@ function EmailRow({
           Open in new tab ↗
         </button>
       </div>
-      <div className="grid grid-cols-[300px_1fr] gap-8 items-start">
+      <div className="grid grid-cols-[300px_1fr] gap-8 items-start max-[700px]:grid-cols-1">
         <div>
           <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-[0.05em] mb-2">
             Parameters
           </p>
-          <table className="w-full border-collapse text-[13px]">
-            <tbody>
-              {Object.entries(type.params).map(([key, val]) => (
-                <tr key={key}>
-                  <td className="py-1 pr-2 pl-0 text-gray-500 whitespace-nowrap align-top">
-                    {key}
-                  </td>
-                  <td className="py-1 text-secondary break-words">
-                    {typeof val === 'boolean' ? (val ? 'true' : 'false') : String(val)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-[13px]">
+              <tbody>
+                {Object.entries(type.params).map(([key, val]) => (
+                  <tr key={key}>
+                    <td className="py-1 pr-2 pl-0 text-gray-500 whitespace-nowrap align-top">
+                      {key}
+                    </td>
+                    <td className="py-1 text-secondary break-words">
+                      {typeof val === 'boolean' ? (val ? 'true' : 'false') : String(val)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
         <div>
           {preview?.subject && (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -101,7 +101,7 @@ export default function AdminLandingPage() {
       <h1>{user.isSuperAdmin ? 'Super Admin' : 'Admin'}</h1>
 
       {!loadingStats && stats && (
-        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 mb-6 max-[500px]:grid-cols-1">
           <div className="bg-surface rounded-xl shadow p-6 overflow-hidden">
             <h2 className="mt-0">Volunteers</h2>
             <div className="grid grid-cols-2 gap-5 mt-4">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -287,7 +287,7 @@ export default function DashboardPage() {
         )}
 
         {/* Quick stats */}
-        <div className="grid grid-cols-3 gap-5 mb-8 max-[600px]:grid-cols-1">
+        <div className="grid grid-cols-3 gap-5 mb-8 max-[900px]:grid-cols-2 max-[600px]:grid-cols-1">
           {/* [test hook] card, stat-number classes used as test selectors */}
           <div className="card bg-surface rounded-xl shadow p-6 text-center">
             <div className="stat-number text-4xl font-bold text-primary mb-1">


### PR DESCRIPTION
## Summary
- Dashboard quick-stats grid only collapsed 3→1 col below 600px, cramped on tablet widths — add a 3→2→1 step
- Admin landing page's stat cards stayed 2-up down to the smallest viewports, squeezing each card's own 2-col stat grid so narrow that labels overlapped ("Total Registered" / "Joined This Month") — drop to 1 column below 500px
- Email-preview's 300px-sidebar layout didn't collapse at all on narrow viewports, and its params table had no horizontal-scroll wrapper

Closes the remainder of #142 (PR #226 already fixed the project-edit, volunteer-detail, and admin-applications grids).

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite — 217 passed, 5 skipped)
- [x] Visually confirmed the admin landing page overlap (screenshot) is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tR28Bp8KTrowk3eHWCEYP