### PR TITLE
Let owners/admins view directory-hidden volunteers; fix directory paging

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1285,7 +1285,16 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                           >
                             <TaskAvatar name={interest.volunteerName} />
                             <div className="flex-1 min-w-0">
-                              <div className="truncate">{interest.volunteerName}</div>
+                              {isAdmin || interestedVolunteerIds.has(interest.volunteerId) ? (
+                                <Link
+                                  href={`/volunteers/${interest.volunteerId}`}
+                                  className="underline truncate block"
+                                >
+                                  {interest.volunteerName}
+                                </Link>
+                              ) : (
+                                <div className="truncate">{interest.volunteerName}</div>
+                              )}
                               <div className="text-text-light text-xs">
                                 {interest.status === InterestStatus.accepted
                                   ? interest.interestType === 'want_to_own'

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, Suspense } from 'react'
 import { useRouter } from 'next/navigation'
 import { useRequireApproved } from '@/lib/hooks/auth'
 import { useUrlParam, useUrlSearchInput } from '@/lib/hooks/url-filters'
+import { DIRECTORY_PAGE_SIZE as PAGE_SIZE } from '@/lib/pagination'
 import Link from 'next/link'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
@@ -70,7 +71,6 @@ function ProjectsPageContent({ user }: { user: ApprovedUser }) {
   const [completedOpen, setCompletedOpen] = useState(false)
 
   const isFlatView = Boolean(statusFilter || needsFilter)
-  const PAGE_SIZE = 50
 
   // Reset to page 1 whenever a filter changes, but not on the initial mount
   // (which would clobber a deep-linked ?page=N&status=... URL).

--- a/app/volunteers/page.tsx
+++ b/app/volunteers/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { useRequireAuth } from '@/lib/hooks/auth'
 import { useUrlParam, useUrlSearchInput } from '@/lib/hooks/url-filters'
+import { DIRECTORY_PAGE_SIZE as PAGE_SIZE } from '@/lib/pagination'
 import Link from 'next/link'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import Button from '@/components/Button'
@@ -20,8 +21,6 @@ type FlatSkill = SkillCategory['skills'][number] & { categoryName: string }
 
 type Volunteer = InferRouterOutputs<AppRouter>['volunteers']['list']['volunteers'][number]
 type AuthUser = NonNullable<ReturnType<typeof useRequireAuth>['user']>
-
-const PAGE_SIZE = 50
 
 function VolunteersPageContent({ user }: { user: AuthUser }) {
   const [searchInput, setSearchInput, urlSearch] = useUrlSearchInput('q')

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -153,6 +153,43 @@ export async function createApprovedVolunteer(baseUrl: string): Promise<ApiVolun
   return pending
 }
 
+// Approved volunteer with a caller-chosen name and directory visibility. Used by tests
+// that need a deterministic name (pagination) or a profile hidden from the public
+// directory (hidden-volunteer access rules).
+export async function createApprovedVolunteerNamed(
+  baseUrl: string,
+  name: string,
+  opts: { hidden?: boolean } = {},
+): Promise<ApiVolunteer> {
+  const api = createApiClient(baseUrl)
+  const email = fake.uniqueEmail()
+  const result = await api.auth.signup({
+    body: {
+      name,
+      email,
+      password: 'testpassword1',
+      bio: 'e2e test bio, at least twenty characters long',
+      country: 'UK',
+      availabilityHoursPerWeek: 5,
+      applicationMessage: 'e2e test application message',
+      consentMakeProfileVisibleInDirectory: !opts.hidden,
+      consentContactableByProjectOwners: true,
+    },
+  })
+  if (result.status !== 200)
+    throw new Error(`Volunteer signup failed: ${JSON.stringify(result.body)}`)
+  const { id, token, emailVerificationToken } = result.body as {
+    id: number
+    token: string
+    emailVerificationToken?: string
+  }
+  if (emailVerificationToken) {
+    await confirmVolunteerEmail(baseUrl, emailVerificationToken)
+  }
+  await approveVolunteer(baseUrl, id)
+  return { id, token, name, email }
+}
+
 export async function rejectVolunteer(
   baseUrl: string,
   volunteerId: number,

--- a/e2e/tests/37-directory-pagination.spec.ts
+++ b/e2e/tests/37-directory-pagination.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../fixtures'
+import { adminCreateProjectViaApi } from '../actions/projects'
+import { fake } from '../fake'
+
+// Prev/Next on the directory pages runs through the shared useUrlParam / useSetParam
+// hook in lib/hooks/url-filters.ts. A stale-closure bug there rebuilt the page setter
+// on every URL change, so the "reset to page 1 on filter change" effect re-fired after
+// each pagination click and snapped the list straight back to page 1 — you could never
+// leave page 1. This proves Next actually advances and Previous comes back. The
+// volunteers directory is driven by the very same hook.
+test.describe('Directory pagination', () => {
+  test('Projects directory Next and Previous move between pages', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    test.slow()
+
+    // PAGE_SIZE is 50, so 51 marker-tagged projects is exactly two pages once the list
+    // is filtered down to them.
+    const marker = `PGN${Date.now().toString(36)}`
+    const TOTAL = 51
+    // Serial, not parallel: each create is a multi-row write and the worker DB is SQLite,
+    // which throws on concurrent writers.
+    for (let n = 0; n < TOTAL; n++) {
+      await adminCreateProjectViaApi(
+        baseUrl,
+        `${marker} ${String(n).padStart(2, '0')} ${fake.projectTitle()}`,
+        'Directory pagination fixture project',
+      )
+    }
+
+    const page = volunteer.page
+    // A status filter switches the list into its flat, paginated view; q narrows it to
+    // exactly the 51 projects created above.
+    await page.goto(`${baseUrl}/projects?status=ready&q=${marker}`)
+    await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    const markerLinks = page.getByRole('link').filter({ hasText: marker })
+
+    await expect(page.getByText('Page 1 of 2')).toBeVisible({ timeout: 15_000 })
+    await expect(markerLinks).toHaveCount(50)
+
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    await expect(page).toHaveURL(/[?&]page=2(&|$)/, { timeout: 10_000 })
+    await expect(page.getByText('Page 2 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(markerLinks).toHaveCount(1)
+
+    await page.getByRole('button', { name: 'Previous' }).click()
+
+    await expect(page.getByText('Page 1 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(page).not.toHaveURL(/[?&]page=/, { timeout: 10_000 })
+    await expect(markerLinks).toHaveCount(50)
+  })
+})

--- a/e2e/tests/37-directory-pagination.spec.ts
+++ b/e2e/tests/37-directory-pagination.spec.ts
@@ -1,13 +1,14 @@
 import { test, expect } from '../fixtures'
 import { adminCreateProjectViaApi } from '../actions/projects'
 import { fake } from '../fake'
+import { DIRECTORY_PAGE_SIZE } from '../../lib/pagination'
 
 // Prev/Next on the directory pages runs through the shared useUrlParam / useSetParam
-// hook in lib/hooks/url-filters.ts. A stale-closure bug there rebuilt the page setter
-// on every URL change, so the "reset to page 1 on filter change" effect re-fired after
-// each pagination click and snapped the list straight back to page 1 — you could never
-// leave page 1. This proves Next actually advances and Previous comes back. The
-// volunteers directory is driven by the very same hook.
+// hook in lib/hooks/url-filters.ts. It used to write with router.replace() on a
+// query-only relative URL, which never synced useSearchParams() in this Next build,
+// so the page param never actually changed and you could not leave page 1. This
+// proves Next advances and Previous comes back. The volunteers directory is driven
+// by the very same hook.
 test.describe('Directory pagination', () => {
   test('Projects directory Next and Previous move between pages', async ({
     volunteer,
@@ -15,23 +16,22 @@ test.describe('Directory pagination', () => {
   }) => {
     test.slow()
 
-    // PAGE_SIZE is 50, so 51 marker-tagged projects is exactly two pages once the list
-    // is filtered down to them.
+    // One more than a page → exactly two pages, with a single row on page 2.
+    const TOTAL = DIRECTORY_PAGE_SIZE + 1
     const marker = `PGN${Date.now().toString(36)}`
-    const TOTAL = 51
     // Serial, not parallel: each create is a multi-row write and the worker DB is SQLite,
     // which throws on concurrent writers.
     for (let n = 0; n < TOTAL; n++) {
       await adminCreateProjectViaApi(
         baseUrl,
-        `${marker} ${String(n).padStart(2, '0')} ${fake.projectTitle()}`,
+        `${marker} ${String(n).padStart(3, '0')} ${fake.projectTitle()}`,
         'Directory pagination fixture project',
       )
     }
 
     const page = volunteer.page
     // A status filter switches the list into its flat, paginated view; q narrows it to
-    // exactly the 51 projects created above.
+    // exactly the projects created above.
     await page.goto(`${baseUrl}/projects?status=ready&q=${marker}`)
     await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible({
       timeout: 10_000,
@@ -40,7 +40,7 @@ test.describe('Directory pagination', () => {
     const markerLinks = page.getByRole('link').filter({ hasText: marker })
 
     await expect(page.getByText('Page 1 of 2')).toBeVisible({ timeout: 15_000 })
-    await expect(markerLinks).toHaveCount(50)
+    await expect(markerLinks).toHaveCount(DIRECTORY_PAGE_SIZE)
 
     await page.getByRole('button', { name: 'Next' }).click()
 
@@ -52,6 +52,6 @@ test.describe('Directory pagination', () => {
 
     await expect(page.getByText('Page 1 of 2')).toBeVisible({ timeout: 10_000 })
     await expect(page).not.toHaveURL(/[?&]page=/, { timeout: 10_000 })
-    await expect(markerLinks).toHaveCount(50)
+    await expect(markerLinks).toHaveCount(DIRECTORY_PAGE_SIZE)
   })
 })

--- a/e2e/tests/38-hidden-volunteer-access.spec.ts
+++ b/e2e/tests/38-hidden-volunteer-access.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '../fixtures'
+import { createApprovedVolunteerNamed, readAdminToken } from '../fixtures'
+import { createApiClient } from '../client'
+import { adminCreateProjectViaApi, transferProjectOwnership } from '../actions/projects'
+import { fake } from '../fake'
+
+// A volunteer who opts out of the public directory
+// (consentMakeProfileVisibleInDirectory = false) is still visible to people with a
+// legitimate need: any admin, and an owner of a project the volunteer is involved in.
+test.describe('Directory-hidden volunteer access', () => {
+  test('Admin sees a hidden volunteer in the directory, badged, and can open the profile', async ({
+    adminPage,
+    baseUrl,
+  }) => {
+    const hidden = await createApprovedVolunteerNamed(baseUrl, fake.personName(), { hidden: true })
+
+    await adminPage.goto(`${baseUrl}/volunteers`)
+    await expect(
+      adminPage.getByRole('heading', { name: 'Volunteer Directory', level: 1 }),
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.locator('#volunteersList .loading')).not.toBeVisible({ timeout: 10_000 })
+    await adminPage.getByLabel('Search').fill(hidden.name)
+
+    const card = adminPage.locator('#volunteersList .card').filter({ hasText: hidden.name })
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    await expect(card.getByText('Hidden')).toBeVisible()
+
+    await adminPage.goto(`${baseUrl}/volunteers/${hidden.id}`)
+    await expect(adminPage.locator('#profileContent')).toBeVisible({ timeout: 10_000 })
+    await expect(adminPage.locator('#volunteerName')).toHaveText(hidden.name)
+  })
+
+  test('An unrelated volunteer cannot see or open a hidden profile', async ({
+    volunteer,
+    baseUrl,
+  }) => {
+    const hidden = await createApprovedVolunteerNamed(baseUrl, fake.personName(), { hidden: true })
+
+    await volunteer.page.goto(`${baseUrl}/volunteers`)
+    await expect(volunteer.page.locator('#volunteersList .loading')).not.toBeVisible({
+      timeout: 10_000,
+    })
+    await volunteer.page.getByLabel('Search').fill(hidden.name)
+    await expect(
+      volunteer.page.locator('#volunteersList .card').filter({ hasText: hidden.name }),
+    ).toHaveCount(0)
+
+    await volunteer.page.goto(`${baseUrl}/volunteers/${hidden.id}`)
+    await expect(volunteer.page.getByText('Volunteer not found.')).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.locator('#profileContent')).toHaveCount(0)
+  })
+
+  test('A project owner opens a hidden applicant profile from the interests list before accepting', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    // The volunteer fixture is the (non-admin) project owner.
+    const projectId = await adminCreateProjectViaApi(
+      baseUrl,
+      fake.projectTitle(),
+      'Owner assesses a hidden applicant',
+    )
+    await transferProjectOwnership(baseUrl, adminPage, projectId, volunteer.name)
+
+    const applicant = await createApprovedVolunteerNamed(baseUrl, fake.personName(), {
+      hidden: true,
+    })
+    const applicantApi = createApiClient(baseUrl, applicant.token)
+    const expressed = await applicantApi.projects.expressInterest({
+      body: { projectId, interestType: 'want_to_contribute' },
+    })
+    expect(expressed.status).toBe(200)
+
+    await volunteer.page.goto(`${baseUrl}/projects/${projectId}`)
+    await expect(volunteer.page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 })
+
+    const card = volunteer.page.locator('.interest-card').filter({ hasText: applicant.name })
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    // The interest is still pending — the owner can view the profile to decide.
+    await card.getByRole('link', { name: applicant.name }).click()
+
+    await expect(volunteer.page).toHaveURL(new RegExp(`/volunteers/${applicant.id}(\\?|$)`), {
+      timeout: 10_000,
+    })
+    await expect(volunteer.page.locator('#profileContent')).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.locator('#volunteerName')).toHaveText(applicant.name)
+  })
+
+  test('A project owner can open the profile of a hidden volunteer holding a task on their project', async ({
+    adminPage,
+    volunteer,
+    baseUrl,
+  }) => {
+    const adminApi = createApiClient(baseUrl, readAdminToken(baseUrl))
+    const projectId = await adminCreateProjectViaApi(
+      baseUrl,
+      fake.projectTitle(),
+      'Owner assesses a hidden task holder',
+    )
+    await transferProjectOwnership(baseUrl, adminPage, projectId, volunteer.name)
+
+    const taskHolder = await createApprovedVolunteerNamed(baseUrl, fake.personName(), {
+      hidden: true,
+    })
+    const task = await adminApi.projects.createTask({
+      body: { projectId, title: 'Task held by a hidden volunteer' },
+    })
+    expect(task.status).toBe(200)
+    const taskId = (task.body as { id: number }).id
+    const assigned = await adminApi.projects.updateTask({
+      body: { projectId, taskId, data: { status: 'in_progress', assigneeId: taskHolder.id } },
+    })
+    expect(assigned.status).toBe(200)
+
+    // Owner reaches the hidden profile directly (task holders aren't in the interests list).
+    await volunteer.page.goto(`${baseUrl}/volunteers/${taskHolder.id}`)
+    await expect(volunteer.page.locator('#profileContent')).toBeVisible({ timeout: 10_000 })
+    await expect(volunteer.page.locator('#volunteerName')).toHaveText(taskHolder.name)
+
+    // A bystander volunteer still can't.
+    const bystander = await createApprovedVolunteerNamed(baseUrl, fake.personName())
+    const bystanderApi = createApiClient(baseUrl, bystander.token)
+    const denied = await bystanderApi.volunteers.getById({ params: { id: taskHolder.id } })
+    expect(denied.status).toBe(404)
+  })
+})

--- a/lib/hooks/url-filters.ts
+++ b/lib/hooks/url-filters.ts
@@ -1,30 +1,28 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import { useSearchParams, usePathname } from 'next/navigation'
 
 function useSetParam() {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  // Read the latest params through a ref so the returned setter keeps a stable
-  // identity across URL changes. Without this, every router.replace() (including
-  // a pagination click writing ?page=N) hands consumers a new setter, which
-  // re-fires any effect that lists the setter in its deps — e.g. the
-  // "reset to page 1 on filter change" effects in the projects/volunteers
-  // directories, which would then clobber every page change back to page 1.
-  const paramsRef = useRef(searchParams)
-  useEffect(() => {
-    paramsRef.current = searchParams
-  }, [searchParams])
-  return useCallback(
-    (key: string, value: string) => {
-      const params = new URLSearchParams(paramsRef.current.toString())
-      if (value) params.set(key, value)
-      else params.delete(key)
-      router.replace(`?${params.toString()}`, { scroll: false })
-    },
-    [router],
-  )
+  // Deliberately depends on nothing: the setter must keep a stable identity for the
+  // life of the component. Directory pages list it (via setPageParam) in the deps of
+  // their "reset to page 1 when a filter changes" effect — a setter that churned on
+  // every URL change would re-fire that effect right after a pagination click and
+  // snap the list straight back to page 1.
+  //
+  // Reads the live URL at call time rather than closing over useSearchParams(), and
+  // writes with history.replaceState (which Next patches to sync
+  // usePathname/useSearchParams) instead of router.replace() — matching
+  // useUrlSearchInput below. router.replace() with a query-only relative URL did not
+  // reliably update useSearchParams() here, which is why paging never advanced.
+  return useCallback((key: string, value: string) => {
+    const params = new URLSearchParams(window.location.search)
+    if (value) params.set(key, value)
+    else params.delete(key)
+    const qs = params.toString()
+    const { pathname } = window.location
+    window.history.replaceState(null, '', qs ? `${pathname}?${qs}` : pathname)
+  }, [])
 }
 
 /**

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,0 +1,3 @@
+// Rows per page in the projects and volunteers directory lists. Shared so the e2e
+// pagination test can size its fixture data off the real value.
+export const DIRECTORY_PAGE_SIZE = 50

--- a/server/routers/volunteers.ts
+++ b/server/routers/volunteers.ts
@@ -6,6 +6,7 @@ import { UpdateVolunteerSchema } from '@/lib/schemas'
 import { approvedProcedure, authedProcedure } from '../procedures'
 import {
   ApprovalStatus,
+  InterestStatus,
   ProjectStatus,
   QuickTaskStatus,
   WorkItemType,
@@ -25,7 +26,10 @@ export const volunteersRouter = {
     )
     .handler(async ({ input, context }) => {
       const currentVolunteer = context.volunteer
-      const isAdmin = currentVolunteer.isAdmin ?? false
+      // Any flavour of admin (full admin or technical admin, which includes super
+      // admins since those always carry isAdmin) may see profiles hidden from the
+      // public directory.
+      const isAdmin = Boolean(currentVolunteer.isAdmin || currentVolunteer.isTechnicalAdmin)
 
       const where: Record<string, unknown> = {
         deletedAt: null,
@@ -121,9 +125,10 @@ export const volunteersRouter = {
     .input(z.object({ id: z.number().int() }))
     .handler(async ({ input, context }) => {
       const currentVolunteer = context.volunteer
+      const isAdmin = Boolean(currentVolunteer.isAdmin || currentVolunteer.isTechnicalAdmin)
 
       const vol = await prisma.volunteer.findFirst({
-        where: { id: input.id, deletedAt: null, consentMakeProfileVisibleInDirectory: true },
+        where: { id: input.id, deletedAt: null },
         include: {
           skills: {
             include: { skill: { include: { category: true } } },
@@ -139,6 +144,36 @@ export const volunteersRouter = {
       })
 
       if (!vol) throw new ORPCError('NOT_FOUND', { message: 'Volunteer not found' })
+
+      // A profile hidden from the public directory is still visible to:
+      //  - the volunteer themselves
+      //  - any admin (full or technical; super admins always carry isAdmin)
+      //  - an owner of a project this volunteer is involved in, so they can assess
+      //    the volunteer's skills — including before accepting them. "Involved in" =
+      //    holds a task under that project, or has a live (non-declined,
+      //    non-withdrawn) interest in it.
+      if (!vol.consentMakeProfileVisibleInDirectory && !isAdmin && currentVolunteer.id !== vol.id) {
+        const ownedProjectLink = await prisma.workItem.count({
+          where: {
+            type: WorkItemType.PROJECT,
+            assigneeId: currentVolunteer.id,
+            OR: [
+              { children: { some: { type: WorkItemType.TASK, assigneeId: vol.id } } },
+              {
+                interests: {
+                  some: {
+                    volunteerId: vol.id,
+                    status: { notIn: [InterestStatus.declined, InterestStatus.withdrawn] },
+                  },
+                },
+              },
+            ],
+          },
+        })
+        if (ownedProjectLink === 0) {
+          throw new ORPCError('NOT_FOUND', { message: 'Volunteer not found' })
+        }
+      }
 
       let showContact = false
       if (currentVolunteer) {


### PR DESCRIPTION
## Directory pagination

`afee82a` (already on main) removed `searchParams` from the URL-setter deps, but paging still never advanced — the new e2e test caught it. Real cause: `useSetParam` wrote via `router.replace()` on a query-only relative URL, which does not sync `useSearchParams()` in this Next build.

Rewrote it to read the live URL and write via `history.replaceState` (matching `useUrlSearchInput`), with zero deps so the setter identity is stable and the "reset to page 1 on filter change" effects in the projects/volunteers directories don't re-fire after a page click. Fixes both directories.

## Directory-hidden volunteers

A volunteer who opts out of the public directory (`consentMakeProfileVisibleInDirectory = false`) is now still visible to people with a legitimate need:

- **Any admin** — full or technical (`list` and `getById`).
- **An owner of a project the volunteer is involved in** — holds a task under it, or has a live (non-declined, non-withdrawn) interest — so the owner can assess their skills, **including before accepting a pending applicant**.

`getById` drops the query-time consent filter and applies this as a post-fetch gate; contact-info redaction is unchanged.

## Project page

In the owner/admin-only interests panel, a volunteer's name is now a link to their profile — rendered for admins on every row, and for a non-admin owner on live interests.

## Tests

- `37-directory-pagination.spec.ts` — projects directory Next/Previous move between pages.
- `38-hidden-volunteer-access.spec.ts` — admin sees badge + opens profile; unrelated volunteer gets 404; owner opens a pending hidden applicant from the interests list; owner opens a hidden task holder (bystander still 404).
- New `createApprovedVolunteerNamed` e2e fixture helper.

`npm run check-all` green — 235 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)