### PR TITLE
Add draft status for org-proposed projects

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -75,7 +75,7 @@ export default function AdminLandingPage() {
       title: 'Projects',
       links: [
         { href: '/admin/triage', label: 'Triage Queue', count: counts?.pendingTriage },
-        { href: '/admin/projects/new', label: 'Create Org Project' },
+        { href: '/admin/projects/new', label: 'Org Projects' },
       ],
     },
     {

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -23,7 +23,8 @@ export default function AdminCreateProjectPage() {
         <div className="max-w-4xl">
           <ProjectForm
             onSubmitForm={(data) => createMutation.mutateAsync(data)}
-            submitLabel="Create Project"
+            submitLabel="Publish"
+            onSaveDraft={(data) => createMutation.mutateAsync({ ...data, saveAsDraft: true })}
             onSuccess={(id) => router.push(`/projects/${id}`)}
             onCancel={() => router.back()}
           />

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -2,7 +2,8 @@
 
 import { useRequireAdmin } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import Button from '@/components/Button'
 import ProjectForm from '@/components/ProjectForm'
 import { orpc } from '@/lib/orpc'
 
@@ -11,21 +12,50 @@ export default function AdminCreateProjectPage() {
   const { user, loading } = useRequireAdmin()
   const createMutation = useMutation({ ...orpc.admin.projects.create.mutationOptions() })
 
+  const { data: drafts = [] } = useQuery({
+    ...orpc.admin.projects.myDrafts.queryOptions(),
+    enabled: !!user,
+  })
+
   if (loading || !user) return null
 
   return (
     <>
       <main className="container py-5 pb-15">
-        <h1 role="heading">Create Organisation Project</h1>
+        <h1 role="heading">Org Projects</h1>
         <p className="text-text-light mb-6">
           Create a project on behalf of PauseAI. This skips the approval process.
         </p>
+
+        {drafts.length > 0 && (
+          <div className="max-w-4xl bg-surface rounded-xl shadow p-6 mb-4">
+            <h2 className="mt-0 mb-3">My Drafts</h2>
+            <p className="text-sm text-text-light mt-0 mb-3">
+              Publishing and deleting a draft are both done from its edit page.
+            </p>
+            <ul className="flex flex-col gap-2">
+              {drafts.map((draft) => (
+                <li
+                  key={draft.id}
+                  className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
+                >
+                  <span className="font-medium">{draft.title || 'Untitled draft'}</span>
+                  <Button href={`/projects/${draft.id}/edit`} size="sm">
+                    Edit
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         <div className="max-w-4xl">
           <ProjectForm
             onSubmitForm={(data) => createMutation.mutateAsync(data)}
             submitLabel="Publish"
             onSaveDraft={(data) => createMutation.mutateAsync({ ...data, saveAsDraft: true })}
             onSuccess={(id) => router.push(`/projects/${id}`)}
+            onDraftSuccess={(id) => router.push(`/projects/${id}/edit`)}
             onCancel={() => router.back()}
           />
         </div>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -50,6 +50,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [initialized, setInitialized] = useState(false)
   const [showPublishModal, setShowPublishModal] = useState(false)
   const [showDeleteDraftModal, setShowDeleteDraftModal] = useState(false)
+  const [showDeleteProjectModal, setShowDeleteProjectModal] = useState(false)
   const [newTaskTitle, setNewTaskTitle] = useState('')
   const [newTaskDescription, setNewTaskDescription] = useState('')
 
@@ -117,15 +118,20 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     onSuccess: () => router.push('/projects'),
     onError: (err: unknown) => {
       showToast(err instanceof Error ? err.message : 'Failed to delete project', 'error')
+      setShowDeleteProjectModal(false)
     },
   })
 
   const publishMutation = useMutation({
     ...orpc.projects.publishDraft.mutationOptions(),
     onSuccess: () => {
-      showToast('Draft submitted for review!', 'success')
+      showToast(isOrgDraft ? 'Project published!' : 'Draft submitted for review!', 'success')
       setShowPublishModal(false)
-      setTimeout(() => router.push('/dashboard#tab-proposed'), 1500)
+      // Otherwise the project page picks up the pre-publish cached `draft` status and
+      // immediately redirects back here.
+      queryClient.invalidateQueries({ queryKey: orpc.projects.getById.key() })
+      const destination = isOrgDraft ? `/projects/${idParam}` : '/dashboard#tab-proposed'
+      setTimeout(() => router.push(destination), 1500)
     },
     onError: (err: unknown) => {
       showToast(err instanceof Error ? err.message : 'Failed to publish draft', 'error')
@@ -204,15 +210,10 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     })
   }
 
-  function handleDelete() {
-    if (!window.confirm('Are you sure you want to delete this project? This cannot be undone.'))
-      return
-    deleteMutation.mutate({ id: parseInt(idParam, 10) })
-  }
-
   if (loading || !user) return null
 
   const isDraft = projectData?.status === 'draft'
+  const isOrgDraft = projectData?.isOrgProposed === true
 
   if (loadingProject) {
     return (
@@ -465,9 +466,11 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               {updateMutation.isPending ? 'Saving…' : 'Save Changes'}
             </Button>
 
-            <Button href={`/projects/${idParam}`} variant="secondary">
-              View Project
-            </Button>
+            {!isDraft && (
+              <Button href={`/projects/${idParam}`} variant="secondary">
+                View Project
+              </Button>
+            )}
 
             {isDraft && canEdit && (
               <Button
@@ -475,7 +478,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
                 onClick={() => setShowPublishModal(true)}
                 disabled={publishMutation.isPending}
               >
-                Publish
+                {isOrgDraft ? 'Publish' : 'Submit'}
               </Button>
             )}
 
@@ -490,11 +493,11 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               </Button>
             )}
 
-            {user.isAdmin && projectData && (
+            {user.isAdmin && projectData && !isDraft && (
               <Button
                 type="button"
                 variant="danger"
-                onClick={handleDelete}
+                onClick={() => setShowDeleteProjectModal(true)}
                 disabled={deleteMutation.isPending}
               >
                 {deleteMutation.isPending ? 'Deleting…' : 'Delete Project'}
@@ -504,14 +507,48 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
         </form>
 
         <Modal
+          id="confirm-delete-project"
+          title="Delete this project?"
+          isOpen={showDeleteProjectModal}
+          onClose={() => setShowDeleteProjectModal(false)}
+        >
+          <p>
+            This will permanently delete <strong>{title || 'this project'}</strong>, including its
+            tasks, comments, and interest history. This cannot be undone.
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setShowDeleteProjectModal(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => deleteMutation.mutate({ id: parseInt(idParam, 10) })}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete Project'}
+            </Button>
+          </div>
+        </Modal>
+
+        <Modal
           id="confirm-publish-draft"
-          title="Submit draft for review?"
+          title={isOrgDraft ? 'Publish this project?' : 'Submit draft for review?'}
           isOpen={showPublishModal}
           onClose={() => setShowPublishModal(false)}
         >
           <p>
-            This will submit <strong>{title || 'this project'}</strong> to PauseAI team leads for
-            review. You won&apos;t be able to edit it as a draft anymore.
+            {isOrgDraft ? (
+              <>
+                This will publish <strong>{title || 'this project'}</strong> immediately. It will be
+                visible to volunteers straight away, and you won&apos;t be able to edit it as a
+                draft anymore.
+              </>
+            ) : (
+              <>
+                This will submit <strong>{title || 'this project'}</strong> to PauseAI team leads
+                for review. You won&apos;t be able to edit it as a draft anymore.
+              </>
+            )}
           </p>
           <div className="mt-4 flex justify-end gap-2">
             <Button variant="secondary" onClick={() => setShowPublishModal(false)}>
@@ -521,7 +558,13 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               onClick={() => publishMutation.mutate({ id: parseInt(idParam, 10) })}
               disabled={publishMutation.isPending}
             >
-              {publishMutation.isPending ? 'Submitting…' : 'Submit for Review'}
+              {isOrgDraft
+                ? publishMutation.isPending
+                  ? 'Publishing…'
+                  : 'Publish'
+                : publishMutation.isPending
+                  ? 'Submitting…'
+                  : 'Submit for Review'}
             </Button>
           </div>
         </Modal>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -53,6 +53,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [showDeleteProjectModal, setShowDeleteProjectModal] = useState(false)
   const [newTaskTitle, setNewTaskTitle] = useState('')
   const [newTaskDescription, setNewTaskDescription] = useState('')
+  const [editingTaskId, setEditingTaskId] = useState<number | null>(null)
+  const [editTaskTitle, setEditTaskTitle] = useState('')
+  const [editTaskDescription, setEditTaskDescription] = useState('')
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -173,6 +176,17 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     },
   })
 
+  const updateTaskMutation = useMutation({
+    ...orpc.projects.updateTask.mutationOptions(),
+    onSuccess: () => {
+      setEditingTaskId(null)
+      queryClient.invalidateQueries({ queryKey: orpc.projects.getById.key() })
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to update task', 'error')
+    },
+  })
+
   function handleAddTask(e: React.FormEvent) {
     e.preventDefault()
     if (!newTaskTitle.trim()) return
@@ -186,6 +200,24 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   function handleDeleteTask(taskId: number) {
     if (!window.confirm('Delete this task?')) return
     deleteTaskMutation.mutate({ projectId: parseInt(idParam, 10), taskId })
+  }
+
+  function startEditingTask(task: { id: number; title: string; description: string | null }) {
+    setEditingTaskId(task.id)
+    setEditTaskTitle(task.title)
+    setEditTaskDescription(task.description ?? '')
+  }
+
+  function handleSaveTask(taskId: number) {
+    if (!editTaskTitle.trim()) return
+    updateTaskMutation.mutate({
+      projectId: parseInt(idParam, 10),
+      taskId,
+      data: {
+        title: editTaskTitle.trim(),
+        description: editTaskDescription.trim() || null,
+      },
+    })
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -389,23 +421,87 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               </p>
               {(projectData?.tasks ?? []).length > 0 && (
                 <ul className="list-none p-0 m-0 mb-3 flex flex-col gap-2">
-                  {(projectData?.tasks ?? []).map((task) => (
-                    <li
-                      key={task.id}
-                      className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
-                    >
-                      <span>{task.title}</span>
-                      <Button
-                        type="button"
-                        variant="danger"
-                        size="sm"
-                        onClick={() => handleDeleteTask(task.id)}
-                        disabled={deleteTaskMutation.isPending}
+                  {(projectData?.tasks ?? []).map((task) =>
+                    editingTaskId === task.id ? (
+                      <li
+                        key={task.id}
+                        className="bg-brand-bg rounded-lg p-3 border border-brand-border"
                       >
-                        Delete
-                      </Button>
-                    </li>
-                  ))}
+                        <div className="mb-2">
+                          <label htmlFor={`edit-task-title-${task.id}`} className="text-sm">
+                            Edit task title
+                          </label>
+                          <input
+                            id={`edit-task-title-${task.id}`}
+                            type="text"
+                            value={editTaskTitle}
+                            onChange={(e) => setEditTaskTitle(e.target.value)}
+                            autoFocus
+                          />
+                        </div>
+                        <div className="mb-2">
+                          <label htmlFor={`edit-task-description-${task.id}`} className="text-sm">
+                            Edit task details (optional)
+                          </label>
+                          <textarea
+                            id={`edit-task-description-${task.id}`}
+                            rows={2}
+                            value={editTaskDescription}
+                            onChange={(e) => setEditTaskDescription(e.target.value)}
+                          />
+                        </div>
+                        <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            onClick={() => handleSaveTask(task.id)}
+                            disabled={updateTaskMutation.isPending || !editTaskTitle.trim()}
+                          >
+                            {updateTaskMutation.isPending ? 'Saving…' : 'Save'}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setEditingTaskId(null)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </li>
+                    ) : (
+                      <li
+                        key={task.id}
+                        className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
+                      >
+                        <div className="min-w-0">
+                          <p className="m-0">{task.title}</p>
+                          {task.description && (
+                            <p className="m-0 text-sm text-text-light">{task.description}</p>
+                          )}
+                        </div>
+                        <div className="flex gap-2 shrink-0">
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => startEditingTask(task)}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="danger"
+                            size="sm"
+                            onClick={() => handleDeleteTask(task.id)}
+                            disabled={deleteTaskMutation.isPending}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </li>
+                    ),
+                  )}
                 </ul>
               )}
               <div className="bg-brand-bg rounded-lg p-3 border border-brand-border">

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -3,11 +3,12 @@
 import React, { use, useEffect, useState } from 'react'
 import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Checkbox from '@/components/Checkbox'
 import FilterDropdown from '@/components/FilterDropdown'
 import SkillPicker from '@/components/SkillPicker'
+import Modal from '@/components/ui/Modal'
 import { orpc } from '@/lib/orpc'
 import { useToast } from '@/lib/toast'
 import { buildLocationOptions } from '@/lib/filter-options'
@@ -42,10 +43,15 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const router = useRouter()
   const { user, loading } = useRequireAuth()
   const showToast = useToast()
+  const queryClient = useQueryClient()
 
   const [canEdit, setCanEdit] = useState(false)
   const [permissionChecked, setPermissionChecked] = useState(false)
   const [initialized, setInitialized] = useState(false)
+  const [showPublishModal, setShowPublishModal] = useState(false)
+  const [showDeleteDraftModal, setShowDeleteDraftModal] = useState(false)
+  const [newTaskTitle, setNewTaskTitle] = useState('')
+  const [newTaskDescription, setNewTaskDescription] = useState('')
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -114,6 +120,68 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     },
   })
 
+  const publishMutation = useMutation({
+    ...orpc.projects.publishDraft.mutationOptions(),
+    onSuccess: () => {
+      showToast('Draft submitted for review!', 'success')
+      setShowPublishModal(false)
+      setTimeout(() => router.push('/dashboard#tab-proposed'), 1500)
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to publish draft', 'error')
+      setShowPublishModal(false)
+    },
+  })
+
+  const deleteDraftMutation = useMutation({
+    ...orpc.projects.deleteDraft.mutationOptions(),
+    onSuccess: () => {
+      showToast('Draft deleted', 'success')
+      router.push('/suggest')
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to delete draft', 'error')
+      setShowDeleteDraftModal(false)
+    },
+  })
+
+  const createTaskMutation = useMutation({
+    ...orpc.projects.createTask.mutationOptions(),
+    onSuccess: () => {
+      setNewTaskTitle('')
+      setNewTaskDescription('')
+      queryClient.invalidateQueries({ queryKey: orpc.projects.getById.key() })
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to create task', 'error')
+    },
+  })
+
+  const deleteTaskMutation = useMutation({
+    ...orpc.projects.deleteTask.mutationOptions(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orpc.projects.getById.key() })
+    },
+    onError: (err: unknown) => {
+      showToast(err instanceof Error ? err.message : 'Failed to delete task', 'error')
+    },
+  })
+
+  function handleAddTask(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newTaskTitle.trim()) return
+    createTaskMutation.mutate({
+      projectId: parseInt(idParam, 10),
+      title: newTaskTitle.trim(),
+      description: newTaskDescription.trim() || undefined,
+    })
+  }
+
+  function handleDeleteTask(taskId: number) {
+    if (!window.confirm('Delete this task?')) return
+    deleteTaskMutation.mutate({ projectId: parseInt(idParam, 10), taskId })
+  }
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!canEdit) return
@@ -143,6 +211,8 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   }
 
   if (loading || !user) return null
+
+  const isDraft = projectData?.status === 'draft'
 
   if (loadingProject) {
     return (
@@ -310,6 +380,70 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             <SkillPicker value={skills} onChange={canEdit ? setSkills : () => {}} />
           </div>
 
+          {isDraft && canEdit && (
+            <div className="mb-5">
+              <label>Tasks</label>
+              <p className="text-sm text-text-light mt-0 mb-2">
+                At least one task is required before this draft can be published.
+              </p>
+              {(projectData?.tasks ?? []).length > 0 && (
+                <ul className="list-none p-0 m-0 mb-3 flex flex-col gap-2">
+                  {(projectData?.tasks ?? []).map((task) => (
+                    <li
+                      key={task.id}
+                      className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
+                    >
+                      <span>{task.title}</span>
+                      <Button
+                        type="button"
+                        variant="danger"
+                        size="sm"
+                        onClick={() => handleDeleteTask(task.id)}
+                        disabled={deleteTaskMutation.isPending}
+                      >
+                        Delete
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div className="bg-brand-bg rounded-lg p-3 border border-brand-border">
+                <div className="mb-2">
+                  <label htmlFor="new-task-title" className="text-sm">
+                    Task title
+                  </label>
+                  <input
+                    id="new-task-title"
+                    type="text"
+                    value={newTaskTitle}
+                    onChange={(e) => setNewTaskTitle(e.target.value)}
+                    placeholder="e.g. Draft copy for homepage"
+                  />
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="new-task-description" className="text-sm">
+                    Details (optional)
+                  </label>
+                  <textarea
+                    id="new-task-description"
+                    rows={2}
+                    value={newTaskDescription}
+                    onChange={(e) => setNewTaskDescription(e.target.value)}
+                    placeholder="More detail about what needs doing…"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleAddTask}
+                  disabled={createTaskMutation.isPending || !newTaskTitle.trim()}
+                >
+                  {createTaskMutation.isPending ? 'Adding…' : 'Add Task'}
+                </Button>
+              </div>
+            </div>
+          )}
+
           {/* There is no "needs an owner" checkbox: a project needs one exactly when it
               hasn't got one, so it's derived rather than asked for. Ownership is changed
               from the project page's owner menu. */}
@@ -331,6 +465,31 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               {updateMutation.isPending ? 'Saving…' : 'Save Changes'}
             </Button>
 
+            <Button href={`/projects/${idParam}`} variant="secondary">
+              View Project
+            </Button>
+
+            {isDraft && canEdit && (
+              <Button
+                type="button"
+                onClick={() => setShowPublishModal(true)}
+                disabled={publishMutation.isPending}
+              >
+                Publish
+              </Button>
+            )}
+
+            {isDraft && canEdit && (
+              <Button
+                type="button"
+                variant="danger"
+                onClick={() => setShowDeleteDraftModal(true)}
+                disabled={deleteDraftMutation.isPending}
+              >
+                Delete Draft
+              </Button>
+            )}
+
             {user.isAdmin && projectData && (
               <Button
                 type="button"
@@ -343,6 +502,53 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             )}
           </div>
         </form>
+
+        <Modal
+          id="confirm-publish-draft"
+          title="Submit draft for review?"
+          isOpen={showPublishModal}
+          onClose={() => setShowPublishModal(false)}
+        >
+          <p>
+            This will submit <strong>{title || 'this project'}</strong> to PauseAI team leads for
+            review. You won&apos;t be able to edit it as a draft anymore.
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setShowPublishModal(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => publishMutation.mutate({ id: parseInt(idParam, 10) })}
+              disabled={publishMutation.isPending}
+            >
+              {publishMutation.isPending ? 'Submitting…' : 'Submit for Review'}
+            </Button>
+          </div>
+        </Modal>
+
+        <Modal
+          id="confirm-delete-draft"
+          title="Delete this draft?"
+          isOpen={showDeleteDraftModal}
+          onClose={() => setShowDeleteDraftModal(false)}
+        >
+          <p>
+            This will permanently delete <strong>{title || 'this draft'}</strong>, including any
+            tasks you&apos;ve added. This cannot be undone.
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setShowDeleteDraftModal(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => deleteDraftMutation.mutate({ id: parseInt(idParam, 10) })}
+              disabled={deleteDraftMutation.isPending}
+            >
+              {deleteDraftMutation.isPending ? 'Deleting…' : 'Delete Draft'}
+            </Button>
+          </div>
+        </Modal>
       </main>
     </>
   )

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -6,7 +6,9 @@ import { useRouter } from 'next/navigation'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import Checkbox from '@/components/Checkbox'
+import Radio from '@/components/Radio'
 import FilterDropdown from '@/components/FilterDropdown'
+import DescriptionTips from '@/components/DescriptionTips'
 import SkillPicker from '@/components/SkillPicker'
 import Modal from '@/components/ui/Modal'
 import { orpc } from '@/lib/orpc'
@@ -26,10 +28,10 @@ const URGENCY_OPTIONS = [
 
 const PROJECT_TYPES = [
   { value: '', label: 'Select a project type…' },
-  { value: 'sprint', label: 'Sprint (1-2 weeks)' },
-  { value: 'container', label: 'Time-boxed (1-3 months)' },
-  { value: 'ongoing', label: 'Ongoing' },
-  { value: 'one_off', label: 'One-off task' },
+  { value: 'sprint', label: 'Sprint (1-2 weeks) - Focused burst of work with clear deliverable' },
+  { value: 'container', label: 'Time-boxed (1-3 months) - Defined scope with end date' },
+  { value: 'ongoing', label: 'Ongoing - Continuous work without fixed end date' },
+  { value: 'one_off', label: 'One-off task - Single deliverable, minimal coordination' },
 ] as const
 
 const REMOTE_ELIGIBILITY_OPTIONS = [
@@ -53,9 +55,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [showDeleteProjectModal, setShowDeleteProjectModal] = useState(false)
   const [newTaskTitle, setNewTaskTitle] = useState('')
   const [newTaskDescription, setNewTaskDescription] = useState('')
-  const [editingTaskId, setEditingTaskId] = useState<number | null>(null)
-  const [editTaskTitle, setEditTaskTitle] = useState('')
-  const [editTaskDescription, setEditTaskDescription] = useState('')
+  const [taskDrafts, setTaskDrafts] = useState<
+    Record<number, { title: string; description: string }>
+  >({})
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -69,6 +71,7 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const [remoteEligibility, setRemoteEligibility] = useState<'NONE' | 'COUNTRY' | 'GLOBAL'>('NONE')
   const [estimatedDuration, setEstimatedDuration] = useState('')
   const [seekingHelp, setSeekingHelp] = useState(true)
+  const [wantToOwn, setWantToOwn] = useState(false)
 
   const { data: localGroupsData } = useQuery({
     ...orpc.localGroups.list.queryOptions({ input: {} }),
@@ -103,14 +106,40 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     setRemoteEligibility(data.remoteEligibility ?? 'NONE')
     setEstimatedDuration(data.estimatedDuration ?? '')
     setSeekingHelp(data.isSeekingHelp ?? false)
+    setWantToOwn(data.ownerId === user?.id)
     const isOwner = data.ownerId === user?.id || data.proposedById === user?.id
     setCanEdit(isOwner || (user?.isAdmin ?? false))
     setPermissionChecked(true)
   }, [projectData, initialized, user])
 
+  // Seeds local editable copies of each task, without clobbering one mid-edit — a task
+  // added or deleted elsewhere (or a save round-tripping through the server) should show
+  // up or disappear, but a field the volunteer is still typing into shouldn't reset.
+  useEffect(() => {
+    if (!projectData?.tasks) return
+    const tasks = projectData.tasks
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTaskDrafts((prev) => {
+      const next: typeof prev = {}
+      for (const t of tasks) {
+        next[t.id] = prev[t.id] ?? { title: t.title, description: t.description ?? '' }
+      }
+      return next
+    })
+  }, [projectData?.tasks])
+
   const updateMutation = useMutation({
     ...orpc.projects.update.mutationOptions(),
-    onSuccess: () => router.push(`/projects/${idParam}`),
+    onSuccess: () => {
+      // Redirecting a draft to its own /projects/[id] would just bounce straight back
+      // here, since that page redirects away from drafts.
+      if (isDraft) {
+        showToast('Draft saved', 'success')
+        queryClient.invalidateQueries({ queryKey: orpc.projects.getById.key() })
+      } else {
+        router.push(`/projects/${idParam}`)
+      }
+    },
     onError: (err: unknown) => {
       showToast(err instanceof Error ? err.message : 'Failed to save changes', 'error')
     },
@@ -179,7 +208,6 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
   const updateTaskMutation = useMutation({
     ...orpc.projects.updateTask.mutationOptions(),
     onSuccess: () => {
-      setEditingTaskId(null)
       queryClient.invalidateQueries({ queryKey: orpc.projects.getById.key() })
     },
     onError: (err: unknown) => {
@@ -202,21 +230,19 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
     deleteTaskMutation.mutate({ projectId: parseInt(idParam, 10), taskId })
   }
 
-  function startEditingTask(task: { id: number; title: string; description: string | null }) {
-    setEditingTaskId(task.id)
-    setEditTaskTitle(task.title)
-    setEditTaskDescription(task.description ?? '')
-  }
-
-  function handleSaveTask(taskId: number) {
-    if (!editTaskTitle.trim()) return
+  // Saves a task's title/description on blur, only if it actually changed from what's
+  // currently persisted — otherwise every click into and out of a field would fire a
+  // mutation.
+  function handleTaskFieldBlur(task: { id: number; title: string; description: string | null }) {
+    const draft = taskDrafts[task.id]
+    if (!draft || !draft.title.trim()) return
+    const newTitle = draft.title.trim()
+    const newDescription = draft.description.trim()
+    if (newTitle === task.title && newDescription === (task.description ?? '')) return
     updateTaskMutation.mutate({
       projectId: parseInt(idParam, 10),
-      taskId,
-      data: {
-        title: editTaskTitle.trim(),
-        description: editTaskDescription.trim() || null,
-      },
+      taskId: task.id,
+      data: { title: newTitle, description: newDescription || null },
     })
   }
 
@@ -239,6 +265,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
       remoteEligibility,
       estimatedDuration: estimatedDuration.trim() || null,
       isSeekingHelp: seekingHelp,
+      // Ownership is only settable here while it's still a draft — once live, it's
+      // changed from the project page's owner menu instead.
+      ...(isDraft ? { assigneeId: wantToOwn ? (user?.id ?? null) : null } : {}),
     })
   }
 
@@ -276,7 +305,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
           onSubmit={handleSubmit}
         >
           <div className="mb-5">
-            <label htmlFor="edit-title">Project Title</label>
+            <label htmlFor="edit-title" className="required">
+              Project Title
+            </label>
             <input
               id="edit-title"
               type="text"
@@ -284,18 +315,27 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               onChange={(e) => setTitle(e.target.value)}
               disabled={!canEdit}
               required
+              placeholder="A clear, descriptive name for the project"
             />
           </div>
 
           <div className="mb-5">
-            <label htmlFor="edit-description">Description</label>
+            <label htmlFor="edit-description" className="required">
+              Description
+            </label>
+            <DescriptionTips />
             <textarea
               id="edit-description"
               rows={6}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               disabled={!canEdit}
+              placeholder="Describe the project: goals, approach, what success looks like, and what kind of help is needed."
             />
+            <p className="text-sm text-text-light mt-1">
+              The more detail you provide, the easier it is to find the right contributors and get
+              started.
+            </p>
           </div>
 
           <div className="mb-5">
@@ -307,6 +347,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               options={PROJECT_TYPES}
               onChange={setProjectType}
             />
+            <p className="text-sm text-text-light mt-1">
+              This helps contributors understand the commitment involved
+            </p>
           </div>
 
           <div className="grid grid-cols-2 gap-5 mb-5 max-[600px]:grid-cols-1">
@@ -322,6 +365,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
                 onChange={(e) => setHoursPerWeek(e.target.value)}
                 disabled={!canEdit}
               />
+              <p className="text-sm text-text-light mt-1">
+                Estimated weekly time from each contributor
+              </p>
             </div>
             <div>
               <FilterDropdown
@@ -346,6 +392,9 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
                 onChange={(e) => setEstimatedDuration(e.target.value)}
                 disabled={!canEdit}
               />
+              <p className="text-sm text-text-light mt-1">
+                Roughly how long do you expect this to take?
+              </p>
             </div>
           )}
 
@@ -360,7 +409,10 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
               searchable
             />
             <p className="text-sm text-text-light mt-1">
-              Local groups appear indented under their country.
+              Where is this project based? Local groups appear indented under their country.{' '}
+              <a href="/suggest-local-group" className="underline">
+                Don&apos;t see your group? Suggest one.
+              </a>
             </p>
           </div>
 
@@ -397,116 +449,140 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
           </div>
 
           <div className="mb-5">
-            <label htmlFor="edit-collab">Collaboration Doc / Link</label>
+            <label htmlFor="edit-collab">Collaboration Doc / Link (optional)</label>
             <input
               id="edit-collab"
               type="text"
-              placeholder="https://…"
+              placeholder="e.g., https://docs.google.com/… or 'Will create a shared doc once team forms'"
               value={collaborationLink}
               onChange={(e) => setCollaborationLink(e.target.value)}
               disabled={!canEdit}
             />
+            <p className="text-sm text-text-light mt-1">
+              A URL to a planning doc or workspace, or just describe your plans for collaboration
+            </p>
           </div>
 
           <div className="mb-5">
-            <label>Skills needed</label>
+            <label>Skills Needed</label>
+            <p className="text-sm text-text-light mt-0 mb-2">
+              What skills would be helpful for this project?
+            </p>
             <SkillPicker value={skills} onChange={canEdit ? setSkills : () => {}} />
           </div>
 
+          <div className="mb-5">
+            <p className="font-medium mb-2">This project needs:</p>
+            <div className="flex flex-col gap-2">
+              <Checkbox
+                checked={seekingHelp}
+                onChange={(e) => setSeekingHelp(e.target.checked)}
+                disabled={!canEdit}
+              >
+                Help / contributors
+              </Checkbox>
+            </div>
+          </div>
+
+          {/* Ownership is only settable here while it's still a draft. Once live, it's
+              changed from the project page's owner menu instead. */}
+          {isDraft && (
+            <div className="mb-5">
+              <p className="font-medium mb-2">Project ownership:</p>
+              <div className="flex flex-col gap-2">
+                <Radio
+                  name="ownership"
+                  checked={!wantToOwn}
+                  onChange={() => setWantToOwn(false)}
+                  disabled={!canEdit}
+                >
+                  This project needs an owner / lead
+                </Radio>
+                <Radio
+                  name="ownership"
+                  checked={wantToOwn}
+                  onChange={() => setWantToOwn(true)}
+                  disabled={!canEdit}
+                >
+                  <span>
+                    <strong>I want to lead this project</strong> &mdash; I&apos;ll be the owner and
+                    coordinate the work
+                  </span>
+                </Radio>
+              </div>
+            </div>
+          )}
+
           {isDraft && canEdit && (
             <div className="mb-5">
-              <label>Tasks</label>
+              <label>Initial Tasks</label>
               <p className="text-sm text-text-light mt-0 mb-2">
-                At least one task is required before this draft can be published.
+                Break the project into concrete tasks. This helps contributors understand the scope
+                and gives them something to pick up.
               </p>
-              {(projectData?.tasks ?? []).length > 0 && (
-                <ul className="list-none p-0 m-0 mb-3 flex flex-col gap-2">
-                  {(projectData?.tasks ?? []).map((task) =>
-                    editingTaskId === task.id ? (
-                      <li
-                        key={task.id}
-                        className="bg-brand-bg rounded-lg p-3 border border-brand-border"
+              {(projectData?.tasks ?? []).map((task) => {
+                const draft = taskDrafts[task.id] ?? {
+                  title: task.title,
+                  description: task.description ?? '',
+                }
+                return (
+                  <div
+                    key={task.id}
+                    className="bg-brand-bg rounded-lg p-4 mb-3 border border-brand-border"
+                  >
+                    <div className="mb-3">
+                      <label htmlFor={`task-title-${task.id}`} className="text-sm required">
+                        Task title
+                      </label>
+                      <input
+                        id={`task-title-${task.id}`}
+                        type="text"
+                        value={draft.title}
+                        onChange={(e) =>
+                          setTaskDrafts((prev) => ({
+                            ...prev,
+                            [task.id]: { ...draft, title: e.target.value },
+                          }))
+                        }
+                        onBlur={() => handleTaskFieldBlur(task)}
+                        placeholder="e.g. Draft copy for homepage"
+                      />
+                    </div>
+                    <div className="mb-2">
+                      <label htmlFor={`task-desc-${task.id}`} className="text-sm">
+                        Details (optional)
+                      </label>
+                      <textarea
+                        id={`task-desc-${task.id}`}
+                        value={draft.description}
+                        onChange={(e) =>
+                          setTaskDrafts((prev) => ({
+                            ...prev,
+                            [task.id]: { ...draft, description: e.target.value },
+                          }))
+                        }
+                        onBlur={() => handleTaskFieldBlur(task)}
+                        placeholder="More detail about what needs doing…"
+                        className="min-h-14"
+                      />
+                    </div>
+                    <div className="flex justify-end mt-2">
+                      <Button
+                        type="button"
+                        variant="danger"
+                        size="sm"
+                        onClick={() => handleDeleteTask(task.id)}
+                        disabled={deleteTaskMutation.isPending}
                       >
-                        <div className="mb-2">
-                          <label htmlFor={`edit-task-title-${task.id}`} className="text-sm">
-                            Edit task title
-                          </label>
-                          <input
-                            id={`edit-task-title-${task.id}`}
-                            type="text"
-                            value={editTaskTitle}
-                            onChange={(e) => setEditTaskTitle(e.target.value)}
-                            autoFocus
-                          />
-                        </div>
-                        <div className="mb-2">
-                          <label htmlFor={`edit-task-description-${task.id}`} className="text-sm">
-                            Edit task details (optional)
-                          </label>
-                          <textarea
-                            id={`edit-task-description-${task.id}`}
-                            rows={2}
-                            value={editTaskDescription}
-                            onChange={(e) => setEditTaskDescription(e.target.value)}
-                          />
-                        </div>
-                        <div className="flex gap-2">
-                          <Button
-                            type="button"
-                            size="sm"
-                            onClick={() => handleSaveTask(task.id)}
-                            disabled={updateTaskMutation.isPending || !editTaskTitle.trim()}
-                          >
-                            {updateTaskMutation.isPending ? 'Saving…' : 'Save'}
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => setEditingTaskId(null)}
-                          >
-                            Cancel
-                          </Button>
-                        </div>
-                      </li>
-                    ) : (
-                      <li
-                        key={task.id}
-                        className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
-                      >
-                        <div className="min-w-0">
-                          <p className="m-0">{task.title}</p>
-                          {task.description && (
-                            <p className="m-0 text-sm text-text-light">{task.description}</p>
-                          )}
-                        </div>
-                        <div className="flex gap-2 shrink-0">
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => startEditingTask(task)}
-                          >
-                            Edit
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="danger"
-                            size="sm"
-                            onClick={() => handleDeleteTask(task.id)}
-                            disabled={deleteTaskMutation.isPending}
-                          >
-                            Delete
-                          </Button>
-                        </div>
-                      </li>
-                    ),
-                  )}
-                </ul>
-              )}
+                        Delete task
+                      </Button>
+                    </div>
+                  </div>
+                )
+              })}
               <div className="bg-brand-bg rounded-lg p-3 border border-brand-border">
                 <div className="mb-2">
-                  <label htmlFor="new-task-title" className="text-sm">
+                  <label htmlFor="new-task-title" className="text-sm required">
                     Task title
                   </label>
                   <input
@@ -541,25 +617,16 @@ export default function EditProjectPage({ params }: { params: Promise<{ id: stri
             </div>
           )}
 
-          {/* There is no "needs an owner" checkbox: a project needs one exactly when it
-              hasn't got one, so it's derived rather than asked for. Ownership is changed
-              from the project page's owner menu. */}
-          <div className="mb-5">
-            <p className="font-medium mb-2">This project needs:</p>
-            <div className="flex flex-col gap-2">
-              <Checkbox
-                checked={seekingHelp}
-                onChange={(e) => setSeekingHelp(e.target.checked)}
-                disabled={!canEdit}
-              >
-                Help / contributors
-              </Checkbox>
+          {isDraft && !isOrgDraft && (
+            <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-[#DBEAFE] text-[#1E40AF] border border-[#93C5FD] dark:bg-[#1E3A5F] dark:text-[#93C5FD] dark:border-[#2563EB]">
+              Your project will be reviewed by PauseAI team leads before being published. We&apos;ll
+              reach out if we have questions or suggestions.
             </div>
-          </div>
+          )}
 
           <div className="flex gap-3 flex-wrap">
             <Button type="submit" disabled={!canEdit || updateMutation.isPending}>
-              {updateMutation.isPending ? 'Saving…' : 'Save Changes'}
+              {updateMutation.isPending ? 'Saving…' : isDraft ? 'Save draft' : 'Save Changes'}
             </Button>
 
             {!isDraft && (

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1101,7 +1101,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
             <div className={card}>
               <div className="flex items-center justify-between gap-2 mb-3">
                 <h2 className="m-0">Status</h2>
-                {isOwnerOrAdmin && (
+                {canManageTasks && (
                   <Button href={`/projects/${idParam}/edit`} variant="secondary" size="sm">
                     Edit Project
                   </Button>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -320,6 +320,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     }
   }, [loadingProject, project, user, router])
 
+  // A draft has no read-only view of its own — everything happens on its edit page.
+  useEffect(() => {
+    if (project?.status === 'draft') {
+      router.replace(`/projects/${idParam}/edit`)
+    }
+  }, [project?.status, idParam, router])
+
   const { data: volunteersData } = useQuery({
     ...orpc.volunteers.list.queryOptions({ input: { limit: 100 } }),
     enabled: !!project && (!!user?.isAdmin || project.ownerId === user?.id),
@@ -525,6 +532,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     )
   }
   if (!project) return null
+  if (project.status === 'draft') return null
 
   const isOwner = project.ownerId !== null && project.ownerId === user.id
   const isAdmin = user.isAdmin

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -531,6 +531,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
   // Org-proposed projects are attributed to the org, not to the admin who filed them.
   const proposer = proposerDisplay(project)
   const isOwnerOrAdmin = isOwner || isAdmin
+  // A draft has no owner yet, so its creator manages its own tasks until they publish it.
+  const canManageTasks =
+    isOwnerOrAdmin || (project.status === 'draft' && project.proposedById === user.id)
 
   const canSeeInterest =
     !isOwnerOrAdmin &&
@@ -811,14 +814,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
             <div className={card}>
               <div className="flex justify-between items-center mb-3">
                 <h2 className="m-0">Tasks</h2>
-                {isOwnerOrAdmin && (
+                {canManageTasks && (
                   <Button variant="secondary" onClick={() => setShowTaskForm((v) => !v)}>
                     Add Task
                   </Button>
                 )}
               </div>
 
-              {showTaskForm && isOwnerOrAdmin && (
+              {showTaskForm && canManageTasks && (
                 <div className="bg-brand-bg rounded-lg p-3 mb-4 border border-brand-border">
                   <form onSubmit={handleAddTask}>
                     <div className="mb-3">
@@ -897,7 +900,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                 <DndContext
                   sensors={taskDragSensors}
                   collisionDetection={closestCenter}
-                  onDragEnd={isOwnerOrAdmin ? handleTaskDragEnd : undefined}
+                  onDragEnd={canManageTasks ? handleTaskDragEnd : undefined}
                 >
                   <SortableContext
                     items={orderedTasks.map((t) => t.id)}
@@ -923,7 +926,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                           <SortableTaskItem
                             key={task.id}
                             task={task}
-                            draggable={isOwnerOrAdmin}
+                            draggable={canManageTasks}
                             title={
                               <Link
                                 href={`/projects/${idParam}/tasks/${task.id}`}
@@ -1007,7 +1010,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                               </>
                             }
                             menu={
-                              (canAssign || isOwnerOrAdmin) && (
+                              (canAssign || canManageTasks) && (
                                 <ActionMenu ariaLabel={`Task actions for ${task.title}`}>
                                   {(close) => (
                                     <>
@@ -1055,7 +1058,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                                           Unassign
                                         </button>
                                       )}
-                                      {isOwnerOrAdmin && (
+                                      {canManageTasks && (
                                         <button
                                           role="menuitem"
                                           className={`w-full text-left px-3 py-2 text-sm text-red-700 dark:text-red-400 hover:bg-accent transition-colors cursor-pointer ${canAssign || canUnassign ? 'border-t border-brand-border mt-1' : ''}`}

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
 import ProjectForm from '@/components/ProjectForm'
 import { useToast } from '@/lib/toast'
@@ -12,7 +12,6 @@ export default function SuggestPage() {
   const router = useRouter()
   const { user, loading } = useRequireAuth()
   const toast = useToast()
-  const queryClient = useQueryClient()
   const createMutation = useMutation({ ...orpc.projects.create.mutationOptions() })
 
   const { data: drafts = [] } = useQuery({
@@ -63,9 +62,9 @@ export default function SuggestPage() {
               setTimeout(() => router.push('/dashboard#tab-proposed'), 2000)
             }}
             onSaveDraft={(data) => createMutation.mutateAsync({ ...data, saveAsDraft: true })}
-            onDraftSuccess={() => {
+            onDraftSuccess={(id) => {
               toast('Draft saved.', 'success')
-              queryClient.invalidateQueries({ queryKey: orpc.projects.myDrafts.key() })
+              router.push(`/projects/${id}/edit`)
             }}
           />
         </div>

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -57,6 +57,9 @@ export default function SuggestPage() {
         {drafts.length > 0 && (
           <div className="max-w-4xl bg-surface rounded-xl shadow p-6 mb-4">
             <h2 className="mt-0 mb-3">My Drafts</h2>
+            <p className="text-sm text-text-light mt-0 mb-3">
+              Open a draft to add tasks. It needs at least one before it can be published.
+            </p>
             <ul className="flex flex-col gap-2">
               {drafts.map((draft) => (
                 <li

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -3,7 +3,6 @@
 import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import Link from 'next/link'
 import Button from '@/components/Button'
 import ProjectForm from '@/components/ProjectForm'
 import { useToast } from '@/lib/toast'
@@ -21,28 +20,6 @@ export default function SuggestPage() {
     enabled: !!user,
   })
 
-  const publishMutation = useMutation({
-    ...orpc.projects.publishDraft.mutationOptions(),
-    onSuccess: () => {
-      toast('Draft submitted for review!', 'success')
-      queryClient.invalidateQueries({ queryKey: orpc.projects.myDrafts.key() })
-    },
-    onError: (err: unknown) => {
-      toast(err instanceof Error ? err.message : 'Failed to publish draft', 'error')
-    },
-  })
-
-  const deleteMutation = useMutation({
-    ...orpc.projects.deleteDraft.mutationOptions(),
-    onSuccess: () => {
-      toast('Draft deleted', 'success')
-      queryClient.invalidateQueries({ queryKey: orpc.projects.myDrafts.key() })
-    },
-    onError: (err: unknown) => {
-      toast(err instanceof Error ? err.message : 'Failed to delete draft', 'error')
-    },
-  })
-
   if (loading || !user) return null
 
   return (
@@ -58,7 +35,7 @@ export default function SuggestPage() {
           <div className="max-w-4xl bg-surface rounded-xl shadow p-6 mb-4">
             <h2 className="mt-0 mb-3">My Drafts</h2>
             <p className="text-sm text-text-light mt-0 mb-3">
-              Open a draft to add tasks. It needs at least one before it can be published.
+              Publishing and deleting a draft are both done from its edit page.
             </p>
             <ul className="flex flex-col gap-2">
               {drafts.map((draft) => (
@@ -66,30 +43,10 @@ export default function SuggestPage() {
                   key={draft.id}
                   className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
                 >
-                  <Link href={`/projects/${draft.id}`} className="font-medium underline">
-                    {draft.title || 'Untitled draft'}
-                  </Link>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      size="sm"
-                      disabled={publishMutation.isPending}
-                      onClick={() => publishMutation.mutate({ id: draft.id })}
-                    >
-                      Publish
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      disabled={deleteMutation.isPending}
-                      onClick={() => {
-                        if (window.confirm('Delete this draft? This cannot be undone.')) {
-                          deleteMutation.mutate({ id: draft.id })
-                        }
-                      }}
-                    >
-                      Delete
-                    </Button>
-                  </div>
+                  <span className="font-medium">{draft.title || 'Untitled draft'}</span>
+                  <Button href={`/projects/${draft.id}/edit`} size="sm">
+                    Edit
+                  </Button>
                 </li>
               ))}
             </ul>

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -2,7 +2,9 @@
 
 import { useRequireAuth } from '@/lib/hooks/auth'
 import { useRouter } from 'next/navigation'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Link from 'next/link'
+import Button from '@/components/Button'
 import ProjectForm from '@/components/ProjectForm'
 import { useToast } from '@/lib/toast'
 import { orpc } from '@/lib/orpc'
@@ -11,7 +13,35 @@ export default function SuggestPage() {
   const router = useRouter()
   const { user, loading } = useRequireAuth()
   const toast = useToast()
+  const queryClient = useQueryClient()
   const createMutation = useMutation({ ...orpc.projects.create.mutationOptions() })
+
+  const { data: drafts = [] } = useQuery({
+    ...orpc.projects.myDrafts.queryOptions(),
+    enabled: !!user,
+  })
+
+  const publishMutation = useMutation({
+    ...orpc.projects.publishDraft.mutationOptions(),
+    onSuccess: () => {
+      toast('Draft submitted for review!', 'success')
+      queryClient.invalidateQueries({ queryKey: orpc.projects.myDrafts.key() })
+    },
+    onError: (err: unknown) => {
+      toast(err instanceof Error ? err.message : 'Failed to publish draft', 'error')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    ...orpc.projects.deleteDraft.mutationOptions(),
+    onSuccess: () => {
+      toast('Draft deleted', 'success')
+      queryClient.invalidateQueries({ queryKey: orpc.projects.myDrafts.key() })
+    },
+    onError: (err: unknown) => {
+      toast(err instanceof Error ? err.message : 'Failed to delete draft', 'error')
+    },
+  })
 
   if (loading || !user) return null
 
@@ -23,6 +53,46 @@ export default function SuggestPage() {
           Have an idea for something PauseAI should do? Propose it here! Our team will review it
           and, if approved, it&apos;ll be visible to all volunteers.
         </p>
+
+        {drafts.length > 0 && (
+          <div className="max-w-4xl bg-surface rounded-xl shadow p-6 mb-4">
+            <h2 className="mt-0 mb-3">My Drafts</h2>
+            <ul className="flex flex-col gap-2">
+              {drafts.map((draft) => (
+                <li
+                  key={draft.id}
+                  className="flex items-center justify-between gap-3 bg-brand-bg rounded-lg p-3 border border-brand-border"
+                >
+                  <Link href={`/projects/${draft.id}`} className="font-medium underline">
+                    {draft.title || 'Untitled draft'}
+                  </Link>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      disabled={publishMutation.isPending}
+                      onClick={() => publishMutation.mutate({ id: draft.id })}
+                    >
+                      Publish
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="danger"
+                      disabled={deleteMutation.isPending}
+                      onClick={() => {
+                        if (window.confirm('Delete this draft? This cannot be undone.')) {
+                          deleteMutation.mutate({ id: draft.id })
+                        }
+                      }}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         <div className="max-w-4xl">
           <ProjectForm
             onSubmitForm={(data) => createMutation.mutateAsync(data)}
@@ -31,6 +101,11 @@ export default function SuggestPage() {
             onSuccess={() => {
               toast("Project submitted for review! We'll be in touch.", 'success')
               setTimeout(() => router.push('/dashboard#tab-proposed'), 2000)
+            }}
+            onSaveDraft={(data) => createMutation.mutateAsync({ ...data, saveAsDraft: true })}
+            onDraftSuccess={() => {
+              toast('Draft saved.', 'success')
+              queryClient.invalidateQueries({ queryKey: orpc.projects.myDrafts.key() })
             }}
           />
         </div>

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -52,6 +52,9 @@ interface ProjectFormProps {
   showReviewNotice?: boolean
   onSuccess: (id: number) => void
   onCancel?: () => void
+  /** When set, renders a secondary "Save as draft" action alongside the main submit. */
+  onSaveDraft?: (data: ProjectCreateInput) => Promise<{ id: number }>
+  draftLabel?: string
 }
 
 export default function ProjectForm({
@@ -60,6 +63,8 @@ export default function ProjectForm({
   showReviewNotice = false,
   onSuccess,
   onCancel,
+  onSaveDraft,
+  draftLabel = 'Save as Draft',
 }: ProjectFormProps) {
   const toast = useToast()
 
@@ -111,6 +116,34 @@ export default function ProjectForm({
     if (tasks.length > 1) setTasks((prev) => prev.filter((_, i) => i !== index))
   }
 
+  function buildPayload(): ProjectCreateInput {
+    const validTasks = tasks.filter((t) => t.title.trim())
+    const [country, localGroup] = locationValue.split(':')
+    return {
+      title: title.trim(),
+      description: description.trim(),
+      projectType: projectType || null,
+      timeCommitmentHoursPerWeek: hoursPerWeek ? Number(hoursPerWeek) : null,
+      urgency,
+      country: country || null,
+      localGroup: localGroup || null,
+      teamId: teamId ? Number(teamId) : null,
+      remoteEligibility: remoteEligibility as ProjectCreateInput['remoteEligibility'],
+      estimatedDuration: duration.trim() || null,
+      collaborationLink: collaborationLink.trim() || null,
+      skillIds: skills.map((s) => s.skillId),
+      skillRequiredMap: Object.fromEntries(skills.map((s) => [s.skillId, true])),
+      isSeekingHelp: seekingHelp,
+      // No isSeekingOwner: `wantToOwn` decides whether an owner is set, and "needs an
+      // owner" is derived from that.
+      wantToOwn,
+      tasks: validTasks.map((t) => ({
+        title: t.title.trim(),
+        description: t.description.trim() || undefined,
+      })),
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const validTasks = tasks.filter((t) => t.title.trim())
@@ -119,34 +152,27 @@ export default function ProjectForm({
       return
     }
     setSubmitting(true)
-    const [country, localGroup] = locationValue.split(':')
     try {
-      const result = await onSubmitForm({
-        title: title.trim(),
-        description: description.trim(),
-        projectType: projectType || null,
-        timeCommitmentHoursPerWeek: hoursPerWeek ? Number(hoursPerWeek) : null,
-        urgency,
-        country: country || null,
-        localGroup: localGroup || null,
-        teamId: teamId ? Number(teamId) : null,
-        remoteEligibility: remoteEligibility as ProjectCreateInput['remoteEligibility'],
-        estimatedDuration: duration.trim() || null,
-        collaborationLink: collaborationLink.trim() || null,
-        skillIds: skills.map((s) => s.skillId),
-        skillRequiredMap: Object.fromEntries(skills.map((s) => [s.skillId, true])),
-        isSeekingHelp: seekingHelp,
-        // No isSeekingOwner: `wantToOwn` decides whether an owner is set, and "needs an
-        // owner" is derived from that.
-        wantToOwn,
-        tasks: validTasks.map((t) => ({
-          title: t.title.trim(),
-          description: t.description.trim() || undefined,
-        })),
-      })
+      const result = await onSubmitForm(buildPayload())
       onSuccess(result.id)
     } catch (err: unknown) {
       toast(err instanceof Error ? err.message : 'Failed to submit', 'error')
+      setSubmitting(false)
+    }
+  }
+
+  async function handleSaveDraft() {
+    if (!onSaveDraft) return
+    if (!title.trim()) {
+      toast('A title is required, even for a draft.', 'error')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const result = await onSaveDraft(buildPayload())
+      onSuccess(result.id)
+    } catch (err: unknown) {
+      toast(err instanceof Error ? err.message : 'Failed to save draft', 'error')
       setSubmitting(false)
     }
   }
@@ -455,6 +481,11 @@ export default function ProjectForm({
         <Button type="submit" disabled={submitting}>
           {submitting ? 'Submitting…' : submitLabel}
         </Button>
+        {onSaveDraft && (
+          <Button type="button" variant="secondary" disabled={submitting} onClick={handleSaveDraft}>
+            {draftLabel}
+          </Button>
+        )}
         {onCancel && (
           <Button type="button" variant="secondary" onClick={onCancel}>
             Cancel

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -9,6 +9,7 @@ import Radio from '@/components/Radio'
 import FilterDropdown from '@/components/FilterDropdown'
 import DescriptionTips from '@/components/DescriptionTips'
 import SkillPicker from '@/components/SkillPicker'
+import Modal from '@/components/ui/Modal'
 import { buildLocationOptions, type LocalGroupOption } from '@/lib/filter-options'
 import { useToast } from '@/lib/toast'
 import { orpc } from '@/lib/orpc'
@@ -66,10 +67,11 @@ export default function ProjectForm({
   onSuccess,
   onCancel,
   onSaveDraft,
-  draftLabel = 'Save as Draft',
+  draftLabel = 'Save draft',
   onDraftSuccess,
 }: ProjectFormProps) {
   const toast = useToast()
+  const [showSubmitModal, setShowSubmitModal] = useState(false)
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -116,7 +118,7 @@ export default function ProjectForm({
   }
 
   function removeTask(index: number) {
-    if (tasks.length > 1) setTasks((prev) => prev.filter((_, i) => i !== index))
+    setTasks((prev) => prev.filter((_, i) => i !== index))
   }
 
   function buildPayload(): ProjectCreateInput {
@@ -147,20 +149,26 @@ export default function ProjectForm({
     }
   }
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const validTasks = tasks.filter((t) => t.title.trim())
     if (!validTasks.length) {
       toast('At least one task with a title is required.', 'error')
       return
     }
+    setShowSubmitModal(true)
+  }
+
+  async function performSubmit() {
     setSubmitting(true)
     try {
       const result = await onSubmitForm(buildPayload())
+      setShowSubmitModal(false)
       onSuccess(result.id)
     } catch (err: unknown) {
       toast(err instanceof Error ? err.message : 'Failed to submit', 'error')
       setSubmitting(false)
+      setShowSubmitModal(false)
     }
   }
 
@@ -182,320 +190,354 @@ export default function ProjectForm({
   }
 
   return (
-    <form
-      className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
-      onSubmit={handleSubmit}
-    >
-      <div className="mb-5">
-        <label htmlFor="project-title" className="required">
-          Project Title
-        </label>
-        <input
-          id="project-title"
-          type="text"
-          value={title}
-          onChange={(e) => {
-            setTitle(e.target.value)
-            clearFieldError('title')
-          }}
-          required
-          placeholder="A clear, descriptive name for the project"
-          aria-invalid={!!fe('title') || undefined}
-        />
-        {fe('title') && <p className="text-sm mt-1 text-error">{fe('title')}</p>}
-      </div>
-
-      <div className="mb-5">
-        <label htmlFor="project-description" className="required">
-          Description
-        </label>
-        <DescriptionTips />
-        <textarea
-          id="project-description"
-          rows={6}
-          value={description}
-          onChange={(e) => {
-            setDescription(e.target.value)
-            clearFieldError('description')
-          }}
-          required
-          placeholder="Describe the project: goals, approach, what success looks like, and what kind of help is needed."
-          aria-invalid={!!fe('description') || undefined}
-        />
-        {fe('description') ? (
-          <p className="text-sm mt-1 text-error">{fe('description')}</p>
-        ) : (
-          <p className="text-sm text-text-light mt-1">
-            The more detail you provide, the easier it is to find the right contributors and get
-            started.
-          </p>
-        )}
-      </div>
-
-      <div className="mb-5">
-        <FilterDropdown
-          id="project-type"
-          label="Project Type"
-          ariaLabel="Select project type"
-          value={projectType}
-          options={PROJECT_TYPES}
-          onChange={(v) => {
-            setProjectType(v)
-            clearFieldError('project_type')
-          }}
-        />
-        {fe('project_type') ? (
-          <p className="text-sm mt-1 text-error">{fe('project_type')}</p>
-        ) : (
-          <p className="text-sm text-text-light mt-1">
-            This helps contributors understand the commitment involved
-          </p>
-        )}
-      </div>
-
-      <div className="grid grid-cols-2 gap-5 mb-5">
-        <div>
-          <label htmlFor="hours-per-week">Hours per Week</label>
-          <input
-            id="hours-per-week"
-            type="number"
-            min={1}
-            max={40}
-            placeholder="e.g., 5"
-            value={hoursPerWeek}
-            onChange={(e) => {
-              setHoursPerWeek(e.target.value)
-              clearFieldError('time_commitment_hours_per_week')
-            }}
-            aria-invalid={!!fe('time_commitment_hours_per_week') || undefined}
-          />
-          {fe('time_commitment_hours_per_week') ? (
-            <p className="text-sm mt-1 text-error">{fe('time_commitment_hours_per_week')}</p>
-          ) : (
-            <p className="text-sm text-text-light mt-1">
-              Estimated weekly time from each contributor
-            </p>
-          )}
-        </div>
-
-        <div>
-          <FilterDropdown
-            id="urgency"
-            label="Urgency"
-            ariaLabel="Select urgency"
-            value={urgency}
-            options={URGENCY_OPTIONS}
-            onChange={(v) => {
-              setUrgency(v)
-              clearFieldError('urgency')
-            }}
-          />
-          {fe('urgency') && <p className="text-sm mt-1 text-error">{fe('urgency')}</p>}
-        </div>
-      </div>
-
-      {['sprint', 'container'].includes(projectType) && (
+    <>
+      <form
+        className="bg-surface rounded-xl shadow p-6 mb-4 overflow-hidden wrap-break-word"
+        onSubmit={handleSubmit}
+      >
         <div className="mb-5">
-          <label htmlFor="duration">Estimated Duration</label>
+          <label htmlFor="project-title" className="required">
+            Project Title
+          </label>
           <input
-            id="duration"
+            id="project-title"
             type="text"
-            placeholder="e.g., 6 weeks, 2 months"
-            value={duration}
+            value={title}
             onChange={(e) => {
-              setDuration(e.target.value)
-              clearFieldError('estimated_duration')
+              setTitle(e.target.value)
+              clearFieldError('title')
             }}
-            aria-invalid={!!fe('estimated_duration') || undefined}
+            required
+            placeholder="A clear, descriptive name for the project"
+            aria-invalid={!!fe('title') || undefined}
           />
-          {fe('estimated_duration') ? (
-            <p className="text-sm mt-1 text-error">{fe('estimated_duration')}</p>
+          {fe('title') && <p className="text-sm mt-1 text-error">{fe('title')}</p>}
+        </div>
+
+        <div className="mb-5">
+          <label htmlFor="project-description" className="required">
+            Description
+          </label>
+          <DescriptionTips />
+          <textarea
+            id="project-description"
+            rows={6}
+            value={description}
+            onChange={(e) => {
+              setDescription(e.target.value)
+              clearFieldError('description')
+            }}
+            required
+            placeholder="Describe the project: goals, approach, what success looks like, and what kind of help is needed."
+            aria-invalid={!!fe('description') || undefined}
+          />
+          {fe('description') ? (
+            <p className="text-sm mt-1 text-error">{fe('description')}</p>
           ) : (
             <p className="text-sm text-text-light mt-1">
-              Roughly how long do you expect this to take?
+              The more detail you provide, the easier it is to find the right contributors and get
+              started.
             </p>
           )}
         </div>
-      )}
 
-      <div className="mb-5">
-        <FilterDropdown
-          id="country"
-          label="Country/Group"
-          ariaLabel="Select country/group"
-          value={locationValue}
-          options={buildLocationOptions(allLocalGroups)}
-          onChange={(v) => {
-            setLocationValue(v)
-            clearFieldError('country')
-            clearFieldError('local_group')
-          }}
-          searchable
-        />
-        {fe('country') || fe('local_group') ? (
-          <p className="text-sm mt-1 text-error">{fe('country') ?? fe('local_group')}</p>
-        ) : (
-          <p className="text-sm text-text-light mt-1">
-            Where is this project based? Local groups appear indented under their country.{' '}
-            <a href="/suggest-local-group" className="underline">
-              Don&apos;t see your group? Suggest one.
-            </a>
-          </p>
-        )}
-      </div>
-
-      <div className="mb-5">
-        <FilterDropdown
-          id="team"
-          label="Team"
-          ariaLabel="Select team"
-          value={teamId}
-          options={[
-            { value: '', label: 'No team: visible to everyone' },
-            ...teams.map((t) => ({ value: String(t.id), label: t.name })),
-          ]}
-          onChange={setTeamId}
-          searchable
-        />
-        <p className="text-sm text-text-light mt-1">
-          Assigning a team restricts visibility to that team, plus the owner and proposer.
-        </p>
-      </div>
-
-      <div className="mb-5">
-        <FilterDropdown
-          id="remote-eligibility"
-          label="Can this be done remotely?"
-          ariaLabel="Select remote eligibility"
-          value={remoteEligibility}
-          options={REMOTE_ELIGIBILITY_OPTIONS}
-          onChange={setRemoteEligibility}
-        />
-        <p className="text-sm text-text-light mt-1">
-          Controls who gets project-match alerts outside the country above.
-        </p>
-      </div>
-
-      <div className="mb-5">
-        <label htmlFor="collaboration-link">Collaboration Doc / Link (optional)</label>
-        <input
-          id="collaboration-link"
-          type="text"
-          placeholder="e.g., https://docs.google.com/… or 'Will create a shared doc once team forms'"
-          value={collaborationLink}
-          onChange={(e) => {
-            setCollaborationLink(e.target.value)
-            clearFieldError('collaboration_link')
-          }}
-          aria-invalid={!!fe('collaboration_link') || undefined}
-        />
-        {fe('collaboration_link') ? (
-          <p className="text-sm mt-1 text-error">{fe('collaboration_link')}</p>
-        ) : (
-          <p className="text-sm text-text-light mt-1">
-            A URL to a planning doc or workspace, or just describe your plans for collaboration
-          </p>
-        )}
-      </div>
-
-      <div className="mb-5">
-        <label>Skills Needed</label>
-        <p className="text-sm text-text-light mt-0 mb-2">
-          What skills would be helpful for this project?
-        </p>
-        <SkillPicker value={skills} onChange={setSkills} />
-      </div>
-
-      <div className="mb-5">
-        <p className="font-medium mb-2">This project needs:</p>
-        <div className="flex flex-col gap-2 mb-4">
-          <Checkbox checked={seekingHelp} onChange={(e) => setSeekingHelp(e.target.checked)}>
-            Help / contributors
-          </Checkbox>
+        <div className="mb-5">
+          <FilterDropdown
+            id="project-type"
+            label="Project Type"
+            ariaLabel="Select project type"
+            value={projectType}
+            options={PROJECT_TYPES}
+            onChange={(v) => {
+              setProjectType(v)
+              clearFieldError('project_type')
+            }}
+          />
+          {fe('project_type') ? (
+            <p className="text-sm mt-1 text-error">{fe('project_type')}</p>
+          ) : (
+            <p className="text-sm text-text-light mt-1">
+              This helps contributors understand the commitment involved
+            </p>
+          )}
         </div>
-        <p className="font-medium mb-2">Project ownership:</p>
-        <div className="flex flex-col gap-2">
-          <Radio name="ownership" checked={!wantToOwn} onChange={() => setWantToOwn(false)}>
-            This project needs an owner / lead
-          </Radio>
-          <Radio name="ownership" checked={wantToOwn} onChange={() => setWantToOwn(true)}>
-            <span>
-              <strong>I want to lead this project</strong> &mdash; I&apos;ll be the owner and
-              coordinate the work
-            </span>
-          </Radio>
-        </div>
-      </div>
 
-      <div className="mb-5">
-        <label>Initial Tasks</label>
-        <p className="text-sm text-text-light mt-0 mb-2">
-          Break the project into concrete tasks. This helps contributors understand the scope and
-          gives them something to pick up.
-        </p>
-        {tasks.map((task, i) => (
-          <div key={i} className="bg-brand-bg rounded-lg p-4 mb-3 border border-brand-border">
-            <div className="mb-3">
-              <label htmlFor={`task-title-${i}`} className="text-sm required">
-                Task title
-              </label>
-              <input
-                id={`task-title-${i}`}
-                type="text"
-                aria-label="Task title"
-                placeholder="e.g. Draft copy for homepage"
-                value={task.title}
-                onChange={(e) => updateTask(i, 'title', e.target.value)}
-              />
-            </div>
-            <div className="mb-2">
-              <label htmlFor={`task-desc-${i}`} className="text-sm">
-                Details (optional)
-              </label>
-              <textarea
-                id={`task-desc-${i}`}
-                placeholder="More detail about what needs doing…"
-                value={task.description}
-                onChange={(e) => updateTask(i, 'description', e.target.value)}
-                className="min-h-14"
-              />
-            </div>
-            {tasks.length > 1 && (
+        <div className="grid grid-cols-2 gap-5 mb-5">
+          <div>
+            <label htmlFor="hours-per-week">Hours per Week</label>
+            <input
+              id="hours-per-week"
+              type="number"
+              min={1}
+              max={40}
+              placeholder="e.g., 5"
+              value={hoursPerWeek}
+              onChange={(e) => {
+                setHoursPerWeek(e.target.value)
+                clearFieldError('time_commitment_hours_per_week')
+              }}
+              aria-invalid={!!fe('time_commitment_hours_per_week') || undefined}
+            />
+            {fe('time_commitment_hours_per_week') ? (
+              <p className="text-sm mt-1 text-error">{fe('time_commitment_hours_per_week')}</p>
+            ) : (
+              <p className="text-sm text-text-light mt-1">
+                Estimated weekly time from each contributor
+              </p>
+            )}
+          </div>
+
+          <div>
+            <FilterDropdown
+              id="urgency"
+              label="Urgency"
+              ariaLabel="Select urgency"
+              value={urgency}
+              options={URGENCY_OPTIONS}
+              onChange={(v) => {
+                setUrgency(v)
+                clearFieldError('urgency')
+              }}
+            />
+            {fe('urgency') && <p className="text-sm mt-1 text-error">{fe('urgency')}</p>}
+          </div>
+        </div>
+
+        {['sprint', 'container'].includes(projectType) && (
+          <div className="mb-5">
+            <label htmlFor="duration">Estimated Duration</label>
+            <input
+              id="duration"
+              type="text"
+              placeholder="e.g., 6 weeks, 2 months"
+              value={duration}
+              onChange={(e) => {
+                setDuration(e.target.value)
+                clearFieldError('estimated_duration')
+              }}
+              aria-invalid={!!fe('estimated_duration') || undefined}
+            />
+            {fe('estimated_duration') ? (
+              <p className="text-sm mt-1 text-error">{fe('estimated_duration')}</p>
+            ) : (
+              <p className="text-sm text-text-light mt-1">
+                Roughly how long do you expect this to take?
+              </p>
+            )}
+          </div>
+        )}
+
+        <div className="mb-5">
+          <FilterDropdown
+            id="country"
+            label="Country/Group"
+            ariaLabel="Select country/group"
+            value={locationValue}
+            options={buildLocationOptions(allLocalGroups)}
+            onChange={(v) => {
+              setLocationValue(v)
+              clearFieldError('country')
+              clearFieldError('local_group')
+            }}
+            searchable
+          />
+          {fe('country') || fe('local_group') ? (
+            <p className="text-sm mt-1 text-error">{fe('country') ?? fe('local_group')}</p>
+          ) : (
+            <p className="text-sm text-text-light mt-1">
+              Where is this project based? Local groups appear indented under their country.{' '}
+              <a href="/suggest-local-group" className="underline">
+                Don&apos;t see your group? Suggest one.
+              </a>
+            </p>
+          )}
+        </div>
+
+        <div className="mb-5">
+          <FilterDropdown
+            id="team"
+            label="Team"
+            ariaLabel="Select team"
+            value={teamId}
+            options={[
+              { value: '', label: 'No team: visible to everyone' },
+              ...teams.map((t) => ({ value: String(t.id), label: t.name })),
+            ]}
+            onChange={setTeamId}
+            searchable
+          />
+          <p className="text-sm text-text-light mt-1">
+            Assigning a team restricts visibility to that team, plus the owner and proposer.
+          </p>
+        </div>
+
+        <div className="mb-5">
+          <FilterDropdown
+            id="remote-eligibility"
+            label="Can this be done remotely?"
+            ariaLabel="Select remote eligibility"
+            value={remoteEligibility}
+            options={REMOTE_ELIGIBILITY_OPTIONS}
+            onChange={setRemoteEligibility}
+          />
+          <p className="text-sm text-text-light mt-1">
+            Controls who gets project-match alerts outside the country above.
+          </p>
+        </div>
+
+        <div className="mb-5">
+          <label htmlFor="collaboration-link">Collaboration Doc / Link (optional)</label>
+          <input
+            id="collaboration-link"
+            type="text"
+            placeholder="e.g., https://docs.google.com/… or 'Will create a shared doc once team forms'"
+            value={collaborationLink}
+            onChange={(e) => {
+              setCollaborationLink(e.target.value)
+              clearFieldError('collaboration_link')
+            }}
+            aria-invalid={!!fe('collaboration_link') || undefined}
+          />
+          {fe('collaboration_link') ? (
+            <p className="text-sm mt-1 text-error">{fe('collaboration_link')}</p>
+          ) : (
+            <p className="text-sm text-text-light mt-1">
+              A URL to a planning doc or workspace, or just describe your plans for collaboration
+            </p>
+          )}
+        </div>
+
+        <div className="mb-5">
+          <label>Skills Needed</label>
+          <p className="text-sm text-text-light mt-0 mb-2">
+            What skills would be helpful for this project?
+          </p>
+          <SkillPicker value={skills} onChange={setSkills} />
+        </div>
+
+        <div className="mb-5">
+          <p className="font-medium mb-2">This project needs:</p>
+          <div className="flex flex-col gap-2 mb-4">
+            <Checkbox checked={seekingHelp} onChange={(e) => setSeekingHelp(e.target.checked)}>
+              Help / contributors
+            </Checkbox>
+          </div>
+          <p className="font-medium mb-2">Project ownership:</p>
+          <div className="flex flex-col gap-2">
+            <Radio name="ownership" checked={!wantToOwn} onChange={() => setWantToOwn(false)}>
+              This project needs an owner / lead
+            </Radio>
+            <Radio name="ownership" checked={wantToOwn} onChange={() => setWantToOwn(true)}>
+              <span>
+                <strong>I want to lead this project</strong> &mdash; I&apos;ll be the owner and
+                coordinate the work
+              </span>
+            </Radio>
+          </div>
+        </div>
+
+        <div className="mb-5">
+          <label>Initial Tasks</label>
+          <p className="text-sm text-text-light mt-0 mb-2">
+            Break the project into concrete tasks. This helps contributors understand the scope and
+            gives them something to pick up.
+          </p>
+          {tasks.map((task, i) => (
+            <div key={i} className="bg-brand-bg rounded-lg p-4 mb-3 border border-brand-border">
+              <div className="mb-3">
+                <label htmlFor={`task-title-${i}`} className="text-sm required">
+                  Task title
+                </label>
+                <input
+                  id={`task-title-${i}`}
+                  type="text"
+                  aria-label="Task title"
+                  placeholder="e.g. Draft copy for homepage"
+                  value={task.title}
+                  onChange={(e) => updateTask(i, 'title', e.target.value)}
+                />
+              </div>
+              <div className="mb-2">
+                <label htmlFor={`task-desc-${i}`} className="text-sm">
+                  Details (optional)
+                </label>
+                <textarea
+                  id={`task-desc-${i}`}
+                  placeholder="More detail about what needs doing…"
+                  value={task.description}
+                  onChange={(e) => updateTask(i, 'description', e.target.value)}
+                  className="min-h-14"
+                />
+              </div>
               <div className="flex justify-end mt-2">
                 <Button type="button" variant="danger" size="sm" onClick={() => removeTask(i)}>
                   Delete task
                 </Button>
               </div>
-            )}
-          </div>
-        ))}
-        <Button type="button" variant="secondary" onClick={addTask}>
-          + Add another task
-        </Button>
-      </div>
-
-      {showReviewNotice && (
-        <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-[#DBEAFE] text-[#1E40AF] border border-[#93C5FD] dark:bg-[#1E3A5F] dark:text-[#93C5FD] dark:border-[#2563EB]">
-          Your project will be reviewed by PauseAI team leads before being published. We&apos;ll
-          reach out if we have questions or suggestions.
-        </div>
-      )}
-
-      <div className="flex items-center gap-3">
-        <Button type="submit" disabled={submitting}>
-          {submitting ? 'Submitting…' : submitLabel}
-        </Button>
-        {onSaveDraft && (
-          <Button type="button" variant="secondary" disabled={submitting} onClick={handleSaveDraft}>
-            {draftLabel}
+            </div>
+          ))}
+          <Button type="button" variant="secondary" onClick={addTask}>
+            + Add another task
           </Button>
+        </div>
+
+        {showReviewNotice && (
+          <div className="flex items-center gap-3 p-4 rounded-lg mb-5 bg-[#DBEAFE] text-[#1E40AF] border border-[#93C5FD] dark:bg-[#1E3A5F] dark:text-[#93C5FD] dark:border-[#2563EB]">
+            Your project will be reviewed by PauseAI team leads before being published. We&apos;ll
+            reach out if we have questions or suggestions.
+          </div>
         )}
-        {onCancel && (
-          <Button type="button" variant="secondary" onClick={onCancel}>
+
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? 'Submitting…' : submitLabel}
+          </Button>
+          {onSaveDraft && (
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={submitting}
+              onClick={handleSaveDraft}
+            >
+              {draftLabel}
+            </Button>
+          )}
+          {onCancel && (
+            <Button type="button" variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      </form>
+
+      <Modal
+        id="confirm-submit-project"
+        title={showReviewNotice ? 'Submit for review?' : 'Publish this project?'}
+        isOpen={showSubmitModal}
+        onClose={() => setShowSubmitModal(false)}
+      >
+        <p>
+          {showReviewNotice ? (
+            <>
+              This will submit <strong>{title || 'this project'}</strong> to PauseAI team leads for
+              review.
+            </>
+          ) : (
+            <>
+              This will publish <strong>{title || 'this project'}</strong> immediately. It will be
+              visible to volunteers straight away.
+            </>
+          )}
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={() => setShowSubmitModal(false)}>
             Cancel
           </Button>
-        )}
-      </div>
-    </form>
+          <Button type="button" onClick={performSubmit} disabled={submitting}>
+            {submitting ? 'Submitting…' : submitLabel}
+          </Button>
+        </div>
+      </Modal>
+    </>
   )
 }

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -55,6 +55,8 @@ interface ProjectFormProps {
   /** When set, renders a secondary "Save as draft" action alongside the main submit. */
   onSaveDraft?: (data: ProjectCreateInput) => Promise<{ id: number }>
   draftLabel?: string
+  /** Called instead of onSuccess after a successful draft save, if provided. */
+  onDraftSuccess?: (id: number) => void
 }
 
 export default function ProjectForm({
@@ -65,6 +67,7 @@ export default function ProjectForm({
   onCancel,
   onSaveDraft,
   draftLabel = 'Save as Draft',
+  onDraftSuccess,
 }: ProjectFormProps) {
   const toast = useToast()
 
@@ -170,7 +173,8 @@ export default function ProjectForm({
     setSubmitting(true)
     try {
       const result = await onSaveDraft(buildPayload())
-      onSuccess(result.id)
+      ;(onDraftSuccess ?? onSuccess)(result.id)
+      setSubmitting(false)
     } catch (err: unknown) {
       toast(err instanceof Error ? err.message : 'Failed to save draft', 'error')
       setSubmitting(false)

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -59,7 +59,7 @@ export async function adminCreateProject(
   await adminPage.getByLabel('Project Title').fill(title)
   await adminPage.getByLabel('Description').fill(description)
   await adminPage.getByLabel('Task title').first().fill('Initial task')
-  await adminPage.getByRole('button', { name: 'Create Project' }).click()
+  await adminPage.getByRole('button', { name: 'Publish' }).click()
 
   await adminPage.waitForURL(/\/projects\/\d+/, { timeout: 15_000 })
   // Wait for project content to render — this ensures auth has completed before we return,
@@ -68,6 +68,96 @@ export async function adminCreateProject(
   const match = adminPage.url().match(/\/projects\/(\d+)/)
   if (!match) throw new Error(`Could not extract project ID from URL: ${adminPage.url()}`)
   return parseInt(match[1])
+}
+
+export async function adminSaveProjectDraft(
+  baseUrl: string,
+  adminPage: Page,
+  title: string,
+): Promise<number> {
+  await adminPage.goto(`${baseUrl}/admin/projects/new`)
+  await expect(adminPage.getByRole('heading', { name: 'Create Organisation Project' })).toBeVisible(
+    { timeout: 10_000 },
+  )
+
+  await adminPage.getByLabel('Project Title').fill(title)
+
+  const [response] = await Promise.all([
+    adminPage.waitForResponse((resp) => resp.url().includes('/api/rpc/admin/projects/create')),
+    adminPage.getByRole('button', { name: 'Save as Draft' }).click(),
+  ])
+  if (!response.ok()) throw new Error(`Draft save failed: ${await response.text()}`)
+  const { id } = (await response.json()).json as { id: number }
+  await adminPage.waitForURL(`${baseUrl}/projects/${id}**`, { timeout: 15_000 })
+  return id
+}
+
+export async function volunteerSaveProjectDraft(
+  baseUrl: string,
+  page: Page,
+  title: string,
+): Promise<number> {
+  await page.goto(`${baseUrl}/suggest`)
+  await expect(page.getByRole('button', { name: 'Submit Project Proposal' })).toBeVisible({
+    timeout: 10_000,
+  })
+
+  await page.getByLabel('Project Title').fill(title)
+
+  const [response] = await Promise.all([
+    page.waitForResponse((resp) => resp.url().includes('/api/rpc/projects/create')),
+    page.getByRole('button', { name: 'Save as Draft' }).click(),
+  ])
+  if (!response.ok()) throw new Error(`Draft save failed: ${await response.text()}`)
+  const { id } = (await response.json()).json as { id: number }
+  return id
+}
+
+export async function addTaskFromEditPage(
+  baseUrl: string,
+  page: Page,
+  projectId: number,
+  taskTitle: string,
+): Promise<void> {
+  if (!page.url().includes(`/projects/${projectId}/edit`)) {
+    await page.goto(`${baseUrl}/projects/${projectId}/edit`)
+  }
+  await expect(page.getByRole('heading', { name: 'Edit Project' })).toBeVisible({
+    timeout: 10_000,
+  })
+  await page.getByLabel('Task title').fill(taskTitle)
+  await page.getByRole('button', { name: 'Add Task' }).click()
+  await expect(page.getByText(taskTitle)).toBeVisible({ timeout: 10_000 })
+}
+
+export async function publishDraftFromEditPage(
+  baseUrl: string,
+  page: Page,
+  projectId: number,
+): Promise<void> {
+  if (!page.url().includes(`/projects/${projectId}/edit`)) {
+    await page.goto(`${baseUrl}/projects/${projectId}/edit`)
+  }
+  await page.getByRole('button', { name: 'Publish', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Submit draft for review?' })).toBeVisible({
+    timeout: 10_000,
+  })
+  await page.getByRole('button', { name: 'Submit for Review' }).click()
+}
+
+export async function deleteDraftFromEditPage(
+  baseUrl: string,
+  page: Page,
+  projectId: number,
+): Promise<void> {
+  if (!page.url().includes(`/projects/${projectId}/edit`)) {
+    await page.goto(`${baseUrl}/projects/${projectId}/edit`)
+  }
+  await page.getByRole('button', { name: 'Delete Draft', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Delete this draft?' })).toBeVisible({
+    timeout: 10_000,
+  })
+  await page.getByRole('dialog').getByRole('button', { name: 'Delete Draft' }).click()
 }
 
 export async function adminApproveProject(

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -52,9 +52,9 @@ export async function adminCreateProject(
   description: string,
 ): Promise<number> {
   await adminPage.goto(`${baseUrl}/admin/projects/new`)
-  await expect(adminPage.getByRole('heading', { name: 'Create Organisation Project' })).toBeVisible(
-    { timeout: 10_000 },
-  )
+  await expect(adminPage.getByRole('heading', { name: 'Org Projects' })).toBeVisible({
+    timeout: 10_000,
+  })
 
   await adminPage.getByLabel('Project Title').fill(title)
   await adminPage.getByLabel('Description').fill(description)
@@ -76,9 +76,9 @@ export async function adminSaveProjectDraft(
   title: string,
 ): Promise<number> {
   await adminPage.goto(`${baseUrl}/admin/projects/new`)
-  await expect(adminPage.getByRole('heading', { name: 'Create Organisation Project' })).toBeVisible(
-    { timeout: 10_000 },
-  )
+  await expect(adminPage.getByRole('heading', { name: 'Org Projects' })).toBeVisible({
+    timeout: 10_000,
+  })
 
   await adminPage.getByLabel('Project Title').fill(title)
 
@@ -110,6 +110,7 @@ export async function volunteerSaveProjectDraft(
   ])
   if (!response.ok()) throw new Error(`Draft save failed: ${await response.text()}`)
   const { id } = (await response.json()).json as { id: number }
+  await page.waitForURL(`${baseUrl}/projects/${id}/edit`, { timeout: 15_000 })
   return id
 }
 

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -131,6 +131,7 @@ export async function addTaskFromEditPage(
   await expect(page.getByText(taskTitle)).toBeVisible({ timeout: 10_000 })
 }
 
+// For a volunteer's own draft: submits it into the review queue.
 export async function publishDraftFromEditPage(
   baseUrl: string,
   page: Page,
@@ -139,11 +140,27 @@ export async function publishDraftFromEditPage(
   if (!page.url().includes(`/projects/${projectId}/edit`)) {
     await page.goto(`${baseUrl}/projects/${projectId}/edit`)
   }
-  await page.getByRole('button', { name: 'Publish', exact: true }).click()
+  await page.getByRole('button', { name: 'Submit', exact: true }).click()
   await expect(page.getByRole('heading', { name: 'Submit draft for review?' })).toBeVisible({
     timeout: 10_000,
   })
   await page.getByRole('button', { name: 'Submit for Review' }).click()
+}
+
+// For an org-proposed draft: publishes it live, skipping review entirely.
+export async function publishOrgDraftFromEditPage(
+  baseUrl: string,
+  page: Page,
+  projectId: number,
+): Promise<void> {
+  if (!page.url().includes(`/projects/${projectId}/edit`)) {
+    await page.goto(`${baseUrl}/projects/${projectId}/edit`)
+  }
+  await page.getByRole('button', { name: 'Publish', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Publish this project?' })).toBeVisible({
+    timeout: 10_000,
+  })
+  await page.getByRole('dialog').getByRole('button', { name: 'Publish', exact: true }).click()
 }
 
 export async function deleteDraftFromEditPage(

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -32,12 +32,16 @@ export async function proposeProject(
       .click()
   }
   await page.getByLabel('Task title').first().fill('Initial task')
+  await page.getByRole('button', { name: 'Submit Project Proposal' }).click()
+  await expect(page.getByRole('heading', { name: 'Submit for review?' })).toBeVisible({
+    timeout: 10_000,
+  })
 
   // Ideally we'd extract the project ID from the dashboard UI after redirect, but that
   // races against the async render. Intercepting the API response is more reliable for now.
   const [response] = await Promise.all([
     page.waitForResponse((resp) => resp.url().includes('/api/rpc/projects/create')),
-    page.getByRole('button', { name: 'Submit Project Proposal' }).click(),
+    page.getByRole('dialog').getByRole('button', { name: 'Submit Project Proposal' }).click(),
   ])
   if (!response.ok()) throw new Error(`Project creation failed: ${await response.text()}`)
   const { id } = (await response.json()).json as { id: number }
@@ -59,7 +63,11 @@ export async function adminCreateProject(
   await adminPage.getByLabel('Project Title').fill(title)
   await adminPage.getByLabel('Description').fill(description)
   await adminPage.getByLabel('Task title').first().fill('Initial task')
-  await adminPage.getByRole('button', { name: 'Publish' }).click()
+  await adminPage.getByRole('button', { name: 'Publish', exact: true }).click()
+  await expect(adminPage.getByRole('heading', { name: 'Publish this project?' })).toBeVisible({
+    timeout: 10_000,
+  })
+  await adminPage.getByRole('dialog').getByRole('button', { name: 'Publish', exact: true }).click()
 
   await adminPage.waitForURL(/\/projects\/\d+/, { timeout: 15_000 })
   // Wait for project content to render — this ensures auth has completed before we return,
@@ -84,7 +92,7 @@ export async function adminSaveProjectDraft(
 
   const [response] = await Promise.all([
     adminPage.waitForResponse((resp) => resp.url().includes('/api/rpc/admin/projects/create')),
-    adminPage.getByRole('button', { name: 'Save as Draft' }).click(),
+    adminPage.getByRole('button', { name: 'Save draft' }).click(),
   ])
   if (!response.ok()) throw new Error(`Draft save failed: ${await response.text()}`)
   const { id } = (await response.json()).json as { id: number }
@@ -106,7 +114,7 @@ export async function volunteerSaveProjectDraft(
 
   const [response] = await Promise.all([
     page.waitForResponse((resp) => resp.url().includes('/api/rpc/projects/create')),
-    page.getByRole('button', { name: 'Save as Draft' }).click(),
+    page.getByRole('button', { name: 'Save draft' }).click(),
   ])
   if (!response.ok()) throw new Error(`Draft save failed: ${await response.text()}`)
   const { id } = (await response.json()).json as { id: number }
@@ -126,9 +134,11 @@ export async function addTaskFromEditPage(
   await expect(page.getByRole('heading', { name: 'Edit Project' })).toBeVisible({
     timeout: 10_000,
   })
-  await page.getByLabel('Task title').fill(taskTitle)
+  // Existing tasks are also labeled "Task title" — target the add-task form's stable id.
+  await page.locator('#new-task-title').fill(taskTitle)
   await page.getByRole('button', { name: 'Add Task' }).click()
-  await expect(page.getByText(taskTitle)).toBeVisible({ timeout: 10_000 })
+  // Existing tasks render as editable inputs, so the title is a value, not a text node.
+  await expect(page.locator(`input[value="${taskTitle}"]`)).toBeVisible({ timeout: 10_000 })
 }
 
 // For a volunteer's own draft: submits it into the review queue.

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -238,7 +238,7 @@ test.describe('Project Creation Requires At Least One Task', () => {
 
     await adminPage.getByLabel('Project Title').fill(fake.projectTitle())
     await adminPage.getByLabel('Description').fill('Org project with no tasks')
-    await adminPage.getByRole('button', { name: 'Create Project' }).click()
+    await adminPage.getByRole('button', { name: 'Publish' }).click()
 
     await expect(getAlert(adminPage)).toContainText('At least one task with a title is required.', {
       timeout: 10_000,

--- a/e2e/tests/06-project-lifecycle.spec.ts
+++ b/e2e/tests/06-project-lifecycle.spec.ts
@@ -232,9 +232,9 @@ test.describe('Project Creation Requires At Least One Task', () => {
     baseUrl,
   }) => {
     await adminPage.goto(`${baseUrl}/admin/projects/new`)
-    await expect(
-      adminPage.getByRole('heading', { name: 'Create Organisation Project' }),
-    ).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.getByRole('heading', { name: 'Org Projects' })).toBeVisible({
+      timeout: 10_000,
+    })
 
     await adminPage.getByLabel('Project Title').fill(fake.projectTitle())
     await adminPage.getByLabel('Description').fill('Org project with no tasks')

--- a/e2e/tests/27-remote-eligibility.spec.ts
+++ b/e2e/tests/27-remote-eligibility.spec.ts
@@ -139,9 +139,9 @@ test.describe('Project form & settings: remote eligibility', () => {
     const title = fake.projectTitle()
 
     await adminPage.goto(`${baseUrl}/admin/projects/new`)
-    await expect(
-      adminPage.getByRole('heading', { name: 'Create Organisation Project' }),
-    ).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.getByRole('heading', { name: 'Org Projects' })).toBeVisible({
+      timeout: 10_000,
+    })
 
     await adminPage.getByLabel('Project Title').fill(title)
     await adminPage.getByLabel('Description').fill('e2e test project description')

--- a/e2e/tests/27-remote-eligibility.spec.ts
+++ b/e2e/tests/27-remote-eligibility.spec.ts
@@ -151,7 +151,7 @@ test.describe('Project form & settings: remote eligibility', () => {
       'Yes - remote OK, from any country',
     )
     await adminPage.getByLabel('Task title').first().fill('Initial task')
-    await adminPage.getByRole('button', { name: 'Create Project' }).click()
+    await adminPage.getByRole('button', { name: 'Publish' }).click()
 
     await adminPage.waitForURL(/\/projects\/\d+/, { timeout: 15_000 })
     await expect(adminPage.locator('#projectContent')).toBeVisible({ timeout: 10_000 })

--- a/e2e/tests/27-remote-eligibility.spec.ts
+++ b/e2e/tests/27-remote-eligibility.spec.ts
@@ -151,7 +151,11 @@ test.describe('Project form & settings: remote eligibility', () => {
       'Yes - remote OK, from any country',
     )
     await adminPage.getByLabel('Task title').first().fill('Initial task')
-    await adminPage.getByRole('button', { name: 'Publish' }).click()
+    await adminPage.getByRole('button', { name: 'Publish', exact: true }).click()
+    await adminPage
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Publish', exact: true })
+      .click()
 
     await adminPage.waitForURL(/\/projects\/\d+/, { timeout: 15_000 })
     await expect(adminPage.locator('#projectContent')).toBeVisible({ timeout: 10_000 })

--- a/e2e/tests/34-project-drafts.spec.ts
+++ b/e2e/tests/34-project-drafts.spec.ts
@@ -117,17 +117,23 @@ test.describe('Volunteer project drafts', () => {
     const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, fake.projectTitle())
     await addTaskFromEditPage(baseUrl, volunteer.page, projectId, 'Original task title')
 
-    await volunteer.page
-      .locator('li', { hasText: 'Original task title' })
-      .getByRole('button', { name: 'Edit' })
-      .click()
-    await volunteer.page.getByLabel('Edit task title').fill('Updated task title')
-    await volunteer.page.getByLabel('Edit task details (optional)').fill('Updated task details')
-    await volunteer.page.getByRole('button', { name: 'Save', exact: true }).click()
+    // Existing tasks use a stable `task-title-{id}` / `task-desc-{id}` id, unlike the
+    // always-present add-task form's `new-task-title` — target that instead of the
+    // (identical, ambiguous) "Task title" label text shared by both.
+    const isUpdateTaskResponse = (resp: { url: () => string }) =>
+      resp.url().includes('/api/rpc/projects/updateTask')
+    const taskTitleInput = volunteer.page.locator('input[id^="task-title-"]')
+    const taskDescInput = volunteer.page.locator('textarea[id^="task-desc-"]')
 
-    await expect(volunteer.page.getByText('Updated task title')).toBeVisible({ timeout: 10_000 })
-    await expect(volunteer.page.getByText('Updated task details')).toBeVisible()
-    await expect(volunteer.page.getByText('Original task title')).toHaveCount(0)
+    await taskTitleInput.fill('Updated task title')
+    await Promise.all([volunteer.page.waitForResponse(isUpdateTaskResponse), taskTitleInput.blur()])
+
+    await taskDescInput.fill('Updated task details')
+    await Promise.all([volunteer.page.waitForResponse(isUpdateTaskResponse), taskDescInput.blur()])
+
+    await volunteer.page.reload()
+    await expect(taskTitleInput).toHaveValue('Updated task title', { timeout: 10_000 })
+    await expect(taskDescInput).toHaveValue('Updated task details')
   })
 
   test('Publishing a draft with no tasks is rejected', async ({ volunteer, baseUrl }) => {
@@ -148,7 +154,7 @@ test.describe('Volunteer project drafts', () => {
 
     await volunteer.page.goto(`${baseUrl}/suggest`)
     await volunteer.page.getByLabel('Project Title').fill(fake.projectTitle())
-    await volunteer.page.getByRole('button', { name: 'Save as Draft' }).click()
+    await volunteer.page.getByRole('button', { name: 'Save draft' }).click()
 
     await expect(getAlert(volunteer.page)).toContainText('You already have 2 drafts', {
       timeout: 10_000,

--- a/e2e/tests/34-project-drafts.spec.ts
+++ b/e2e/tests/34-project-drafts.spec.ts
@@ -110,6 +110,26 @@ test.describe('Volunteer project drafts', () => {
     })
   })
 
+  test('Volunteer edits a task title and details on the draft edit page', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, fake.projectTitle())
+    await addTaskFromEditPage(baseUrl, volunteer.page, projectId, 'Original task title')
+
+    await volunteer.page
+      .locator('li', { hasText: 'Original task title' })
+      .getByRole('button', { name: 'Edit' })
+      .click()
+    await volunteer.page.getByLabel('Edit task title').fill('Updated task title')
+    await volunteer.page.getByLabel('Edit task details (optional)').fill('Updated task details')
+    await volunteer.page.getByRole('button', { name: 'Save', exact: true }).click()
+
+    await expect(volunteer.page.getByText('Updated task title')).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.getByText('Updated task details')).toBeVisible()
+    await expect(volunteer.page.getByText('Original task title')).toHaveCount(0)
+  })
+
   test('Publishing a draft with no tasks is rejected', async ({ volunteer, baseUrl }) => {
     const title = fake.projectTitle()
     const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, title)

--- a/e2e/tests/34-project-drafts.spec.ts
+++ b/e2e/tests/34-project-drafts.spec.ts
@@ -16,9 +16,17 @@ test.describe('Admin project drafts', () => {
     baseUrl,
   }) => {
     const title = fake.projectTitle()
+    // Saving a draft lands directly on its edit page.
     const projectId = await adminSaveProjectDraft(baseUrl, adminPage, title)
 
-    await expect(adminPage.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    // Also shows up in "My Drafts" back on the Org Projects page
+    await adminPage.goto(`${baseUrl}/admin/projects/new`)
+    await expect(adminPage.getByRole('heading', { name: 'My Drafts' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(adminPage.getByText(title)).toBeVisible()
+
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
     await expect(adminPage.getByLabel('project status')).toContainText('Draft', {
       timeout: 10_000,
     })
@@ -54,9 +62,10 @@ test.describe('Volunteer project drafts', () => {
     baseUrl,
   }) => {
     const title = fake.projectTitle()
+    // Saving a draft lands directly on its edit page.
     const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, title)
 
-    // Shows up in "My Drafts" on the suggest page
+    // Also shows up in "My Drafts" back on the suggest page
     await volunteer.page.goto(`${baseUrl}/suggest`)
     await expect(volunteer.page.getByRole('heading', { name: 'My Drafts' })).toBeVisible({
       timeout: 10_000,
@@ -69,9 +78,8 @@ test.describe('Volunteer project drafts', () => {
       timeout: 5_000,
     })
 
-    // Edit the draft: add the required task, then publish
-    await volunteer.page.getByRole('link', { name: 'Edit' }).first().click()
-    await volunteer.page.waitForURL(`${baseUrl}/projects/${projectId}/edit`, { timeout: 10_000 })
+    // Back to the draft's edit page: add the required task, then publish
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}/edit`)
     await addTaskFromEditPage(baseUrl, volunteer.page, projectId, 'Initial task')
     await publishDraftFromEditPage(baseUrl, volunteer.page, projectId)
 

--- a/e2e/tests/34-project-drafts.spec.ts
+++ b/e2e/tests/34-project-drafts.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, getAlert } from '../fixtures'
+import { fake } from '../fake'
+import {
+  adminSaveProjectDraft,
+  volunteerSaveProjectDraft,
+  addTaskFromEditPage,
+  publishDraftFromEditPage,
+  deleteDraftFromEditPage,
+  setProjectStatus,
+} from '../actions/projects'
+
+test.describe('Admin project drafts', () => {
+  test('Admin saves a draft with no tasks; it stays hidden until published', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const title = fake.projectTitle()
+    const projectId = await adminSaveProjectDraft(baseUrl, adminPage, title)
+
+    await expect(adminPage.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.getByLabel('project status')).toContainText('Draft', {
+      timeout: 10_000,
+    })
+
+    // Not in the triage queue — drafts never entered the review pipeline
+    await adminPage.goto(`${baseUrl}/admin/triage`)
+    await expect(adminPage.locator('.card').filter({ hasText: title })).not.toBeVisible({
+      timeout: 5_000,
+    })
+
+    // Not visible to a volunteer browsing projects
+    await volunteer.page.goto(`${baseUrl}/projects`)
+    await expect(volunteer.page.getByRole('link', { name: title })).toHaveCount(0)
+
+    // Admin adds a task and publishes it live
+    await addTaskFromEditPage(baseUrl, adminPage, projectId, 'Initial task')
+    await setProjectStatus(baseUrl, adminPage, projectId, 'ready')
+
+    await expect(adminPage.getByLabel('project status')).toContainText('Ready', {
+      timeout: 10_000,
+    })
+    await volunteer.page.goto(`${baseUrl}/projects`)
+    await expect(volunteer.page.getByRole('link', { name: title })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+})
+
+test.describe('Volunteer project drafts', () => {
+  test('Volunteer saves a draft, adds a task, and publishes it for review', async ({
+    volunteer,
+    adminPage,
+    baseUrl,
+  }) => {
+    const title = fake.projectTitle()
+    const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, title)
+
+    // Shows up in "My Drafts" on the suggest page
+    await volunteer.page.goto(`${baseUrl}/suggest`)
+    await expect(volunteer.page.getByRole('heading', { name: 'My Drafts' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(volunteer.page.getByText(title)).toBeVisible()
+
+    // Not visible to admins yet — no proposal notification, not in triage
+    await adminPage.goto(`${baseUrl}/admin/triage`)
+    await expect(adminPage.locator('.card').filter({ hasText: title })).not.toBeVisible({
+      timeout: 5_000,
+    })
+
+    // Edit the draft: add the required task, then publish
+    await volunteer.page.getByRole('link', { name: 'Edit' }).first().click()
+    await volunteer.page.waitForURL(`${baseUrl}/projects/${projectId}/edit`, { timeout: 10_000 })
+    await addTaskFromEditPage(baseUrl, volunteer.page, projectId, 'Initial task')
+    await publishDraftFromEditPage(baseUrl, volunteer.page, projectId)
+
+    await expect(getAlert(volunteer.page)).toContainText('Draft submitted for review', {
+      timeout: 10_000,
+    })
+
+    // Now shows up in the admin triage queue like any other proposal
+    await adminPage.goto(`${baseUrl}/admin/triage`)
+    await expect(adminPage.locator('.card').filter({ hasText: title })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('Publishing a draft with no tasks is rejected', async ({ volunteer, baseUrl }) => {
+    const title = fake.projectTitle()
+    const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, title)
+
+    await publishDraftFromEditPage(baseUrl, volunteer.page, projectId)
+
+    await expect(getAlert(volunteer.page)).toContainText(
+      'Add at least one task before submitting this draft for review',
+      { timeout: 10_000 },
+    )
+  })
+
+  test('A volunteer is blocked from saving a third draft', async ({ volunteer, baseUrl }) => {
+    await volunteerSaveProjectDraft(baseUrl, volunteer.page, fake.projectTitle())
+    await volunteerSaveProjectDraft(baseUrl, volunteer.page, fake.projectTitle())
+
+    await volunteer.page.goto(`${baseUrl}/suggest`)
+    await volunteer.page.getByLabel('Project Title').fill(fake.projectTitle())
+    await volunteer.page.getByRole('button', { name: 'Save as Draft' }).click()
+
+    await expect(getAlert(volunteer.page)).toContainText('You already have 2 drafts', {
+      timeout: 10_000,
+    })
+  })
+
+  test('Volunteer deletes a draft from the edit page', async ({ volunteer, baseUrl }) => {
+    const title = fake.projectTitle()
+    const projectId = await volunteerSaveProjectDraft(baseUrl, volunteer.page, title)
+
+    await deleteDraftFromEditPage(baseUrl, volunteer.page, projectId)
+    await expect(getAlert(volunteer.page)).toContainText('Draft deleted', { timeout: 10_000 })
+
+    await volunteer.page.waitForURL(`${baseUrl}/suggest`, { timeout: 10_000 })
+    await expect(volunteer.page.getByText(title)).toHaveCount(0)
+  })
+})

--- a/e2e/tests/34-project-drafts.spec.ts
+++ b/e2e/tests/34-project-drafts.spec.ts
@@ -6,7 +6,6 @@ import {
   addTaskFromEditPage,
   publishDraftFromEditPage,
   deleteDraftFromEditPage,
-  setProjectStatus,
 } from '../actions/projects'
 
 test.describe('Admin project drafts', () => {
@@ -26,10 +25,9 @@ test.describe('Admin project drafts', () => {
     })
     await expect(adminPage.getByText(title)).toBeVisible()
 
+    // Visiting the project page while it's still a draft redirects to its edit page
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
-    await expect(adminPage.getByLabel('project status')).toContainText('Draft', {
-      timeout: 10_000,
-    })
+    await adminPage.waitForURL(`${baseUrl}/projects/${projectId}/edit`, { timeout: 10_000 })
 
     // Not in the triage queue — drafts never entered the review pipeline
     await adminPage.goto(`${baseUrl}/admin/triage`)
@@ -41,13 +39,31 @@ test.describe('Admin project drafts', () => {
     await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(volunteer.page.getByRole('link', { name: title })).toHaveCount(0)
 
-    // Admin adds a task and publishes it live
+    // Admin adds a task, then publishes via the edit page — straight live, no review step
     await addTaskFromEditPage(baseUrl, adminPage, projectId, 'Initial task')
-    await setProjectStatus(baseUrl, adminPage, projectId, 'ready')
+    await adminPage.goto(`${baseUrl}/projects/${projectId}/edit`)
+    await adminPage.getByRole('button', { name: 'Publish', exact: true }).click()
+    const publishModal = adminPage.getByRole('dialog')
+    await expect(publishModal.getByRole('heading', { name: 'Publish this project?' })).toBeVisible({
+      timeout: 10_000,
+    })
+    // No mention of a review step — org projects skip it entirely
+    await expect(publishModal).not.toContainText('review')
+    await expect(publishModal).not.toContainText('team leads')
+    await publishModal.getByRole('button', { name: 'Publish', exact: true }).click()
 
+    await expect(getAlert(adminPage)).toContainText('Project published', { timeout: 10_000 })
+    await adminPage.waitForURL(`${baseUrl}/projects/${projectId}`, { timeout: 10_000 })
     await expect(adminPage.getByLabel('project status')).toContainText('Ready', {
       timeout: 10_000,
     })
+
+    // Never touched the triage queue
+    await adminPage.goto(`${baseUrl}/admin/triage`)
+    await expect(adminPage.locator('.card').filter({ hasText: title })).not.toBeVisible({
+      timeout: 5_000,
+    })
+
     await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(volunteer.page.getByRole('link', { name: title })).toBeVisible({
       timeout: 10_000,

--- a/lib/project-status.ts
+++ b/lib/project-status.ts
@@ -10,8 +10,8 @@ import { ProjectStatus } from '@/generated/prisma/enums'
  *   draft → pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
  *
  * `ready` means approved and live, but unowned. Assigning an owner is what moves a
- * project to `in_progress`. `draft` is org-proposed only — an admin still preparing a
- * project before it enters review or goes live.
+ * project to `in_progress`. `draft` is a creator still preparing a project before it
+ * enters review (volunteer proposals) or goes live (org projects, which skip review).
  */
 export const PROJECT_STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
   draft: { label: 'Draft', variant: 'neutral' },
@@ -96,6 +96,9 @@ export const ADVERTISABLE_STATUSES: string[] = Object.keys(PROJECT_STATUS_CONFIG
  * name as the proposer misattributes the project to an individual.
  */
 export const ORG_PROPOSER_NAME = 'PauseAI'
+
+/** A volunteer may have at most this many of their own proposals sitting in `draft` at once. */
+export const MAX_VOLUNTEER_DRAFTS = 2
 
 export type ProposerDisplay = { name: string; volunteerId: number | null }
 

--- a/lib/project-status.ts
+++ b/lib/project-status.ts
@@ -7,12 +7,14 @@ import { ProjectStatus } from '@/generated/prisma/enums'
  * here; previously each kept its own copy and they drifted (notification emails were
  * sending raw enum strings for statuses the server's copy had never heard of).
  *
- *   pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
+ *   draft → pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
  *
  * `ready` means approved and live, but unowned. Assigning an owner is what moves a
- * project to `in_progress`.
+ * project to `in_progress`. `draft` is org-proposed only — an admin still preparing a
+ * project before it enters review or goes live.
  */
 export const PROJECT_STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
+  draft: { label: 'Draft', variant: 'neutral' },
   pending_review: { label: 'Pending Review', variant: 'warning' },
   needs_discussion: { label: 'Needs Discussion', variant: 'neutral' },
   ready: { label: 'Ready', variant: 'caution' },
@@ -41,12 +43,14 @@ export const OWNER_ALLOWED_STATUSES: ProjectStatus[] = [
 /** Additional statuses only an admin may set. */
 export const ADMIN_ONLY_STATUSES: ProjectStatus[] = [
   ProjectStatus.archived,
+  ProjectStatus.draft,
   ProjectStatus.pending_review,
   ProjectStatus.needs_discussion,
 ]
 
 /** Pre-approval: hidden from browse, never advertised to volunteers. */
 export const UNAPPROVED_STATUSES: string[] = [
+  ProjectStatus.draft,
   ProjectStatus.pending_review,
   ProjectStatus.needs_discussion,
 ]

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -136,6 +136,7 @@ export const CreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS)
     wantToOwn: z.boolean().optional().default(false),
     skillIds: z.array(z.number().int()).optional().default([]),
     skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
+    saveAsDraft: z.boolean().optional().default(false),
   })
 
 export const UpdateProjectSchema = WorkItemSchema.pick({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -195,6 +195,7 @@ export const AdminCreateProjectSchema = WorkItemSchema.pick(PROJECT_INPUT_FIELDS
     wantToOwn: z.boolean().optional().default(false),
     skillIds: z.array(z.number().int()).optional().default([]),
     skillRequiredMap: z.record(z.string(), z.boolean()).optional().default({}),
+    saveAsDraft: z.boolean().optional().default(false),
   })
 
 export const ReviewProjectSchema = z.object({

--- a/prisma/migrations/20260824191641_add_draft_project_status/migration.sql
+++ b/prisma/migrations/20260824191641_add_draft_project_status/migration.sql
@@ -1,0 +1,2 @@
+-- This is an empty migration.
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,9 +18,11 @@ datasource db {
 // Lifecycle position only. Whether a project wants an owner or more help is not a
 // status: `isSeekingOwner` is derived (see lib/project-status.ts) and `isSeekingHelp`
 // is an independent flag the owner controls.
-//   pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
+//   draft → pending_review → needs_discussion → ready → in_progress → on_hold → completed → archived
 // `ready` = approved and live, but nobody owns it yet.
+// `draft` = org-proposed only, admin still preparing it; never enters the review queue.
 enum ProjectStatus {
+  draft
   pending_review
   needs_discussion
   ready

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -10,6 +10,21 @@ import { adminProcedure } from '../../procedures'
 import { ProjectStatus, TaskStatus, WorkItemType } from '@/generated/prisma/enums'
 
 export const adminProjectsRouter = {
+  myDrafts: adminProcedure.handler(async ({ context }) => {
+    const admin = context.volunteer
+    const drafts = await prisma.workItem.findMany({
+      where: {
+        type: WorkItemType.PROJECT,
+        creatorId: admin.id,
+        status: ProjectStatus.draft,
+        isOrgProposed: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, title: true, createdAt: true },
+    })
+    return drafts
+  }),
+
   create: adminProcedure.input(AdminCreateProjectSchema).handler(async ({ input, context }) => {
     const admin = context.volunteer
     const { wantToOwn, skillIds, skillRequiredMap, tasks, saveAsDraft } = input

--- a/server/routers/admin/projects.ts
+++ b/server/routers/admin/projects.ts
@@ -12,8 +12,8 @@ import { ProjectStatus, TaskStatus, WorkItemType } from '@/generated/prisma/enum
 export const adminProjectsRouter = {
   create: adminProcedure.input(AdminCreateProjectSchema).handler(async ({ input, context }) => {
     const admin = context.volunteer
-    const { wantToOwn, skillIds, skillRequiredMap, tasks } = input
-    if (tasks.length === 0) {
+    const { wantToOwn, skillIds, skillRequiredMap, tasks, saveAsDraft } = input
+    if (!saveAsDraft && tasks.length === 0) {
       throw new ORPCError('BAD_REQUEST', {
         message: 'At least one task is required to create a project',
       })
@@ -25,9 +25,14 @@ export const adminProjectsRouter = {
           type: WorkItemType.PROJECT,
           title: input.title,
           description: input.description,
-          // Org projects skip review, so they go live immediately — owned by the admin
-          // who created it, or `ready` for someone to pick up.
-          status: wantToOwn ? ProjectStatus.in_progress : ProjectStatus.ready,
+          // Org projects skip review, so a published one goes live immediately — owned by
+          // the admin who created it, or `ready` for someone to pick up. A draft stays
+          // invisible to volunteers until the admin explicitly publishes it.
+          status: saveAsDraft
+            ? ProjectStatus.draft
+            : wantToOwn
+              ? ProjectStatus.in_progress
+              : ProjectStatus.ready,
           assigneeId: wantToOwn ? admin.id : null,
           creatorId: admin.id,
           isOrgProposed: true,
@@ -68,15 +73,17 @@ export const adminProjectsRouter = {
       return newProject
     })
 
-    notifyMatchingVolunteers(project.id).catch((e) => console.error('[MATCH NOTIFY]', e))
+    if (!saveAsDraft) {
+      notifyMatchingVolunteers(project.id).catch((e) => console.error('[MATCH NOTIFY]', e))
 
-    if (input.teamId) {
-      notifyTeamOfProject(input.teamId, project.id, project.title).catch((e) =>
-        console.error('[TEAM NOTIFY]', e),
-      )
+      if (input.teamId) {
+        notifyTeamOfProject(input.teamId, project.id, project.title).catch((e) =>
+          console.error('[TEAM NOTIFY]', e),
+        )
+      }
     }
 
-    return { id: project.id, message: 'Org project created' }
+    return { id: project.id, message: saveAsDraft ? 'Draft saved' : 'Org project created' }
   }),
 
   review: adminProcedure

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -494,6 +494,7 @@ export const projectsRouter = {
       }
 
       const hiddenStatuses: string[] = [
+        ProjectStatus.draft,
         ProjectStatus.pending_review,
         ProjectStatus.needs_discussion,
       ]

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -12,6 +12,7 @@ import {
   serializeTask,
 } from '@/lib/work-item'
 import { notifyUser, notifyAdmins, notifyTeamOfProject, clearNotifications } from '@/lib/notify'
+import { notifyMatchingVolunteers } from '@/lib/project-match-notify'
 import { html } from '@/lib/email'
 import {
   CreateProjectSchema,
@@ -525,6 +526,26 @@ export const projectsRouter = {
         throw new ORPCError('BAD_REQUEST', {
           message: 'Add at least one task before submitting this draft for review',
         })
+      }
+
+      if (project.isOrgProposed) {
+        // Org projects skip review entirely — publishing a draft goes straight live,
+        // same as a non-draft org project created directly.
+        const newStatus =
+          project.assigneeId === null ? ProjectStatus.ready : ProjectStatus.in_progress
+        await prisma.workItem.update({
+          where: { id: input.id },
+          data: { status: newStatus, updatedAt: new Date() },
+        })
+
+        notifyMatchingVolunteers(project.id).catch((e) => console.error('[MATCH NOTIFY]', e))
+        if (project.teamId) {
+          notifyTeamOfProject(project.teamId, project.id, project.title).catch((e) =>
+            console.error('[TEAM NOTIFY]', e),
+          )
+        }
+
+        return { message: 'Project published' }
       }
 
       await prisma.workItem.update({

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -414,6 +414,7 @@ export const projectsRouter = {
           type: WorkItemType.PROJECT,
           creatorId: volunteer.id,
           status: ProjectStatus.draft,
+          isOrgProposed: false,
         },
       })
       if (draftCount >= MAX_VOLUNTEER_DRAFTS) {
@@ -500,6 +501,8 @@ export const projectsRouter = {
         type: WorkItemType.PROJECT,
         creatorId: volunteer.id,
         status: ProjectStatus.draft,
+        // Org drafts belong to the "Org Projects" admin page's own My Drafts list.
+        isOrgProposed: false,
       },
       orderBy: { createdAt: 'desc' },
       select: { id: true, title: true, createdAt: true },
@@ -807,7 +810,12 @@ export const projectsRouter = {
       // Handing the project to a different owner or team is the owner's call (or an
       // admin's) — a proposer who never owned it can't appoint themselves. Submitting the
       // current value is always fine: the edit form posts every field back unchanged.
-      const canReassign = isAssignee || Boolean(volunteer.isAdmin)
+      // A draft has no owner yet, so its creator can set themselves as owner while it's
+      // still a draft — the "I want to lead this project" choice from the create form.
+      const canReassign =
+        isAssignee ||
+        Boolean(volunteer.isAdmin) ||
+        (isCreator && project.status === ProjectStatus.draft)
 
       if (body.teamId !== undefined && body.teamId !== project.teamId) {
         if (!canReassign) {

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -26,6 +26,7 @@ import {
   SEEKING_OWNER_SQL,
   TERMINAL_STATUSES,
   UNAPPROVED_STATUSES,
+  MAX_VOLUNTEER_DRAFTS,
   projectStatusLabel,
 } from '@/lib/project-status'
 import {
@@ -399,11 +400,26 @@ export const projectsRouter = {
 
   create: approvedProcedure.input(CreateProjectSchema).handler(async ({ input, context }) => {
     const volunteer = context.volunteer
-    const { tasks, wantToOwn, skillIds, skillRequiredMap } = input
+    const { tasks, wantToOwn, skillIds, skillRequiredMap, saveAsDraft } = input
     if (tasks.length === 0) {
       throw new ORPCError('BAD_REQUEST', {
         message: 'At least one task is required to submit a project proposal',
       })
+    }
+
+    if (saveAsDraft) {
+      const draftCount = await prisma.workItem.count({
+        where: {
+          type: WorkItemType.PROJECT,
+          creatorId: volunteer.id,
+          status: ProjectStatus.draft,
+        },
+      })
+      if (draftCount >= MAX_VOLUNTEER_DRAFTS) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: `You already have ${MAX_VOLUNTEER_DRAFTS} drafts — publish or delete one before saving another.`,
+        })
+      }
     }
 
     const project = await prisma.$transaction(async (tx) => {
@@ -412,7 +428,8 @@ export const projectsRouter = {
           type: WorkItemType.PROJECT,
           title: input.title,
           description: input.description,
-          status: ProjectStatus.pending_review,
+          // A draft stays invisible to admins until the volunteer explicitly publishes it.
+          status: saveAsDraft ? ProjectStatus.draft : ProjectStatus.pending_review,
           assigneeId: wantToOwn ? volunteer.id : null,
           creatorId: volunteer.id,
           isOrgProposed: false,
@@ -453,22 +470,90 @@ export const projectsRouter = {
       return newProject
     })
 
-    await notifyAdmins(
-      'new_project_proposal',
-      `New project proposal: ${project.title}`,
-      `Proposed by ${volunteer.name}`,
-      '/admin/triage',
-      {
-        message: html`<strong>${volunteer.name}</strong> has submitted a new project proposal:
-          <strong>${project.title}</strong>. Please review it in the triage queue.`,
-        projectTitle: project.title,
-        projectId: project.id,
-      },
-      project.id,
-    )
+    if (!saveAsDraft) {
+      await notifyAdmins(
+        'new_project_proposal',
+        `New project proposal: ${project.title}`,
+        `Proposed by ${volunteer.name}`,
+        '/admin/triage',
+        {
+          message: html`<strong>${volunteer.name}</strong> has submitted a new project proposal:
+            <strong>${project.title}</strong>. Please review it in the triage queue.`,
+          projectTitle: project.title,
+          projectId: project.id,
+        },
+        project.id,
+      )
+    }
 
-    return { id: project.id, message: 'Project submitted for review' }
+    return {
+      id: project.id,
+      message: saveAsDraft ? 'Draft saved' : 'Project submitted for review',
+    }
   }),
+
+  myDrafts: approvedProcedure.handler(async ({ context }) => {
+    const volunteer = context.volunteer
+    const drafts = await prisma.workItem.findMany({
+      where: {
+        type: WorkItemType.PROJECT,
+        creatorId: volunteer.id,
+        status: ProjectStatus.draft,
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, title: true, createdAt: true },
+    })
+    return drafts
+  }),
+
+  publishDraft: approvedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      const volunteer = context.volunteer
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.PROJECT },
+      })
+      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Draft not found' })
+      if (project.creatorId !== volunteer.id || project.status !== ProjectStatus.draft) {
+        throw new ORPCError('FORBIDDEN', { message: 'Not authorized to publish this draft' })
+      }
+
+      await prisma.workItem.update({
+        where: { id: input.id },
+        data: { status: ProjectStatus.pending_review, updatedAt: new Date() },
+      })
+
+      await notifyAdmins(
+        'new_project_proposal',
+        `New project proposal: ${project.title}`,
+        `Proposed by ${volunteer.name}`,
+        '/admin/triage',
+        {
+          message: html`<strong>${volunteer.name}</strong> has submitted a new project proposal:
+            <strong>${project.title}</strong>. Please review it in the triage queue.`,
+          projectTitle: project.title,
+          projectId: project.id,
+        },
+        project.id,
+      )
+
+      return { message: 'Project submitted for review' }
+    }),
+
+  deleteDraft: approvedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .handler(async ({ input, context }) => {
+      const volunteer = context.volunteer
+      const project = await prisma.workItem.findFirst({
+        where: { id: input.id, type: WorkItemType.PROJECT },
+      })
+      if (!project) throw new ORPCError('NOT_FOUND', { message: 'Draft not found' })
+      if (project.creatorId !== volunteer.id || project.status !== ProjectStatus.draft) {
+        throw new ORPCError('FORBIDDEN', { message: 'Not authorized to delete this draft' })
+      }
+      await prisma.workItem.delete({ where: { id: input.id } })
+      return { message: 'Draft deleted' }
+    }),
 
   getById: approvedProcedure
     .input(z.object({ id: z.number().int() }))

--- a/server/routers/projects.ts
+++ b/server/routers/projects.ts
@@ -401,7 +401,7 @@ export const projectsRouter = {
   create: approvedProcedure.input(CreateProjectSchema).handler(async ({ input, context }) => {
     const volunteer = context.volunteer
     const { tasks, wantToOwn, skillIds, skillRequiredMap, saveAsDraft } = input
-    if (tasks.length === 0) {
+    if (!saveAsDraft && tasks.length === 0) {
       throw new ORPCError('BAD_REQUEST', {
         message: 'At least one task is required to submit a project proposal',
       })
@@ -417,7 +417,7 @@ export const projectsRouter = {
       })
       if (draftCount >= MAX_VOLUNTEER_DRAFTS) {
         throw new ORPCError('BAD_REQUEST', {
-          message: `You already have ${MAX_VOLUNTEER_DRAFTS} drafts — publish or delete one before saving another.`,
+          message: `You already have ${MAX_VOLUNTEER_DRAFTS} drafts. Publish or delete one before saving another.`,
         })
       }
     }
@@ -516,6 +516,15 @@ export const projectsRouter = {
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Draft not found' })
       if (project.creatorId !== volunteer.id || project.status !== ProjectStatus.draft) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized to publish this draft' })
+      }
+
+      const taskCount = await prisma.workItem.count({
+        where: { parentId: input.id, type: WorkItemType.TASK },
+      })
+      if (taskCount === 0) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'Add at least one task before submitting this draft for review',
+        })
       }
 
       await prisma.workItem.update({
@@ -1321,7 +1330,10 @@ export const projectsRouter = {
       })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
+      // A draft has no owner yet, so its creator manages its own tasks until publish.
+      const isDraftCreator =
+        project.creatorId === volunteer.id && project.status === ProjectStatus.draft
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin && !isDraftCreator) {
         throw new ORPCError('FORBIDDEN', {
           message: 'Only project owner or admin can create tasks',
         })
@@ -1366,7 +1378,9 @@ export const projectsRouter = {
       })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
+      const isDraftCreator =
+        project.creatorId === volunteer.id && project.status === ProjectStatus.draft
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin && !isDraftCreator) {
         throw new ORPCError('FORBIDDEN', {
           message: 'Only project owner or admin can reorder tasks',
         })
@@ -1427,7 +1441,9 @@ export const projectsRouter = {
         isTaskAssignee &&
         task.status === TaskStatus.in_progress
 
-      if (!isAssignee && !volunteer.isAdmin && !isSelfClaim && !isMarkingDone) {
+      const isDraftCreator =
+        project.creatorId === volunteer.id && project.status === ProjectStatus.draft
+      if (!isAssignee && !volunteer.isAdmin && !isSelfClaim && !isMarkingDone && !isDraftCreator) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized to update this task' })
       }
 
@@ -1571,7 +1587,9 @@ export const projectsRouter = {
       })
       if (!project) throw new ORPCError('NOT_FOUND', { message: 'Project not found' })
 
-      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin) {
+      const isDraftCreator =
+        project.creatorId === volunteer.id && project.status === ProjectStatus.draft
+      if (project.assigneeId !== volunteer.id && !volunteer.isAdmin && !isDraftCreator) {
         throw new ORPCError('FORBIDDEN', { message: 'Not authorized' })
       }
 


### PR DESCRIPTION
## Summary
- Adds `draft` as a new `ProjectStatus` enum value (migration + regenerated client), resolving the design decision `#93` left as TODO: a distinct status rather than reusing `pending_review` in a different context.
- Both org projects (admin) and volunteer proposals can be saved as drafts with zero tasks, capped at `MAX_VOLUNTEER_DRAFTS = 2` for a volunteer's own proposals.
- Drafts are excluded from browse/advertisable queries and the triage queue, and hidden from non-creator/admin viewers. Visiting a draft's plain `/projects/[id]` URL redirects straight to its edit page — a draft has no read-only view of its own.
- Since a draft has no owner yet and task mutations normally require project ownership, its own creator can fully manage its tasks (add, edit title/description, delete, reorder) while it stays a draft.
- All draft management (Edit, Publish/Submit, Delete Draft) lives on `/projects/[id]/edit`, each destructive action behind a confirmation modal (including the existing "Delete Project" action, which now uses the same modal instead of `window.confirm`, and is hidden entirely while a project is still a draft to avoid two overlapping delete actions).
- Publishing branches on `isOrgProposed`: an org draft goes straight to `ready`/`in_progress` (skipping review, matching how org projects have always worked) with no mention of review; a volunteer's own draft still submits into `pending_review` for team-lead review. The trigger button (Publish vs Submit), modal wording, and post-publish destination all follow this split.
- Both entry points show a "My Drafts" list: `/suggest` for volunteers, and the admin nav item (renamed from "Create Org Project" to "Org Projects") at `/admin/projects/new` for admins, via a new `admin.projects.myDrafts` procedure scoped to org-proposed drafts (an admin's own personal `/suggest` drafts stay separate, since attribution — "PauseAI" vs the admin's own name — is what actually distinguishes the two, not who created it).
- Filed `#229` to consider draft autosave later, only if it turns out people lose draft work. Not built here, out of scope.
- Adds `e2e/tests/34-project-drafts.spec.ts` covering both flows end to end.
- Along the way, fixed a stale e2e helper (`adminCreateProject` was still clicking a "Create Project" button renamed to "Publish" earlier in this PR) that had gone undetected because `check-all`'s `| tail -200` pipe was masking `npm test`'s real exit code.

Closes #93

## Test plan
- [x] `npm run typecheck && npm run lint && npm run format:check` pass
- [x] `npm test` (full e2e suite, 225 tests) passes with a real (unpiped) exit code check
- [x] Manual smoke test in browser is still worth doing before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tR28Bp8KTrowk3eHWCEYP