### PR TITLE
Fill #141 e2e gaps; cut redundant UI-flow proving in setup scaffolding

### DIFF
--- a/e2e/actions/bugs.ts
+++ b/e2e/actions/bugs.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test'
 import { selectFilterDropdown } from './ui'
+import { createApiClient } from '../client'
 
 const SEVERITY_LABELS: Record<string, string> = {
   low: 'Low: minor inconvenience',
@@ -61,4 +62,24 @@ export async function submitBugReport(
       .getByRole('dialog', { name: 'Report an Issue' })
       .getByRole('heading', { name: 'Thank you!' }),
   ).toBeVisible({ timeout: 10_000 })
+}
+
+// API-equivalent of submitBugReport, for tests that need "a bug report exists" purely as setup
+// for testing admin status/assignment changes — the report dialog itself is already proven
+// end-to-end by 14-bug-reporting.spec.ts.
+export async function submitBugReportViaApi(
+  baseUrl: string,
+  volunteerPage: Page,
+  title: string,
+  description: string,
+): Promise<number> {
+  // localStorage is only readable once the page has loaded a real origin — a fresh
+  // volunteer.page fixture starts at about:blank, where evaluate throws a SecurityError.
+  if (volunteerPage.url() === 'about:blank') await volunteerPage.goto(baseUrl)
+  const token = await volunteerPage.evaluate(() => localStorage.getItem('authToken'))
+  const api = createApiClient(baseUrl, token)
+  const result = await api.bugReports.create({ body: { title, description } })
+  if (result.status !== 200)
+    throw new Error(`Bug report creation failed: ${JSON.stringify(result.body)}`)
+  return (result.body as { id: number }).id
 }

--- a/e2e/actions/local-groups.ts
+++ b/e2e/actions/local-groups.ts
@@ -1,5 +1,7 @@
 import { type Page } from '@playwright/test'
 import { selectFilterDropdown } from './ui'
+import { createApiClient } from '../client'
+import { BASE_LOCATION_OPTIONS } from '../../lib/filter-options'
 
 export async function submitLocalGroupSuggestion(
   baseUrl: string,
@@ -15,6 +17,31 @@ export async function submitLocalGroupSuggestion(
   await page.getByLabel('Local Group Name').fill(name)
   await page.getByRole('button', { name: 'Submit Suggestion' }).click()
   await page.getByText('Suggestion submitted!').waitFor({ timeout: 10_000 })
+}
+
+// API-equivalent of submitLocalGroupSuggestion, for tests that need "a pending suggestion
+// exists" purely as setup for testing the admin review flow — the submission form itself is
+// already proven end-to-end by the first two tests in 19-local-group-suggestions.spec.ts.
+// `country` takes the same display label the UI dropdown shows (e.g. "United Kingdom") —
+// it's translated to the underlying option value (e.g. "UK") the API actually expects.
+export async function submitLocalGroupSuggestionViaApi(
+  baseUrl: string,
+  volunteerPage: Page,
+  country: string,
+  name: string,
+): Promise<void> {
+  const countryValue = BASE_LOCATION_OPTIONS.find((o) => o.label === country)?.value ?? country
+
+  // localStorage is only readable once the page has loaded a real origin — a fresh
+  // volunteer.page fixture starts at about:blank, where evaluate throws a SecurityError.
+  if (volunteerPage.url() === 'about:blank') await volunteerPage.goto(baseUrl)
+  const token = await volunteerPage.evaluate(() => localStorage.getItem('authToken'))
+  const api = createApiClient(baseUrl, token)
+  const result = await api.localGroupSuggestions.create({
+    body: { country: countryValue, name },
+  })
+  if (result.status !== 200)
+    throw new Error(`Local group suggestion creation failed: ${JSON.stringify(result.body)}`)
 }
 
 export async function navigateToAdminLocalGroups(baseUrl: string, adminPage: Page): Promise<void> {

--- a/e2e/actions/projects.ts
+++ b/e2e/actions/projects.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test'
-import { getAlert } from '../fixtures'
+import { getAlert, readAdminToken } from '../fixtures'
+import { createApiClient } from '../client'
 import { selectFilterDropdown } from './ui'
 
 import { PROJECT_STATUS_LABELS } from '../../lib/project-status'
@@ -110,6 +111,40 @@ export async function adminCreateProject(
   // so callers don't interrupt the in-flight /api/auth/me fetch and accidentally clear the token.
   await expect(adminPage.locator('#projectContent')).toBeVisible({ timeout: 10_000 })
   return id
+}
+
+// API-equivalent of adminCreateProject, for tests that need "a published org project exists"
+// purely as setup for some other assertion and don't need to re-prove the create+publish UI
+// flow itself — that's already covered end-to-end by 06-project-lifecycle.spec.ts. Produces
+// the same resulting state (status ready, isSeekingHelp true, one task) without the form
+// fill / Add Task / Publish / confirm-dialog round trip.
+export async function adminCreateProjectViaApi(
+  baseUrl: string,
+  title: string,
+  description: string,
+): Promise<number> {
+  const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+  const created = await adminApi.admin.projects.create({
+    body: {
+      title,
+      description,
+      projectType: null,
+      estimatedDuration: null,
+      timeCommitmentHoursPerWeek: null,
+      urgency: 'medium',
+      collaborationLink: null,
+      country: null,
+      localGroup: null,
+      remoteEligibility: 'NONE',
+      isSeekingHelp: true,
+      skillIds: [],
+      skillRequiredMap: {},
+      tasks: [{ title: 'Initial task' }],
+    },
+  })
+  if (created.status !== 200)
+    throw new Error(`Project creation failed: ${JSON.stringify(created.body)}`)
+  return (created.body as { id: number }).id
 }
 
 export async function adminSaveProjectDraft(

--- a/e2e/actions/skills.ts
+++ b/e2e/actions/skills.ts
@@ -1,10 +1,13 @@
 import { Page, expect } from '@playwright/test'
-import { getAlert } from '../fixtures'
+import { getAlert, readAdminToken } from '../fixtures'
+import { createApiClient } from '../client'
 import { fake } from '../fake'
 
 export interface SkillInfo {
   name: string
   optionLabel: string
+  // Only populated by createSkillViaApi — the UI flow doesn't surface the created skill's id.
+  id?: number
 }
 
 export async function createSkill(baseUrl: string, adminPage: Page): Promise<SkillInfo> {
@@ -28,4 +31,29 @@ export async function createSkill(baseUrl: string, adminPage: Page): Promise<Ski
   await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
 
   return { name: skillName, optionLabel: `${skillName} (${categoryName})` }
+}
+
+// API-equivalent of createSkill, for tests that need "a skill that exists" purely as setup —
+// the category+skill create UI flow itself is already proven end-to-end in
+// 03-skill-management.spec.ts.
+export async function createSkillViaApi(baseUrl: string): Promise<SkillInfo> {
+  const categoryName = fake.skillCategory()
+  const skillName = fake.skillName()
+
+  const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+  const categoryResult = await adminApi.admin.skillCategories.create({
+    body: { name: categoryName },
+  })
+  if (categoryResult.status !== 200)
+    throw new Error(`Skill category creation failed: ${JSON.stringify(categoryResult.body)}`)
+  const { id: categoryId } = categoryResult.body as { id: number }
+
+  const skillResult = await adminApi.admin.skills.create({
+    body: { name: skillName, categoryId },
+  })
+  if (skillResult.status !== 200)
+    throw new Error(`Skill creation failed: ${JSON.stringify(skillResult.body)}`)
+  const { id: skillId } = skillResult.body as { id: number }
+
+  return { name: skillName, optionLabel: `${skillName} (${categoryName})`, id: skillId }
 }

--- a/e2e/tests/08-project-tasks.spec.ts
+++ b/e2e/tests/08-project-tasks.spec.ts
@@ -8,7 +8,7 @@ import {
   createApprovedVolunteer,
 } from '../fixtures'
 import { fake } from '../fake'
-import { proposeProject, adminCreateProject, adminApproveProject } from '../actions/projects'
+import { proposeProject, adminCreateProjectViaApi, adminApproveProject } from '../actions/projects'
 import { Page } from '@playwright/test'
 import { createApiClient } from '../client'
 
@@ -228,12 +228,13 @@ test.describe('Project Tasks', () => {
 
   test('Admin deletes a task', async ({ adminPage, baseUrl }) => {
     test.setTimeout(60_000)
-    await adminCreateProject(
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'Project for task deletion test',
     )
+    await adminPage.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(adminPage.locator('#projectContent')).toBeVisible({ timeout: 10_000 })
 
     await adminPage.getByRole('button', { name: 'Add Task' }).click()
     await adminPage.getByLabel('Task title').fill('Task to delete')

--- a/e2e/tests/09-project-interests-assignment.spec.ts
+++ b/e2e/tests/09-project-interests-assignment.spec.ts
@@ -4,20 +4,19 @@ import { fake } from '../fake'
 import {
   proposeProject,
   adminApproveProject,
-  adminCreateProject,
+  adminCreateProjectViaApi,
   transferProjectOwnership,
 } from '../actions/projects'
-import { Page } from '@playwright/test'
 import { selectFilterDropdown } from '../actions/ui'
 
 // Creates an org project that immediately accepts interest (is_seeking_help = true by default)
-async function setupSeekingProject(baseUrl: string, adminPage: Page): Promise<number> {
-  return adminCreateProject(baseUrl, adminPage, fake.projectTitle(), 'Project seeking volunteers')
+async function setupSeekingProject(baseUrl: string): Promise<number> {
+  return adminCreateProjectViaApi(baseUrl, fake.projectTitle(), 'Project seeking volunteers')
 }
 
 test.describe('Project Interests and Assignment', () => {
-  test('Volunteer expresses interest to contribute', async ({ adminPage, volunteer, baseUrl }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+  test('Volunteer expresses interest to contribute', async ({ volunteer, baseUrl }) => {
+    const projectId = await setupSeekingProject(baseUrl)
 
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
     await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
@@ -37,8 +36,8 @@ test.describe('Project Interests and Assignment', () => {
     })
   })
 
-  test('Volunteer expresses interest to own / lead', async ({ adminPage, volunteer, baseUrl }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+  test('Volunteer expresses interest to own / lead', async ({ volunteer, baseUrl }) => {
+    const projectId = await setupSeekingProject(baseUrl)
 
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
     await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
@@ -57,7 +56,7 @@ test.describe('Project Interests and Assignment', () => {
     volunteer,
     baseUrl,
   }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
 
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
     await volunteer.page.getByRole('radio', { name: /I want to own/ }).click()
@@ -84,7 +83,7 @@ test.describe('Project Interests and Assignment', () => {
     volunteer,
     baseUrl,
   }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
     const applicantMessage = fake.feedbackText()
 
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
@@ -106,7 +105,7 @@ test.describe('Project Interests and Assignment', () => {
     volunteer,
     baseUrl,
   }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
 
     // Volunteer expresses interest
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
@@ -137,7 +136,7 @@ test.describe('Project Interests and Assignment', () => {
   })
 
   test('Project owner declines a pending interest', async ({ adminPage, volunteer, baseUrl }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
     const declineMessage = fake.feedbackText()
 
     // Volunteer expresses interest
@@ -166,8 +165,8 @@ test.describe('Project Interests and Assignment', () => {
     ).toContainText('Declined', { timeout: 10_000 })
   })
 
-  test('Volunteer withdraws their pending interest', async ({ adminPage, volunteer, baseUrl }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+  test('Volunteer withdraws their pending interest', async ({ volunteer, baseUrl }) => {
+    const projectId = await setupSeekingProject(baseUrl)
 
     // Express interest first
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
@@ -195,7 +194,7 @@ test.describe('Project Interests and Assignment', () => {
     volunteer,
     baseUrl,
   }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
 
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
     await expect(adminPage.getByRole('heading', { name: 'Volunteers' })).toBeVisible({
@@ -220,7 +219,7 @@ test.describe('Project Interests and Assignment', () => {
   })
 
   test('Owner removes an already-accepted volunteer', async ({ adminPage, volunteer, baseUrl }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
 
     await adminPage.goto(`${baseUrl}/projects/${projectId}`)
     await selectFilterDropdown(adminPage, 'Volunteer to assign', volunteer.name)
@@ -244,7 +243,7 @@ test.describe('Project Interests and Assignment', () => {
     volunteer,
     baseUrl,
   }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
     const commentText = `admin note ${Date.now()}`
 
     // Admin posts a comment on the project
@@ -269,7 +268,7 @@ test.describe('Project Interests and Assignment', () => {
     volunteer,
     baseUrl,
   }) => {
-    const projectId = await setupSeekingProject(baseUrl, adminPage)
+    const projectId = await setupSeekingProject(baseUrl)
 
     // Volunteer expresses interest to contribute
     await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
@@ -301,7 +300,7 @@ test.describe('Project Interests and Assignment', () => {
     baseUrl,
   }) => {
     const title = fake.projectTitle()
-    const projectId = await adminCreateProject(baseUrl, adminPage, title, 'Notify-on-comment test')
+    const projectId = await adminCreateProjectViaApi(baseUrl, title, 'Notify-on-comment test')
     // Admin is the creator; make the volunteer the owner (assignee)
     await transferProjectOwnership(baseUrl, adminPage, projectId, volunteer.name)
 

--- a/e2e/tests/10-project-discovery.spec.ts
+++ b/e2e/tests/10-project-discovery.spec.ts
@@ -1,6 +1,6 @@
 import type { Browser } from '@playwright/test'
 import { test, expect, createPendingVolunteer, dismissCookieConsentScript } from '../fixtures'
-import { adminCreateProject } from '../actions/projects'
+import { adminCreateProjectViaApi } from '../actions/projects'
 import { fake } from '../fake'
 
 // Both the project list and individual project pages redirect unauthenticated
@@ -13,13 +13,9 @@ test.describe('Unauthenticated Project Access', () => {
     await page.waitForURL(`${baseUrl}/login**`, { timeout: 10_000 })
   })
 
-  test('Visitor sees the public landing page and no project data', async ({
-    page,
-    adminPage,
-    baseUrl,
-  }) => {
+  test('Visitor sees the public landing page and no project data', async ({ page, baseUrl }) => {
     const title = fake.projectTitle()
-    await adminCreateProject(baseUrl, adminPage, title, 'A project that must not leak to visitors')
+    await adminCreateProjectViaApi(baseUrl, title, 'A project that must not leak to visitors')
 
     await page.goto(`${baseUrl}/`)
 
@@ -64,14 +60,9 @@ test.describe('Unauthenticated Project Access', () => {
     }
   })
 
-  test('Visitor views a project detail page unauthenticated', async ({
-    page,
-    adminPage,
-    baseUrl,
-  }) => {
-    const projectId = await adminCreateProject(
+  test('Visitor views a project detail page unauthenticated', async ({ page, baseUrl }) => {
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'A project for the unauthenticated access test',
     )
@@ -109,12 +100,10 @@ test.describe('Pending Volunteer Project Access', () => {
 
   test('Pending volunteer is redirected away from a project detail page', async ({
     browser,
-    adminPage,
     baseUrl,
   }) => {
-    const projectId = await adminCreateProject(
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'A project for the pending-volunteer access test',
     )
@@ -128,9 +117,9 @@ test.describe('Pending Volunteer Project Access', () => {
 })
 
 test.describe('Project Discovery', () => {
-  test('Volunteer searches projects by keyword', async ({ adminPage, volunteer, baseUrl }) => {
+  test('Volunteer searches projects by keyword', async ({ volunteer, baseUrl }) => {
     const title = fake.projectTitle()
-    await adminCreateProject(baseUrl, adminPage, title, 'A searchable project for discovery tests')
+    await adminCreateProjectViaApi(baseUrl, title, 'A searchable project for discovery tests')
 
     await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(
@@ -142,14 +131,10 @@ test.describe('Project Discovery', () => {
     await expect(volunteer.page.getByRole('link', { name: title })).toBeVisible({ timeout: 5_000 })
   })
 
-  test('Volunteer filters projects by "Seeking Help" status', async ({
-    adminPage,
-    volunteer,
-    baseUrl,
-  }) => {
+  test('Volunteer filters projects by "Seeking Help" status', async ({ volunteer, baseUrl }) => {
     const title = fake.projectTitle()
     // Admin-created projects have is_seeking_help = true by default
-    await adminCreateProject(baseUrl, adminPage, title, 'Project for seeking-filter discovery test')
+    await adminCreateProjectViaApi(baseUrl, title, 'Project for seeking-filter discovery test')
 
     await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(

--- a/e2e/tests/12-quick-tasks-admin.spec.ts
+++ b/e2e/tests/12-quick-tasks-admin.spec.ts
@@ -1,35 +1,29 @@
 import { test, expect, getAlert, readAdminToken, createApprovedVolunteer } from '../fixtures'
 import type { Page } from '@playwright/test'
-import { createSkill } from '../actions/skills'
+import { createSkillViaApi } from '../actions/skills'
 import type { SkillInfo } from '../actions/skills'
 import { goToDashboardNotifications } from '../actions/dashboard'
 import { fake } from '../fake'
 import { selectFilterDropdown } from '../actions/ui'
 import { createApiClient } from '../client'
 
-async function createOpenQuickTask(
-  baseUrl: string,
-  adminPage: Page,
-  skill: SkillInfo,
-): Promise<string> {
+// API-equivalent of driving the create-quick-task dialog, for tests that need "an open quick
+// task exists" purely as setup for testing claim/assign/complete/comment flows — the
+// create-dialog UI flow itself is already proven end-to-end by "Admin creates a quick task"
+// below.
+async function createOpenQuickTaskViaApi(baseUrl: string, skill: SkillInfo): Promise<string> {
   const taskTitle = fake.quickTaskTitle()
-
-  await adminPage.goto(`${baseUrl}/quick-tasks`)
-  await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
-    timeout: 10_000,
+  const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+  const result = await adminApi.quickTasks.create({
+    body: {
+      title: taskTitle,
+      description: 'E2E test task description',
+      skillId: skill.id,
+      estimatedHours: 2,
+    },
   })
-
-  await adminPage.getByRole('button', { name: 'Create Task' }).click()
-  const createDialog = adminPage.getByRole('dialog', { name: 'Create Quick Task' })
-  await expect(createDialog).toBeVisible({ timeout: 10_000 })
-
-  await createDialog.getByLabel('Title').fill(taskTitle)
-  await createDialog.getByLabel('Description').fill('E2E test task description')
-  await selectFilterDropdown(adminPage, 'Skill Being Tested', skill.optionLabel, createDialog)
-  await createDialog.getByLabel('Estimated Hours').fill('2')
-  await createDialog.getByRole('button', { name: 'Create Task' }).click()
-  await expect(getAlert(adminPage)).toBeVisible({ timeout: 10_000 })
-
+  if (result.status !== 200)
+    throw new Error(`Quick task creation failed: ${JSON.stringify(result.body)}`)
   return taskTitle
 }
 
@@ -77,7 +71,7 @@ async function submitQuickTask(
 
 test.describe('Quick Tasks (admin)', () => {
   test('Admin creates a quick task', async ({ adminPage, baseUrl }) => {
-    const skill = await createSkill(baseUrl, adminPage)
+    const skill = await createSkillViaApi(baseUrl)
     const taskTitle = fake.quickTaskTitle()
 
     await adminPage.goto(`${baseUrl}/quick-tasks`)
@@ -108,8 +102,13 @@ test.describe('Quick Tasks (admin)', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
+
+    await adminPage.goto(`${baseUrl}/quick-tasks`)
+    await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    })
 
     // Expand the card to reveal the inline assign dropdown
     const taskCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
@@ -137,9 +136,14 @@ test.describe('Quick Tasks (admin)', () => {
     adminPage,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
     const commentText = `comment ${Date.now()}`
+
+    await adminPage.goto(`${baseUrl}/quick-tasks`)
+    await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    })
 
     const taskCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
     await expect(taskCard).toBeVisible({ timeout: 10_000 })
@@ -156,8 +160,8 @@ test.describe('Quick Tasks (admin)', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
     await assignQuickTask(baseUrl, adminPage, taskTitle, volunteer.name)
     const adminComment = `admin note ${Date.now()}`
     const volunteerReply = `volunteer reply ${Date.now()}`
@@ -196,8 +200,8 @@ test.describe('Quick Tasks (admin)', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
     await assignQuickTask(baseUrl, adminPage, taskTitle, volunteer.name)
 
     await volunteer.page.goto(`${baseUrl}/dashboard`)
@@ -217,8 +221,8 @@ test.describe('Quick Tasks (admin)', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
     await assignQuickTask(baseUrl, adminPage, taskTitle, volunteer.name)
 
     // Volunteer expands the task card and submits it
@@ -261,8 +265,8 @@ test.describe('Quick Tasks (admin)', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
     await assignQuickTask(baseUrl, adminPage, taskTitle, volunteer.name)
     await submitQuickTask(baseUrl, volunteer.page, taskTitle)
 
@@ -308,8 +312,8 @@ test.describe('Quick Tasks (admin)', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
     await assignQuickTask(baseUrl, adminPage, taskTitle, volunteer.name)
     await submitQuickTask(baseUrl, volunteer.page, taskTitle)
 
@@ -358,8 +362,13 @@ test.describe('Quick Tasks (admin)', () => {
     adminPage,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
+
+    await adminPage.goto(`${baseUrl}/quick-tasks`)
+    await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    })
 
     const taskCard = adminPage.getByRole('article').filter({ hasText: taskTitle })
     await expect(taskCard).toBeVisible({ timeout: 10_000 })
@@ -377,8 +386,13 @@ test.describe('Quick Tasks (admin)', () => {
     adminPage,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
-    const taskTitle = await createOpenQuickTask(baseUrl, adminPage, skill)
+    const skill = await createSkillViaApi(baseUrl)
+    const taskTitle = await createOpenQuickTaskViaApi(baseUrl, skill)
+
+    await adminPage.goto(`${baseUrl}/quick-tasks`)
+    await expect(adminPage.getByRole('heading', { name: 'Quick Tasks', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    })
 
     // Get the task ID from the card's DOM id attribute (card has id="task-N")
     const taskCard = adminPage.getByRole('article').filter({ hasText: taskTitle })

--- a/e2e/tests/13-volunteer-management.spec.ts
+++ b/e2e/tests/13-volunteer-management.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, getAlert } from '../fixtures'
 import type { Page } from '@playwright/test'
-import { createSkill } from '../actions/skills'
+import { createSkillViaApi } from '../actions/skills'
 import { fake } from '../fake'
 import { selectFilterDropdown } from '../actions/ui'
 
@@ -185,7 +185,7 @@ test.describe('Volunteer Management', () => {
     volunteer,
     baseUrl,
   }) => {
-    const skill = await createSkill(baseUrl, adminPage)
+    const skill = await createSkillViaApi(baseUrl)
 
     await navigateToAdminVolunteerDetail(baseUrl, adminPage, volunteer.name)
 

--- a/e2e/tests/15-bug-report-management.spec.ts
+++ b/e2e/tests/15-bug-report-management.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, getAlert } from '../fixtures'
 import type { Page } from '@playwright/test'
-import { submitBugReport } from '../actions/bugs'
+import { submitBugReportViaApi } from '../actions/bugs'
 import { selectFilterDropdown } from '../actions/ui'
 import { fake } from '../fake'
 
@@ -51,7 +51,7 @@ test.describe('Bug Report Management', () => {
   test('Admin views the bug reports list', async ({ adminPage, volunteer, baseUrl }) => {
     const title = fake.bugTitle()
 
-    await submitBugReport(
+    await submitBugReportViaApi(
       baseUrl,
       volunteer.page,
       title,
@@ -67,7 +67,7 @@ test.describe('Bug Report Management', () => {
   test('Admin filters bug reports by status', async ({ adminPage, volunteer, baseUrl }) => {
     const title = fake.bugTitle()
 
-    await submitBugReport(
+    await submitBugReportViaApi(
       baseUrl,
       volunteer.page,
       title,
@@ -89,7 +89,7 @@ test.describe('Bug Report Management', () => {
   test('Admin moves a bug report to in_progress', async ({ adminPage, volunteer, baseUrl }) => {
     const title = fake.bugTitle()
 
-    await submitBugReport(
+    await submitBugReportViaApi(
       baseUrl,
       volunteer.page,
       title,
@@ -113,7 +113,7 @@ test.describe('Bug Report Management', () => {
     const title = fake.bugTitle()
     const notes = fake.resolutionNotes()
 
-    await submitBugReport(
+    await submitBugReportViaApi(
       baseUrl,
       volunteer.page,
       title,
@@ -138,7 +138,7 @@ test.describe('Bug Report Management', () => {
   test('Admin marks a bug report as wont_fix', async ({ adminPage, volunteer, baseUrl }) => {
     const title = fake.bugTitle()
 
-    await submitBugReport(
+    await submitBugReportViaApi(
       baseUrl,
       volunteer.page,
       title,

--- a/e2e/tests/16-messaging.spec.ts
+++ b/e2e/tests/16-messaging.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, getAlert, approveVolunteer, dismissCookieConsentScript } from '../fixtures'
-import { adminCreateProject, transferProjectOwnership } from '../actions/projects'
+import { adminCreateProjectViaApi, transferProjectOwnership } from '../actions/projects'
 import { fake } from '../fake'
 import { createApiClient } from '../client'
 
@@ -13,9 +13,8 @@ test.describe('Messaging', () => {
     const subject = fake.messageSubject()
     const body = fake.messageBody()
 
-    const projectId = await adminCreateProject(
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'Project for contact test',
     )
@@ -76,9 +75,8 @@ test.describe('Messaging', () => {
     test.setTimeout(60_000)
     const subject = fake.messageSubject()
 
-    const projectId = await adminCreateProject(
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'Project for notification test',
     )

--- a/e2e/tests/17-access-control.spec.ts
+++ b/e2e/tests/17-access-control.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, getAlert, dismissCookieConsentScript } from '../fixtures'
-import { proposeProject, adminCreateProject, adminApproveProject } from '../actions/projects'
+import { proposeProject, adminCreateProjectViaApi, adminApproveProject } from '../actions/projects'
 import { fake } from '../fake'
 
 test.describe('Access Control', () => {
@@ -21,14 +21,9 @@ test.describe('Access Control', () => {
     await volunteer.page.waitForURL(`${baseUrl}/projects`, { timeout: 10_000 })
   })
 
-  test("Non-owner cannot update another volunteer's project", async ({
-    adminPage,
-    volunteer,
-    baseUrl,
-  }) => {
-    const projectId = await adminCreateProject(
+  test("Non-owner cannot update another volunteer's project", async ({ volunteer, baseUrl }) => {
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'Test project for access control',
     )
@@ -41,14 +36,9 @@ test.describe('Access Control', () => {
     await expect(volunteer.page.getByLabel('Project Title')).toBeDisabled()
   })
 
-  test("Non-owner cannot delete another volunteer's project", async ({
-    adminPage,
-    volunteer,
-    baseUrl,
-  }) => {
-    const projectId = await adminCreateProject(
+  test("Non-owner cannot delete another volunteer's project", async ({ volunteer, baseUrl }) => {
+    const projectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'Test project for delete access control',
     )

--- a/e2e/tests/18-gdpr-privacy.spec.ts
+++ b/e2e/tests/18-gdpr-privacy.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { test, expect, getAlert, approveVolunteer, dismissCookieConsentScript } from '../fixtures'
 import { fake } from '../fake'
-import { createSkill } from '../actions/skills'
+import { createSkillViaApi } from '../actions/skills'
 import { adminCreateProjectViaApi, transferProjectOwnership } from '../actions/projects'
 import { createApiClient } from '../client'
 
@@ -14,7 +14,7 @@ test.describe('GDPR & Privacy', () => {
   }) => {
     test.setTimeout(120_000)
     // Add a skill to the volunteer's profile
-    const skill = await createSkill(baseUrl, adminPage)
+    const skill = await createSkillViaApi(baseUrl)
     await volunteer.page.goto(`${baseUrl}/profile`)
     await expect(
       volunteer.page.locator('.skill-option').filter({ hasText: skill.name }),

--- a/e2e/tests/18-gdpr-privacy.spec.ts
+++ b/e2e/tests/18-gdpr-privacy.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs'
 import { test, expect, getAlert, approveVolunteer, dismissCookieConsentScript } from '../fixtures'
 import { fake } from '../fake'
 import { createSkill } from '../actions/skills'
-import { adminCreateProject, transferProjectOwnership } from '../actions/projects'
+import { adminCreateProjectViaApi, transferProjectOwnership } from '../actions/projects'
 import { createApiClient } from '../client'
 
 test.describe('GDPR & Privacy', () => {
@@ -28,18 +28,16 @@ test.describe('GDPR & Privacy', () => {
 
     // Admin creates a project and transfers ownership to the volunteer so they have a project in the
     // export and a contactable owner page for the inbound message step
-    const volunteerProjectId = await adminCreateProject(
+    const volunteerProjectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'GDPR export test project',
     )
     await transferProjectOwnership(baseUrl, adminPage, volunteerProjectId, volunteer.name)
 
     // Admin creates a seeking-help project (no owner); volunteer expresses interest
-    const seekingProjectId = await adminCreateProject(
+    const seekingProjectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'GDPR test seeking-help project',
     )
@@ -71,9 +69,8 @@ test.describe('GDPR & Privacy', () => {
     await approveVolunteer(baseUrl, vol2Id)
 
     // Admin creates a project and transfers ownership to vol2 so it has a contactable owner
-    const contactProjectId = await adminCreateProject(
+    const contactProjectId = await adminCreateProjectViaApi(
       baseUrl,
-      adminPage,
       fake.projectTitle(),
       'GDPR test contact project',
     )

--- a/e2e/tests/19-local-group-suggestions.spec.ts
+++ b/e2e/tests/19-local-group-suggestions.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, getAlert } from '../fixtures'
 import { goToDashboardNotifications } from '../actions/dashboard'
 import {
   submitLocalGroupSuggestion,
+  submitLocalGroupSuggestionViaApi,
   navigateToAdminLocalGroups,
   adminReviewSuggestion,
   adminAddGroup,
@@ -50,7 +51,7 @@ test.describe('Local Group Suggestions', () => {
   test('Admin sees pending suggestion', async ({ volunteer, adminPage, baseUrl }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
 
     await expect(adminPage.getByRole('article').filter({ hasText: groupName })).toBeVisible({
@@ -65,7 +66,7 @@ test.describe('Local Group Suggestions', () => {
   }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'accept')
 
@@ -91,7 +92,7 @@ test.describe('Local Group Suggestions', () => {
     const original = fake.localGroupName()
     const adjusted = `${original} (Adjusted)`
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', original)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', original)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, original, 'accept', { editName: adjusted })
 
@@ -116,7 +117,7 @@ test.describe('Local Group Suggestions', () => {
   }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'accept')
     await expect(getAlert(adminPage)).toContainText('accepted', { timeout: 10_000 })
@@ -142,7 +143,7 @@ test.describe('Local Group Suggestions', () => {
   }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'merge', {
       mergeTarget: 'United Kingdom, London',
@@ -160,7 +161,7 @@ test.describe('Local Group Suggestions', () => {
     const groupName = fake.localGroupName()
     const note = 'Reviewing similar groups in this area first'
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'on_hold', { adminNotes: note })
 
@@ -177,7 +178,7 @@ test.describe('Local Group Suggestions', () => {
     const groupName = fake.localGroupName()
     const note = 'This area is covered by an existing group'
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'decline', { adminNotes: note })
 
@@ -197,7 +198,7 @@ test.describe('Local Group Suggestions', () => {
   }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'decline')
     await expect(getAlert(adminPage)).toContainText('declined', { timeout: 10_000 })
@@ -219,7 +220,7 @@ test.describe('Local Group Suggestions', () => {
   }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'decline')
 
@@ -241,7 +242,7 @@ test.describe('Local Group Suggestions', () => {
   }) => {
     const groupName = fake.localGroupName()
 
-    await submitLocalGroupSuggestion(baseUrl, volunteer.page, 'United Kingdom', groupName)
+    await submitLocalGroupSuggestionViaApi(baseUrl, volunteer.page, 'United Kingdom', groupName)
     await navigateToAdminLocalGroups(baseUrl, adminPage)
     await adminReviewSuggestion(adminPage, groupName, 'accept')
     await expect(getAlert(adminPage)).toContainText('accepted', { timeout: 10_000 })

--- a/e2e/tests/24-bug-report-detail.spec.ts
+++ b/e2e/tests/24-bug-report-detail.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, confirmVolunteerEmail, approveVolunteer } from '../fixtures'
-import { openBugReportForm, fillAndSubmitBugReport } from '../actions/bugs'
+import { submitBugReportViaApi } from '../actions/bugs'
 import { goToDashboardNotifications } from '../actions/dashboard'
 import { createApiClient } from '../client'
 import { fake } from '../fake'
@@ -40,21 +40,14 @@ test.describe('Bug Report Detail Page', () => {
   }) => {
     const title = fake.bugTitle()
 
-    await volunteer.page.goto(`${baseUrl}/dashboard`)
-    await expect(volunteer.page.getByRole('heading', { name: /Welcome back/ })).toBeVisible({
-      timeout: 10_000,
-    })
-    await openBugReportForm(volunteer.page)
-    await fillAndSubmitBugReport(volunteer.page, {
+    const reportId = await submitBugReportViaApi(
+      baseUrl,
+      volunteer.page,
       title,
-      description: 'A bug report to exercise its own comment thread',
-    })
+      'A bug report to exercise its own comment thread',
+    )
 
-    const dialog = volunteer.page.getByRole('dialog', { name: 'Report an Issue' })
-    await expect(dialog.getByRole('heading', { name: 'Thank you!' })).toBeVisible({
-      timeout: 10_000,
-    })
-    await dialog.getByRole('link', { name: 'View your report' }).click()
+    await volunteer.page.goto(`${baseUrl}/bugs/${reportId}`)
     await expect(volunteer.page.getByRole('heading', { name: title, level: 1 })).toBeVisible({
       timeout: 10_000,
     })

--- a/e2e/tests/25-search-and-filter-ux.spec.ts
+++ b/e2e/tests/25-search-and-filter-ux.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures'
-import { adminCreateProject } from '../actions/projects'
+import { adminCreateProjectViaApi } from '../actions/projects'
 import { fake } from '../fake'
 
 test.describe('Search and filter UX', () => {
@@ -36,12 +36,11 @@ test.describe('Search and filter UX', () => {
   })
 
   test('Clicking a project search result right after typing is not cancelled by the debounced URL sync', async ({
-    adminPage,
     volunteer,
     baseUrl,
   }) => {
     const title = fake.projectTitle()
-    await adminCreateProject(baseUrl, adminPage, title, 'Search-click race regression test')
+    await adminCreateProjectViaApi(baseUrl, title, 'Search-click race regression test')
 
     await volunteer.page.goto(`${baseUrl}/projects`)
     await expect(
@@ -67,7 +66,7 @@ test.describe('Search and filter UX', () => {
     baseUrl,
   }) => {
     const title = fake.projectTitle()
-    await adminCreateProject(baseUrl, adminPage, title, 'keepPreviousData regression test')
+    await adminCreateProjectViaApi(baseUrl, title, 'keepPreviousData regression test')
 
     await adminPage.goto(`${baseUrl}/projects`)
     await expect(adminPage.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible({

--- a/e2e/tests/35-verify-email-edge-cases.spec.ts
+++ b/e2e/tests/35-verify-email-edge-cases.spec.ts
@@ -1,0 +1,166 @@
+import path from 'path'
+import { DatabaseSync } from 'node:sqlite'
+import { test, expect } from '../fixtures'
+import { createApiClient } from '../client'
+import { fake } from '../fake'
+import { IS_LOCAL, parallelIndexFromBaseUrl, workerDbDir } from '../config'
+
+// API-level coverage (01-auth-signup-login.spec.ts) confirms invalid/reused tokens return a
+// 400. This file covers what the /verify-email page actually renders for each error state,
+// since the UI distinguishes "invalid", "already used" and "expired" with different copy and
+// different follow-up actions (resend form vs. login link).
+
+test.describe('Verify Email page (edge cases)', () => {
+  test('An invalid confirmation token shows an error with a resend form', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      await page.goto(`${baseUrl}/verify-email?token=not-a-real-token`)
+      await expect(page.getByRole('heading', { name: 'Confirmation failed' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await expect(page.getByText('Invalid or expired confirmation link')).toBeVisible()
+      await expect(page.getByPlaceholder('Your email address')).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('An already-used confirmation token shows an error with no resend form, only a login link', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      const person = fake.person()
+      const api = createApiClient(baseUrl)
+      const signup = await api.auth.signup({
+        body: {
+          name: person.name,
+          email: person.email,
+          password: 'testpassword1',
+          bio: 'e2e test bio, at least twenty characters long',
+          country: 'UK',
+          availabilityHoursPerWeek: 5,
+          applicationMessage: 'e2e test application message',
+          consentMakeProfileVisibleInDirectory: true,
+          consentContactableByProjectOwners: true,
+        },
+      })
+      expect(signup.status).toBe(200)
+      const { emailVerificationToken: token } = signup.body
+      expect(token).toBeTruthy()
+
+      const first = await api.auth.verifyEmail({ body: { token: token! } })
+      expect(first.status).toBe(200)
+
+      await page.goto(`${baseUrl}/verify-email?token=${token}`)
+      await expect(page.getByRole('heading', { name: 'Confirmation failed' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await expect(page.getByText('This confirmation link has already been used')).toBeVisible()
+      await expect(page.getByPlaceholder('Your email address')).not.toBeVisible()
+      await expect(page.getByRole('link', { name: 'Go to login' })).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('An expired confirmation token shows an expiry-specific error', async ({
+    browser,
+    baseUrl,
+  }) => {
+    test.skip(!IS_LOCAL, 'backdates the token directly in the worker SQLite DB')
+
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      const person = fake.person()
+      const api = createApiClient(baseUrl)
+      const signup = await api.auth.signup({
+        body: {
+          name: person.name,
+          email: person.email,
+          password: 'testpassword1',
+          bio: 'e2e test bio, at least twenty characters long',
+          country: 'UK',
+          availabilityHoursPerWeek: 5,
+          applicationMessage: 'e2e test application message',
+          consentMakeProfileVisibleInDirectory: true,
+          consentContactableByProjectOwners: true,
+        },
+      })
+      expect(signup.status).toBe(200)
+      const { emailVerificationToken: token } = signup.body
+      expect(token).toBeTruthy()
+
+      // Backdate the token straight in the worker's SQLite file (node:sqlite, same tool
+      // scripts/seed-migration-test-state.ts uses) — this path is only exercised when
+      // IS_LOCAL, and the generated Prisma client can't be imported from Playwright's own
+      // module loader (CJS/ESM interop mismatch with Next's build pipeline).
+      const dbPath = path.join(workerDbDir(parallelIndexFromBaseUrl(baseUrl)), 'catalyse.db')
+      const db = new DatabaseSync(dbPath)
+      try {
+        db.prepare('UPDATE email_verification_tokens SET expires_at = ? WHERE token = ?').run(
+          new Date(Date.now() - 60_000).toISOString(),
+          token!,
+        )
+      } finally {
+        db.close()
+      }
+
+      await page.goto(`${baseUrl}/verify-email?token=${token}`)
+      await expect(page.getByRole('heading', { name: 'Confirmation failed' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await expect(page.getByText('This confirmation link has expired')).toBeVisible()
+      await expect(page.getByPlaceholder('Your email address')).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('Resending from the plain /verify-email page (no token) sends a new link', async ({
+    browser,
+    baseUrl,
+  }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    try {
+      const person = fake.person()
+      const api = createApiClient(baseUrl)
+      const signup = await api.auth.signup({
+        body: {
+          name: person.name,
+          email: person.email,
+          password: 'testpassword1',
+          bio: 'e2e test bio, at least twenty characters long',
+          country: 'UK',
+          availabilityHoursPerWeek: 5,
+          applicationMessage: 'e2e test application message',
+          consentMakeProfileVisibleInDirectory: true,
+          consentContactableByProjectOwners: true,
+        },
+      })
+      expect(signup.status).toBe(200)
+
+      await page.goto(`${baseUrl}/verify-email`)
+      await expect(page.getByRole('heading', { name: 'Confirm your email' })).toBeVisible({
+        timeout: 10_000,
+      })
+      await page.getByPlaceholder('Your email address').fill(person.email)
+      await page.getByRole('button', { name: 'Send' }).click()
+      // Immediately after sending, the 60s cooldown is active, so the copy is
+      // "Email sent! You can request another in <n>s." rather than the post-cooldown text.
+      // The form (including the Send button) is swapped out entirely once sent.
+      await expect(page.getByText(/Email sent!/)).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByRole('button', { name: 'Send' })).toBeHidden()
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/e2e/tests/35-verify-email-edge-cases.spec.ts
+++ b/e2e/tests/35-verify-email-edge-cases.spec.ts
@@ -105,6 +105,10 @@ test.describe('Verify Email page (edge cases)', () => {
       const dbPath = path.join(workerDbDir(parallelIndexFromBaseUrl(baseUrl)), 'catalyse.db')
       const db = new DatabaseSync(dbPath)
       try {
+        // The app server (via Prisma) holds this same file open, and other tests are
+        // writing to it concurrently under fullyParallel — without a busy timeout a
+        // momentary lock throws immediately instead of waiting it out.
+        db.exec('PRAGMA busy_timeout = 5000')
         db.prepare('UPDATE email_verification_tokens SET expires_at = ? WHERE token = ?').run(
           new Date(Date.now() - 60_000).toISOString(),
           token!,

--- a/e2e/tests/36-settings-notifications-privacy.spec.ts
+++ b/e2e/tests/36-settings-notifications-privacy.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, getAlert } from '../fixtures'
+import { selectFilterDropdown } from '../actions/ui'
+
+// 27-remote-eligibility.spec.ts covers the notify_remote_projects checkbox and its effect on
+// match alerts. 18-gdpr-privacy.spec.ts covers directory visibility and contact-sharing consent
+// end-to-end via another volunteer's search. This file covers what neither exercises: the email
+// digest dropdown itself, and the share-contact-info checkbox's disabled/enabled gating.
+
+test.describe('Settings: Notifications tab', () => {
+  test('Email digest preference persists after save and reload', async ({ volunteer, baseUrl }) => {
+    await volunteer.page.goto(`${baseUrl}/settings?tab=notifications`)
+    await expect(volunteer.page.getByLabel('Keep me in the loop about new projects')).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await selectFilterDropdown(
+      volunteer.page,
+      'Keep me in the loop about new projects',
+      'Send me a fortnightly digest',
+    )
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(getAlert(volunteer.page)).toBeVisible({ timeout: 10_000 })
+
+    await volunteer.page.reload()
+    await expect(volunteer.page.getByLabel('Keep me in the loop about new projects')).toContainText(
+      'Send me a fortnightly digest',
+      { timeout: 10_000 },
+    )
+  })
+})
+
+test.describe('Settings: Privacy & Data tab', () => {
+  test('Share-contact-info checkbox is disabled until contactable-by-owners is checked', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    await volunteer.page.goto(`${baseUrl}/settings?tab=privacy`)
+    const contactable = volunteer.page.getByLabel(
+      'Allow project owners to contact me about opportunities',
+    )
+    const shareContact = volunteer.page.getByLabel(/Share my contact info directly/)
+    await expect(contactable).toBeVisible({ timeout: 10_000 })
+
+    if (await contactable.isChecked()) {
+      await volunteer.page.locator('label:has(#consent_contactable_by_project_owners)').click()
+    }
+    await expect(contactable).not.toBeChecked()
+    await expect(shareContact).toBeDisabled()
+
+    await volunteer.page.locator('label:has(#consent_contactable_by_project_owners)').click()
+    await expect(contactable).toBeChecked()
+    await expect(shareContact).toBeEnabled()
+
+    await volunteer.page
+      .locator('label:has(#consent_share_contact_info_with_project_owner)')
+      .click()
+    await expect(shareContact).toBeChecked()
+    await volunteer.page.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(getAlert(volunteer.page)).toBeVisible({ timeout: 10_000 })
+
+    await volunteer.page.reload()
+    await expect(volunteer.page.getByLabel(/Share my contact info directly/)).toBeChecked({
+      timeout: 10_000,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

**Coverage (closes #141):**
- New spec `35-verify-email-edge-cases.spec.ts` — invalid/already-used/expired confirmation token states, plus the resend-from-scratch flow. Expired-token case backdates via `node:sqlite` directly against the worker DB (local-only), since the generated Prisma client can't be imported from Playwright's own module loader.
- New spec `36-settings-notifications-privacy.spec.ts` — email digest dropdown persistence, and the share-contact-info checkbox's disabled/enabled gating.

**Streamlining — cut redundant UI-flow *proving* used only as setup scaffolding, no coverage lost:**
- Admin project creation: 7 files were re-driving the full create+publish UI round trip just to seed a project for an unrelated assertion. Added `adminCreateProjectViaApi`; `06-project-lifecycle.spec.ts` stays the one place that proves the UI flow itself.
- Same pattern for skill creation (12 sites → `createSkillViaApi`), local-group suggestions (9 of 11 sites in one file → `submitLocalGroupSuggestionViaApi`), quick-task creation (9 sites → `createOpenQuickTaskViaApi`; the old UI-only helper is now dead and deleted), and bug report submission (6 sites → `submitBugReportViaApi`).

Two real bugs surfaced while building the API helpers, both fixed:
- `volunteer.page` starts at `about:blank` in the fixtures, so reading its auth token via `page.evaluate()` throws a `SecurityError` unless the page has navigated somewhere first.
- The local-group suggestion API expects the option *value* (`"UK"`), not the display label the UI shows (`"United Kingdom"`) — the helper translates so call sites can keep passing what the UI helper always took.

## Test plan
- [x] `npm run check-all` (typecheck, lint, format, full e2e suite) passes clean: 230 passed, 5 skipped, 0 failed
- [x] Ran each touched spec file in isolation during development to confirm before folding into the full suite run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tR28Bp8KTrowk3eHWCEYP