### PR TITLE
Multi-session model: hashed per-device sessions replace single auth token

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -223,6 +223,16 @@ function SettingsPageContent() {
     },
   })
 
+  const logoutOtherSessionsMutation = useMutation({
+    ...orpc.auth.logoutOtherSessions.mutationOptions(),
+    onSuccess: (data) => {
+      showToast(data.message, 'success')
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to sign out other sessions', 'error')
+    },
+  })
+
   const deleteAccountMutation = useMutation({
     ...orpc.auth.deleteAccount.mutationOptions(),
     onSuccess: (data) => {
@@ -639,6 +649,23 @@ function SettingsPageContent() {
                 {changePasswordMutation.isPending ? 'Changing…' : 'Change Password'}
               </Button>
             </form>
+          </div>
+
+          <div className="bg-surface rounded-xl shadow p-6 mb-6 overflow-hidden wrap-break-word">
+            <h2>Sessions</h2>
+            <p className="text-text-light mb-4">
+              Sign out everywhere except this device — use this if you signed in somewhere you no
+              longer trust.
+            </p>
+            <Button
+              variant="outline"
+              disabled={logoutOtherSessionsMutation.isPending}
+              onClick={() => logoutOtherSessionsMutation.mutate({})}
+            >
+              {logoutOtherSessionsMutation.isPending
+                ? 'Signing out other sessions…'
+                : 'Log out of all other sessions'}
+            </Button>
           </div>
 
           <div className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word">

--- a/e2e/tests/33-sessions.spec.ts
+++ b/e2e/tests/33-sessions.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '../fixtures'
+import { createApiClient } from '../client'
+
+test.describe('Sessions (API)', () => {
+  test('Logging out other sessions kills every other token but keeps the caller signed in', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    const anonApi = createApiClient(baseUrl)
+
+    const loginA = await anonApi.auth.login({
+      body: { email: volunteer.email, password: volunteer.password },
+    })
+    expect(loginA.status).toBe(200)
+    const tokenA = (loginA.body as { token: string }).token
+
+    const loginB = await anonApi.auth.login({
+      body: { email: volunteer.email, password: volunteer.password },
+    })
+    expect(loginB.status).toBe(200)
+    const tokenB = (loginB.body as { token: string }).token
+
+    // Both sessions independently authenticated before either is touched.
+    const apiA = createApiClient(baseUrl, tokenA)
+    const apiB = createApiClient(baseUrl, tokenB)
+    expect((await apiA.auth.me()).status).toBe(200)
+    expect((await apiB.auth.me()).status).toBe(200)
+
+    const result = await apiA.auth.logoutOtherSessions()
+    expect(result.status).toBe(200)
+
+    // The session that made the call survives...
+    expect((await apiA.auth.me()).status).toBe(200)
+    // ...but every other session for that volunteer is gone.
+    expect((await apiB.auth.me()).status).toBe(401)
+
+    // A new login afterwards is unaffected.
+    const loginC = await anonApi.auth.login({
+      body: { email: volunteer.email, password: volunteer.password },
+    })
+    expect(loginC.status).toBe(200)
+    const tokenC = (loginC.body as { token: string }).token
+    const apiC = createApiClient(baseUrl, tokenC)
+    expect((await apiC.auth.me()).status).toBe(200)
+  })
+
+  test('logoutOtherSessions requires authentication', async ({ baseUrl }) => {
+    const anonApi = createApiClient(baseUrl)
+    const result = await anonApi.auth.logoutOtherSessions()
+    expect(result.status).toBe(401)
+  })
+})

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,4 @@
-import { randomBytes, pbkdf2Sync, timingSafeEqual } from 'crypto'
+import { randomBytes, pbkdf2Sync, timingSafeEqual, createHash } from 'crypto'
 import type { Volunteer } from '@/generated/prisma/client'
 import { prisma } from './prisma'
 import { env } from './env'
@@ -39,19 +39,80 @@ export function authTokenExpiry(): Date {
   return new Date(Date.now() + AUTH_TOKEN_TTL_MS)
 }
 
-export async function getCurrentVolunteer(authorization: string | null | undefined) {
+export function extractToken(authorization: string | null | undefined): string | null {
   if (!authorization) return null
-  const token = authorization.startsWith('Bearer ') ? authorization.slice(7) : authorization
-  // A null expiry is treated as expired, not as "never expires" — every code path that
-  // issues a token sets one (see authTokenExpiry), and the backfill migration gave
-  // pre-existing sessions an expiry too.
-  return prisma.volunteer.findFirst({
-    where: {
-      authToken: token,
-      deletedAt: null,
-      authTokenExpiresAt: { gt: new Date() },
-    },
+  return authorization.startsWith('Bearer ') ? authorization.slice(7) : authorization
+}
+
+// Session tokens are stored hashed (see #225 / #224): a DB or backup leak hands over
+// ciphertext, not live sessions. The raw token only ever exists in the Authorization
+// header and the client's localStorage.
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+export async function createSession(volunteerId: number): Promise<string> {
+  const token = generateAuthToken()
+  await prisma.session.create({
+    data: { volunteerId, tokenHash: hashToken(token), expiresAt: authTokenExpiry() },
   })
+  return token
+}
+
+export async function deleteSession(token: string): Promise<void> {
+  await prisma.session.deleteMany({ where: { tokenHash: hashToken(token) } })
+}
+
+// "Sign out everywhere" / password change / account deletion.
+export async function deleteAllSessions(volunteerId: number): Promise<void> {
+  await prisma.session.deleteMany({ where: { volunteerId } })
+}
+
+// "Sign out of all other devices" — keeps the session the request came in on.
+export async function deleteOtherSessions(
+  volunteerId: number,
+  currentToken: string,
+): Promise<void> {
+  await prisma.session.deleteMany({
+    where: { volunteerId, tokenHash: { not: hashToken(currentToken) } },
+  })
+}
+
+export async function getCurrentVolunteer(authorization: string | null | undefined) {
+  const token = extractToken(authorization)
+  if (!token) return null
+
+  const session = await prisma.session.findFirst({
+    where: { tokenHash: hashToken(token), expiresAt: { gt: new Date() } },
+    include: { volunteer: true },
+  })
+  if (session) {
+    if (session.volunteer.deletedAt) return null
+    // Fire-and-forget: a failed lastUsedAt touch shouldn't fail the request it came with.
+    prisma.session
+      .update({ where: { id: session.id }, data: { lastUsedAt: new Date() } })
+      .catch(() => {})
+    return session.volunteer
+  }
+
+  // Legacy fallback: a session opened before #225, still living on the old single-token
+  // columns. Lazily promote it into a real (hashed) Session row so it keeps working
+  // without forcing a re-login, then never touch the legacy columns again — new logins
+  // no longer write to them, so this path stops firing once those tokens expire.
+  const legacyVolunteer = await prisma.volunteer.findFirst({
+    where: { authToken: token, deletedAt: null, authTokenExpiresAt: { gt: new Date() } },
+  })
+  if (!legacyVolunteer) return null
+  await prisma.session
+    .create({
+      data: {
+        volunteerId: legacyVolunteer.id,
+        tokenHash: hashToken(token),
+        expiresAt: legacyVolunteer.authTokenExpiresAt as Date,
+      },
+    })
+    .catch(() => {})
+  return legacyVolunteer
 }
 
 // showContact controls whether email and direct contact fields are included.

--- a/prisma/migrations/20260824183733_add_sessions_table/migration.sql
+++ b/prisma/migrations/20260824183733_add_sessions_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "volunteer_id" INTEGER NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_used_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" DATETIME NOT NULL,
+    CONSTRAINT "sessions_volunteer_id_fkey" FOREIGN KEY ("volunteer_id") REFERENCES "volunteers" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_hash_key" ON "sessions"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "idx_sessions_volunteer" ON "sessions"("volunteer_id");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -630,6 +630,10 @@ model Volunteer {
   consentShareContactInfoWithProjectOwner Boolean?                 @default(false) @map("consent_share_contact_info_with_project_owner")
   consentGivenAt                          DateTime?                @map("consent_given_at")
   cookieConsentAnalytics                  Boolean?                 @map("cookie_consent_analytics")
+  /// Legacy single-session token, superseded by Session. Kept only so getCurrentVolunteer
+  /// can lazily migrate pre-existing sessions into Session rows without logging anyone out;
+  /// nothing writes to these columns anymore. Safe to drop once #225's 30-day expiry window
+  /// has fully elapsed.
   /// @zod.custom.omit([model])
   authToken                               String?                  @unique(map: "sqlite_autoindex_volunteers_2") @map("auth_token")
   /// @zod.custom.omit([model])
@@ -684,6 +688,7 @@ model Volunteer {
   teamSuggestionsReviewed                 TeamSuggestion[]         @relation("TeamSuggestionReviewedBy")
   teamJoinRequests                        TeamJoinRequest[]        @relation("TeamJoinRequestVolunteer")
   teamJoinRequestsReviewed                TeamJoinRequest[]        @relation("TeamJoinRequestReviewedBy")
+  sessions                                Session[]
 
   @@index([localGroup], map: "idx_volunteers_local_group")
   @@index([country], map: "idx_volunteers_country")
@@ -691,6 +696,19 @@ model Volunteer {
   @@index([authToken], map: "idx_volunteers_auth_token")
   @@index([email], map: "idx_volunteers_email")
   @@map("volunteers")
+}
+
+model Session {
+  id          Int       @id @default(autoincrement())
+  volunteerId Int       @map("volunteer_id")
+  tokenHash   String    @unique @map("token_hash")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  lastUsedAt  DateTime  @default(now()) @map("last_used_at")
+  expiresAt   DateTime  @map("expires_at")
+  volunteer   Volunteer @relation(fields: [volunteerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([volunteerId], map: "idx_sessions_volunteer")
+  @@map("sessions")
 }
 
 model RejectedApplication {

--- a/server/context.ts
+++ b/server/context.ts
@@ -1,9 +1,9 @@
-import { getCurrentVolunteer } from '@/lib/auth'
+import { getCurrentVolunteer, extractToken } from '@/lib/auth'
 
 export async function createContext(request: Request) {
   const authorization = request.headers.get('authorization')
   const volunteer = await getCurrentVolunteer(authorization)
-  return { volunteer, request }
+  return { volunteer, token: extractToken(authorization), request }
 }
 
 export type Context = Awaited<ReturnType<typeof createContext>>

--- a/server/procedures.ts
+++ b/server/procedures.ts
@@ -9,7 +9,7 @@ export const publicProcedure = base
 
 export const authedProcedure = base.use(({ context, next }) => {
   if (!context.volunteer) throw new ORPCError('UNAUTHORIZED')
-  return next({ context: { volunteer: context.volunteer } })
+  return next({ context: { volunteer: context.volunteer, token: context.token } })
 })
 
 export const approvedProcedure = authedProcedure.use(({ context, next }) => {

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -6,7 +6,10 @@ import {
   verifyPassword,
   hashPassword,
   generateAuthToken,
-  authTokenExpiry,
+  createSession,
+  deleteSession,
+  deleteAllSessions,
+  deleteOtherSessions,
   checkAdminBootstrap,
   acceptPendingInvite,
   redactVolunteer,
@@ -217,14 +220,10 @@ export const authRouter = {
       const inviteAccepted = await acceptPendingInvite(email, volunteer.id)
       if (inviteAccepted) wasPromoted = true
 
-      const authToken = generateAuthToken()
-      await prisma.volunteer.update({
-        where: { id: volunteer.id },
-        data: { authToken, authTokenExpiresAt: authTokenExpiry(), updatedAt: new Date() },
-      })
+      const token = await createSession(volunteer.id)
 
       return {
-        token: authToken,
+        token,
         wasPromoted,
         message: wasPromoted
           ? "Login successful - you've been granted admin access!"
@@ -266,14 +265,11 @@ export const authRouter = {
       })
     }
 
-    const authToken = generateAuthToken()
     const volunteer = await prisma.volunteer.create({
       data: {
         name: input.name,
         email,
         passwordHash: hashPassword(input.password),
-        authToken,
-        authTokenExpiresAt: authTokenExpiry(),
         applicationMessage: input.applicationMessage ?? null,
         bio: input.bio ?? null,
         discordHandle: input.discordHandle ?? null,
@@ -350,20 +346,24 @@ export const authRouter = {
       ).catch((e) => console.error('[SIGNUP NOTIFY]', e))
     }
 
+    const token = await createSession(volunteer.id)
     return {
       id: volunteer.id,
-      token: authToken,
+      token,
       pending: !isApproved,
       ...(STUB_EMAIL && emailVerificationToken ? { emailVerificationToken } : {}),
     }
   }),
 
   logout: authedProcedure.handler(async ({ context }) => {
-    await prisma.volunteer.update({
-      where: { id: context.volunteer.id },
-      data: { authToken: null, authTokenExpiresAt: null },
-    })
+    if (context.token) await deleteSession(context.token)
     return { message: 'Logged out' }
+  }),
+
+  logoutOtherSessions: authedProcedure.handler(async ({ context }) => {
+    if (!context.token) throw new ORPCError('UNAUTHORIZED')
+    await deleteOtherSessions(context.volunteer.id, context.token)
+    return { message: 'Signed out of all other sessions' }
   }),
 
   me: authedProcedure.handler(async ({ context }) => {
@@ -417,19 +417,19 @@ export const authRouter = {
       if (!vol?.passwordHash || !verifyPassword(input.currentPassword, vol.passwordHash)) {
         throw new ORPCError('BAD_REQUEST', { message: 'Current password is incorrect' })
       }
-      // Rotate the session token: a password change must invalidate any session opened
-      // with the old password. The caller gets the replacement so it stays signed in.
-      const authToken = generateAuthToken()
+      // A password change must invalidate every session opened with the old password —
+      // not just this one. Drop them all, then issue a fresh one so the caller stays
+      // signed in.
       await prisma.volunteer.update({
         where: { id: context.volunteer.id },
         data: {
           passwordHash: hashPassword(input.newPassword),
-          authToken,
-          authTokenExpiresAt: authTokenExpiry(),
           updatedAt: new Date(),
         },
       })
-      return { message: 'Password changed successfully', token: authToken }
+      await deleteAllSessions(context.volunteer.id)
+      const token = await createSession(context.volunteer.id)
+      return { message: 'Password changed successfully', token }
     }),
 
   changeEmail: authedProcedure.input(ChangeEmailSchema).handler(async ({ input, context }) => {
@@ -548,11 +548,10 @@ export const authRouter = {
       where: { id: tokenRecord.volunteerId },
       data: {
         passwordHash: hashPassword(input.newPassword),
-        authToken: null,
-        authTokenExpiresAt: null,
         updatedAt: new Date(),
       },
     })
+    await deleteAllSessions(tokenRecord.volunteerId)
     await prisma.passwordResetToken.update({
       where: { id: tokenRecord.id },
       data: { usedAt: new Date() },
@@ -685,6 +684,7 @@ export const authRouter = {
         },
       })
       await sendAccountDeletionNotifications(context.volunteer.id, context.volunteer.name)
+      await deleteAllSessions(context.volunteer.id)
       await prisma.volunteer.update({
         where: { id: context.volunteer.id },
         data: {
@@ -743,15 +743,11 @@ export const authRouter = {
 
       const existing = await prisma.volunteer.findFirst({ where: { email, deletedAt: null } })
       if (existing) {
-        const authToken = generateAuthToken()
-        await prisma.volunteer.update({
-          where: { id: existing.id },
-          data: { authToken, authTokenExpiresAt: authTokenExpiry(), updatedAt: new Date() },
-        })
+        const token = await createSession(existing.id)
         let wasPromoted = await checkAdminBootstrap(email, existing.id)
         if (await acceptPendingInvite(email, existing.id)) wasPromoted = true
         return {
-          token: authToken,
+          token,
           wasPromoted,
           isNewUser: false,
           isPending: false,
@@ -816,13 +812,10 @@ export const authRouter = {
         })
       }
 
-      const authToken = generateAuthToken()
       const volunteer = await prisma.volunteer.create({
         data: {
           name,
           email,
-          authToken,
-          authTokenExpiresAt: authTokenExpiry(),
           emailConfirmed: true,
           applicationMessage: input.applicationMessage,
           bio: input.bio,
@@ -865,8 +858,9 @@ export const authRouter = {
           console.error('[GOOGLE_SIGNUP]', e),
         )
       }
+      const token = await createSession(volunteer.id)
       return {
-        token: authToken,
+        token,
         wasPromoted: wasBootstrapped || wasInvited,
         pending: !isApproved,
         name,


### PR DESCRIPTION
## Summary
- Replaces the single `authToken`/`authTokenExpiresAt` columns on `volunteers` with a `sessions` table — one row per signed-in device, so signing in on a phone no longer silently signs you out on your laptop.
- Session tokens are stored hashed (SHA-256), not plaintext — pairs with #224's threat model (DB/backup leak should hand over ciphertext, not live sessions).
- Existing single-token sessions are lazily migrated into `Session` rows on first use, so nobody gets logged out on deploy.
- Adds "Log out of all other sessions" in Settings.

## Details
- `lib/auth.ts`: `createSession`, `deleteSession`, `deleteAllSessions`, `deleteOtherSessions`, `hashToken`; `getCurrentVolunteer` checks `Session` first, falls back to the legacy `auth_token` column and lazily promotes it.
- `login`/`signup`/`google`/`completeGoogleSignup` now issue a session via `createSession`.
- `logout` deletes just the calling session; `changePassword`/`resetPassword`/`deleteAccount` call `deleteAllSessions`.
- New `authRouter.logoutOtherSessions` endpoint + Settings UI button.
- Migration `20260824183733_add_sessions_table` only creates the table — no data movement, since SQLite has no way to compute the SHA-256 hash in pure SQL. Legacy columns are kept (unused by new logins) purely so the lazy-migration fallback has something to read from; safe to drop in a follow-up once the 30-day expiry window has fully elapsed.

Closes #225

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite — 219 passed / 5 skipped)
- [x] New `e2e/tests/33-sessions.spec.ts`: confirms `logoutOtherSessions` kills every other token for a volunteer while the calling session survives, and that a fresh login afterward is unaffected; confirms the endpoint requires auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tR28Bp8KTrowk3eHWCEYP